### PR TITLE
smaller gap on billing, adding different border

### DIFF
--- a/apps/console/src/components/pages/protected/organization/billing/billing-settings.styles.tsx
+++ b/apps/console/src/components/pages/protected/organization/billing/billing-settings.styles.tsx
@@ -3,7 +3,7 @@ import { tv, type VariantProps } from 'tailwind-variants'
 const billingSettingsStyles = tv({
   slots: {
     panel: 'p-6 w-2/3',
-    section: 'flex justify-between items-start py-6 border-b border-gray-300 last:border-b-0',
+    section: 'flex justify-between items-start py-6  border-b  last:border-b-0',
     sectionTitle: 'text-xl font-medium text-text-header w-1/5',
     sectionContent: 'flex justify-between w-full gap-4',
     text: 'text-sm mb-2',

--- a/apps/console/src/components/pages/protected/organization/billing/pricing-plan.tsx
+++ b/apps/console/src/components/pages/protected/organization/billing/pricing-plan.tsx
@@ -57,7 +57,7 @@ const PricingPlan = () => {
   }
 
   return (
-    <div className="p-6 w-1/3">
+    <div className="p-6 w-1/3 2xl:w-1/4">
       <h2 className="text-2xl">Pricing Plan</h2>
       <div className="mt-4 flex items-center justify-between">
         <div className="flex gap-10 w-full">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6cfe74ba-f98a-4bdf-9d13-7b10769778a3)
