### PR TITLE
Fix policy page edit

### DIFF
--- a/apps/console/src/components/pages/protected/policies/policy-page.tsx
+++ b/apps/console/src/components/pages/protected/policies/policy-page.tsx
@@ -72,9 +72,12 @@ export function PolicyPage({ policyId }: PolicyPageProps) {
     // TODO: wire this up to a delete button and api call with confirmation dialog
   }
 
-  const onNameChange = useCallback((name: string) => {
-    setPolicy({ ...policy, name })
-  }, [])
+  const onNameChange = useCallback(
+    (name: string) => {
+      setPolicy({ ...policy, name })
+    },
+    [policy],
+  )
 
   const onDocumentChange = useCallback((content: TElement[]) => {
     console.log('onDocumentChange', content)

--- a/packages/ui/src/page-heading/page-heading.tsx
+++ b/packages/ui/src/page-heading/page-heading.tsx
@@ -14,10 +14,17 @@ interface PageHeadingProps extends PageHeadingVariants {
 
 const PageHeading: React.FC<PageHeadingProps> = ({ heading, eyebrow, className, editable, onChange }) => {
   const styles = pageHeadingStyles()
+  const inputRef = React.useRef<HTMLInputElement>(null)
 
   const [editing, setEditing] = React.useState<boolean>(false)
 
   const isEditing = editable && editing
+
+  React.useEffect(() => {
+    if (isEditing && inputRef?.current) {
+      inputRef.current.focus()
+    }
+  }, [isEditing])
 
   const onBlurHandler = (e: React.FocusEvent<HTMLInputElement>) => {
     if (onChange) {
@@ -36,7 +43,7 @@ const PageHeading: React.FC<PageHeadingProps> = ({ heading, eyebrow, className, 
           {heading}
         </h2>
       ) : (
-        <input className="" defaultValue={heading as string} onBlur={onBlurHandler} />
+        <input className="" defaultValue={heading as string} onBlur={onBlurHandler} ref={inputRef} />
       )}
     </div>
   )

--- a/packages/ui/src/textarea.tsx
+++ b/packages/ui/src/textarea.tsx
@@ -21,8 +21,14 @@ Textarea.displayName = 'Textarea'
 type EditableTextareaProps = React.ComponentProps<'textarea'>
 
 const EditableTextarea = React.forwardRef<HTMLTextAreaElement, EditableTextareaProps>(({ className, ...props }, ref) => {
-  const textarea = React.useRef()
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null)
   const [editing, setEditing] = React.useState<boolean>(false)
+
+  React.useEffect(() => {
+    if (editing && textareaRef?.current) {
+      textareaRef.current.focus()
+    }
+  }, [editing])
 
   if (editing) {
     return (
@@ -34,7 +40,7 @@ const EditableTextarea = React.forwardRef<HTMLTextAreaElement, EditableTextareaP
           'flex min-h-[80px] w-full focus:rounded-md border border-oxford-blue-200 bg-white dark:bg-glaucous-900 px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className,
         )}
-        ref={ref}
+        ref={textareaRef}
         {...props}
       />
     )

--- a/packages/ui/src/textarea.tsx
+++ b/packages/ui/src/textarea.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 
 import { cn } from '@repo/ui/lib/utils'
-import { on } from 'events'
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(({ className, ...props }, ref) => {
   return (


### PR DESCRIPTION
fields are now focused when clicked - for both page header and textareas
fixed editable page header - this was breaking the save button if you tried to rename the document.