### PR TITLE
fix: fixes infinite loop on profile and organization settings pages

### DIFF
--- a/apps/console/src/components/pages/protected/organization/general-settings/organization-email-form.tsx
+++ b/apps/console/src/components/pages/protected/organization/general-settings/organization-email-form.tsx
@@ -48,7 +48,7 @@ const OrganizationEmailForm = () => {
         email: currentOrg.setting?.billingEmail ?? undefined,
       })
     }
-  }, [currentOrg, form])
+  }, [currentOrg])
 
   const updateOrganization = async ({ email }: { email: string }) => {
     await updateOrg({
@@ -62,8 +62,8 @@ const OrganizationEmailForm = () => {
     setIsSuccess(true)
   }
 
-  const onSubmit = (data: z.infer<typeof formSchema>) => {
-    updateOrganization({ email: data.email })
+  const onSubmit = async (data: z.infer<typeof formSchema>) => {
+    await updateOrganization({ email: data.email })
   }
 
   useEffect(() => {

--- a/apps/console/src/components/pages/protected/organization/general-settings/organization-name-form.tsx
+++ b/apps/console/src/components/pages/protected/organization/general-settings/organization-name-form.tsx
@@ -50,7 +50,7 @@ const OrganizationNameForm = () => {
         displayName: currentOrganization.displayName,
       })
     }
-  }, [currentOrganization, form])
+  }, [currentOrganization])
 
   const updateOrganization = async ({ displayName }: { displayName: string }) => {
     await updateOrg({
@@ -62,8 +62,8 @@ const OrganizationNameForm = () => {
     setIsSuccess(true)
   }
 
-  const onSubmit = (data: z.infer<typeof formSchema>) => {
-    updateOrganization({ displayName: data.displayName })
+  const onSubmit = async (data: z.infer<typeof formSchema>) => {
+    await updateOrganization({ displayName: data.displayName })
   }
 
   useEffect(() => {

--- a/apps/console/src/components/pages/protected/profile/user-settings/profile-name-form.tsx
+++ b/apps/console/src/components/pages/protected/profile/user-settings/profile-name-form.tsx
@@ -62,7 +62,7 @@ const ProfileNameForm = () => {
         lastName: userData.user.lastName ?? '',
       })
     }
-  }, [userData, form])
+  }, [userData])
 
   const updateName = async ({
     firstName,
@@ -81,8 +81,8 @@ const ProfileNameForm = () => {
     setIsSuccess(true)
   }
 
-  const onSubmit = (data: z.infer<typeof formSchema>) => {
-    updateName({ firstName: data.firstName, lastName: data.lastName })
+  const onSubmit = async (data: z.infer<typeof formSchema>) => {
+    await updateName({ firstName: data.firstName, lastName: data.lastName })
   }
 
   useEffect(() => {


### PR DESCRIPTION
Both these pages locally had a infinite loop error: 
 
```
 Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render. Error Component Stack
 ```

There's still an error related to the org delete form, but this should at least prevent the pages from hanging