### PR TITLE
Feat policy toasts and policy type field

### DIFF
--- a/apps/console/src/app/(protected)/policies/[id]/edit/page.tsx
+++ b/apps/console/src/app/(protected)/policies/[id]/edit/page.tsx
@@ -2,13 +2,11 @@
 
 import { NextPage } from 'next'
 import { PolicyEditPage } from '@/components/pages/protected/policies/policy-edit-page'
+import { useParams } from 'next/navigation'
 
-type PageProps = {
-  params: { id: string }
-}
-
-export const Page: NextPage<PageProps> = ({ params }) => {
-  return <PolicyEditPage policyId={params.id} />
+export const Page: NextPage = () => {
+  const { id } = useParams()
+  return <PolicyEditPage policyId={id as string} />
 }
 
 export default Page

--- a/apps/console/src/app/(protected)/policies/[id]/page.tsx
+++ b/apps/console/src/app/(protected)/policies/[id]/page.tsx
@@ -2,13 +2,11 @@
 
 import { NextPage } from 'next'
 import { PolicyPage } from '@/components/pages/protected/policies/policy-page'
+import { useParams } from 'next/navigation'
 
-type PageProps = {
-  params: { id: string }
-}
-
-export const Page: NextPage<PageProps> = ({ params }) => {
-  return <PolicyPage policyId={params.id} />
+export const Page: NextPage = () => {
+  const { id } = useParams()
+  return <PolicyPage policyId={id as string} />
 }
 
 export default Page

--- a/apps/console/src/components/pages/protected/policies/policies-table.tsx
+++ b/apps/console/src/components/pages/protected/policies/policies-table.tsx
@@ -45,7 +45,7 @@ export const PoliciesTable = () => {
 
   const handleCreateNew = async () => {
     const { data, error } = await createPolicy({
-      input: { name: 'Untitled Policy', status: 'new', version: '0.0.0', policyType: 'unknown' },
+      input: { name: 'Untitled Policy', status: 'new', version: '0.0.0' },
     })
 
     if (error) {

--- a/apps/console/src/components/pages/protected/policies/policy-edit-form-types.ts
+++ b/apps/console/src/components/pages/protected/policies/policy-edit-form-types.ts
@@ -5,6 +5,7 @@ export const EditPolicySchema = z.object({
   description: z.string().optional(),
   background: z.string().optional(),
   purposeAndScope: z.string().optional(),
+  policyType: z.string().optional(),
   tags: z.array(z.string()).optional(),
   details: z.object({
     content: z.array(z.any()).optional(),

--- a/apps/console/src/components/pages/protected/policies/policy-edit-page.tsx
+++ b/apps/console/src/components/pages/protected/policies/policy-edit-page.tsx
@@ -11,6 +11,8 @@ import type { Value } from '@udecode/plate-common'
 import { Button } from '@repo/ui/button'
 import { Eye } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { useGQLErrorToast } from '@/hooks/useGQLErrorToast'
+import { useToast } from '@repo/ui/use-toast'
 
 type PolicyEditPageProps = {
   policyId: string
@@ -18,6 +20,9 @@ type PolicyEditPageProps = {
 
 export function PolicyEditPage({ policyId }: PolicyEditPageProps) {
   const router = useRouter()
+  const { toast } = useToast()
+  const { toastGQLError } = useGQLErrorToast()
+
   const [{ fetching: saving }, updatePolicy] = useUpdateInternalPolicyMutation()
   const [{ data: policyData }] = useGetInternalPolicyDetailsByIdQuery({ requestPolicy: 'network-only', variables: { internalPolicyId: policyId } })
   const [policy, setPolicy] = useState(policyData?.internalPolicy ?? ({} as InternalPolicyByIdFragment))
@@ -85,8 +90,11 @@ export function PolicyEditPage({ policyId }: PolicyEditPageProps) {
     })
 
     if (error) {
-      console.error(error)
+      toastGQLError({ title: 'Failed to save Policy', error })
+      return
     }
+
+    toast({ title: 'Policy updated', variant: 'success' })
   }
 
   const policyName = policy.displayID ? `${policy.displayID} - ${policy.name}` : policy.name

--- a/apps/console/src/components/pages/protected/policies/policy-edit-page.tsx
+++ b/apps/console/src/components/pages/protected/policies/policy-edit-page.tsx
@@ -36,6 +36,7 @@ export function PolicyEditPage({ policyId }: PolicyEditPageProps) {
       name: policy.name || '',
       description: policy.description || '',
       background: policy.background || '',
+      policyType: policy.policyType || '',
       purposeAndScope: policy.purposeAndScope || '',
       tags: policy.tags || [],
       details: policy.details || {
@@ -57,6 +58,7 @@ export function PolicyEditPage({ policyId }: PolicyEditPageProps) {
       description: policy.description || '',
       background: policy.background || '',
       purposeAndScope: policy.purposeAndScope || '',
+      policyType: policy.policyType || '',
       tags: policy.tags || [],
       details: policy.details,
     })
@@ -73,7 +75,7 @@ export function PolicyEditPage({ policyId }: PolicyEditPageProps) {
   if (!policyData?.internalPolicy) return <></>
 
   const handleSave = async () => {
-    const { name, description, background, purposeAndScope, tags } = form.getValues()
+    const { name, description, background, purposeAndScope, policyType, tags } = form.getValues()
 
     const { error } = await updatePolicy({
       updateInternalPolicyId: policyData?.internalPolicy.id,
@@ -82,6 +84,7 @@ export function PolicyEditPage({ policyId }: PolicyEditPageProps) {
         description,
         background,
         purposeAndScope,
+        policyType,
         tags,
         details: {
           content: document,

--- a/apps/console/src/components/pages/protected/policies/policy-edit-sidebar.tsx
+++ b/apps/console/src/components/pages/protected/policies/policy-edit-sidebar.tsx
@@ -28,7 +28,7 @@ export const PolicyEditSidebar = ({ policy, form, handleSave }: PolicyEditSideba
       status: [
         { icon: Binoculars, label: 'Status', value: policy.status },
         { icon: FileStack, label: 'Version', value: policy.version },
-        { icon: ScrollText, label: 'Policy Type', value: policy.policyType },
+        { icon: ScrollText, label: 'Policy Type', value: <PolicyTypeField form={form} /> },
         { icon: CalendarCheck2, label: 'Created At', value: formatTime(policy.createdAt) },
         { icon: CalendarClock, label: 'Updated At', value: formatTime(policy.updatedAt) },
       ],
@@ -94,5 +94,24 @@ const TagsPanel = ({ form }: { form: UseFormReturn<EditPolicyFormData> }) => {
         />
       </Form>
     </Panel>
+  )
+}
+
+function PolicyTypeField({ form }: { form: UseFormReturn<EditPolicyFormData> }) {
+  return (
+    <Form {...form}>
+      <FormField
+        name="policyType"
+        control={form.control}
+        render={({ field }) => (
+          <FormItem>
+            <FormControl className="w-full">
+              <Input placeholder="Policy type" {...field} className="bg-background text-white w-full text-sm h-auto p-1" />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </Form>
   )
 }

--- a/apps/console/src/components/pages/protected/policies/policy-sidebar.tsx
+++ b/apps/console/src/components/pages/protected/policies/policy-sidebar.tsx
@@ -4,7 +4,7 @@ import React, { useMemo } from 'react'
 import { InternalPolicyByIdFragment } from '@repo/codegen/src/schema'
 import { UserRoundCheck, Binoculars, FileStack, ScrollText, Tag, CalendarCheck2, UserRoundPen, CalendarClock } from 'lucide-react'
 import { Badge } from '@repo/ui/badge'
-import { MetaPanel, formatTime } from '@/components/shared/meta-panel/meta-panel'
+import { MetaPanel, formatTime, MetaPanelEntry } from '@/components/shared/meta-panel/meta-panel'
 import { useGetUserProfileQuery } from '@repo/codegen/src/schema'
 import { UserChip } from '@/components/shared/user-chip/user-chip'
 
@@ -25,7 +25,7 @@ export const PolicySidebar: React.FC<PolicySidebarProps> = function ({ policy })
     pause: !policy.updatedBy,
   })
 
-  const sidebarItems = useMemo(() => {
+  const sidebarItems: Record<string, MetaPanelEntry[]> = useMemo(() => {
     return {
       // ownership: [
       //   { icon: CircleUser, label: 'Owner', value: 'owner' },
@@ -38,6 +38,7 @@ export const PolicySidebar: React.FC<PolicySidebarProps> = function ({ policy })
         {
           icon: Tag,
           label: 'Tags',
+          align: 'top',
           value: policy.tags?.length ? (
             policy.tags.map((t) => (
               <Badge key={t} variant="outline" className="mr-1">

--- a/apps/console/src/components/shared/meta-panel/meta-panel.tsx
+++ b/apps/console/src/components/shared/meta-panel/meta-panel.tsx
@@ -2,11 +2,13 @@ import React from 'react'
 import { Panel } from '@repo/ui/panel'
 import { LucideProps } from 'lucide-react'
 import { format } from 'date-fns'
+import { cn } from '@repo/ui/lib/utils'
 
-type MetaPanelEntry = {
+export type MetaPanelEntry = {
   icon: React.ElementType<LucideProps>
   label: string
   value: string | React.ReactNode
+  align?: 'top' | 'middle'
 }
 
 type MetaPanelProps = {
@@ -16,16 +18,25 @@ type MetaPanelProps = {
 export const formatTime = (str: string) => (str ? format(str, 'h:mm bbb. MMMM d, yyyy') : '')
 
 export const MetaPanel: React.FC<MetaPanelProps> = ({ entries }) => {
+  const getAlignment = (align: string | undefined) => {
+    switch (align) {
+      case 'top':
+        return 'items-start'
+      default:
+        return 'items-center'
+    }
+  }
+
   return (
     <Panel className="py-1">
       <div className="flex flex-col divide-y divide-border">
         {entries.map((entry) => (
-          <div key={entry.label} className="flex items-start py-3">
-            <div className="w-36 min-w-36 flex items-center gap-2">
+          <div key={entry.label} className={cn('flex py-3', getAlignment(entry.align))}>
+            <div className="w-32 min-w-32 flex items-center gap-2">
               <entry.icon size={16} className="text-brand" />
               <span className="font-bold">{entry.label}</span>
             </div>
-            <div>{entry.value}</div>
+            <div className="grow">{entry.value}</div>
           </div>
         ))}
       </div>

--- a/apps/console/src/hooks/useGQLErrorToast.tsx
+++ b/apps/console/src/hooks/useGQLErrorToast.tsx
@@ -1,0 +1,41 @@
+import { useToast } from '@repo/ui/use-toast'
+import { useEffect, useState } from 'react'
+import { CombinedError } from 'urql'
+
+export function useGQLErrorToast() {
+  const { toast } = useToast()
+  const [title, setTitle] = useState('API Error')
+  const [error, setError] = useState<CombinedError | null>(null)
+
+  const toastGQLError = ({ title, error }: { title: string; error: CombinedError }) => {
+    setTitle(title)
+    setError(error)
+  }
+
+  useEffect(() => {
+    if (!error) return
+
+    console.error(error)
+
+    const messages: string[] = []
+
+    if (error.graphQLErrors) {
+      error.graphQLErrors.forEach((graphQLError) => {
+        const path = graphQLError.path?.join('.') ?? ''
+        messages.push(path + ' ' + graphQLError.message)
+      })
+    }
+
+    if (error.networkError) {
+      messages.push(error.networkError.message)
+    }
+
+    toast({
+      title: title,
+      variant: 'destructive',
+      description: messages.join('\n'),
+    })
+  }, [error])
+
+  return { toastGQLError }
+}


### PR DESCRIPTION
- use useParam
- Policy Type - text field entry
- new GQL Toaster as customer react hook

![CleanShot 2025-02-27 at 17 13 21](https://github.com/user-attachments/assets/262c255e-70f4-4fb8-979a-ee15f923e68c)
![CleanShot 2025-02-27 at 17 13 36](https://github.com/user-attachments/assets/317c1e9c-ef17-4b2f-a672-9b99560253f4)
![CleanShot 2025-02-27 at 17 14 13](https://github.com/user-attachments/assets/cfbabffe-d766-4565-87a8-5840e5181f92)
