### PR TITLE
Feature policy datatable filtering search

### DIFF
--- a/apps/console/src/components/pages/protected/policies/policies-table.tsx
+++ b/apps/console/src/components/pages/protected/policies/policies-table.tsx
@@ -155,8 +155,6 @@ const InternalPolicyFilterableFields: FilterField[] = [
 
   { key: 'createdAt', label: 'Date Created', type: 'date' },
   { key: 'createdBy', label: 'Created By', type: 'text' },
-  { key: 'deletedAt', label: 'Date Deleted', type: 'date' },
-  { key: 'deletedBy', label: 'Deleted By', type: 'text' },
   { key: 'updatedAt', label: 'Date Updated', type: 'date' },
   { key: 'updatedBy', label: 'Updated By', type: 'text' },
 ]

--- a/apps/console/src/components/pages/protected/policies/policies-table.tsx
+++ b/apps/console/src/components/pages/protected/policies/policies-table.tsx
@@ -144,7 +144,6 @@ const InternalPolicyFilterableFields: FilterField[] = [
   { key: 'hasControls', label: 'Has Controls', type: 'boolean' },
   { key: 'hasEditors', label: 'Has Editors', type: 'boolean' },
   { key: 'hasNarratives', label: 'Has Narratives', type: 'boolean' },
-  { key: 'hasOwner', label: 'Has Owner', type: 'boolean' },
   { key: 'hasProcedures', label: 'Has Procedures', type: 'boolean' },
   { key: 'hasPrograms', label: 'Has Programs', type: 'boolean' },
   { key: 'policyType', label: 'Type', type: 'text' },

--- a/apps/console/src/components/pages/protected/policies/policies-table.tsx
+++ b/apps/console/src/components/pages/protected/policies/policies-table.tsx
@@ -2,16 +2,21 @@
 
 import { useRouter } from 'next/navigation'
 import { Button } from '@repo/ui/button'
-import { PlusIcon } from 'lucide-react'
+import { LoaderCircle, PlusCircle, SearchIcon } from 'lucide-react'
 import { DataTable } from '@repo/ui/data-table'
 import { ColumnDef } from '@tanstack/react-table'
 import { format } from 'date-fns'
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Input } from '@repo/ui/input'
 import { pageStyles } from './page.styles'
 import { Actions } from './actions/actions'
-import { useCreateInternalPolicyMutation, useGetInternalPoliciesListQuery } from '@repo/codegen/src/schema'
+import { useCreateInternalPolicyMutation, useGetInternalPoliciesListQuery, useSearchInternalPoliciesQuery } from '@repo/codegen/src/schema'
 import Link from 'next/link'
+import { useDebounce } from '@uidotdev/usehooks'
+import { cn } from '@repo/ui/lib/utils'
+import { TableFilter } from '@/components/shared/table-filter/table-filter'
+import { TableSort } from '@/components/shared/table-filter/table-sort'
+import { FilterField } from '@/types'
 
 type PoliciesEdge = any
 type Policies = NonNullable<PoliciesEdge>['node']
@@ -19,29 +24,38 @@ type Policies = NonNullable<PoliciesEdge>['node']
 export const PoliciesTable = () => {
   const router = useRouter()
 
-  const { searchRow, searchField } = pageStyles()
-
-  const [filteredPolicies, setFilteredPolicies] = useState<Policies[]>([])
-
-  const [result] = useGetInternalPoliciesListQuery({ variables: {} })
-  const { data, fetching } = result
-
   const [{ fetching: creating }, createPolicy] = useCreateInternalPolicyMutation()
 
+  const [filteredPolicies, setFilteredPolicies] = useState<Policies[]>([])
+  const [searchTerm, setSearchTerm] = useState('')
+  const [filters, setFilters] = useState<Record<string, any>>({})
+  const [sort, setSort] = useState<Record<string, any>>({})
+
+  const debouncedSearchTerm = useDebounce(searchTerm, 300)
+
+  const [{ data, fetching }] = useGetInternalPoliciesListQuery({ variables: { where: filters } })
+  const [{ data: searchData, fetching: searching }] = useSearchInternalPoliciesQuery({ variables: { query: debouncedSearchTerm }, pause: !debouncedSearchTerm })
+
   useEffect(() => {
-    if (data) {
+    if (data && !searchTerm) {
       const policies = data?.internalPolicies?.edges?.map((e) => e?.node)
       if (policies) {
         setFilteredPolicies(policies)
       }
     }
-  }, [data])
+  }, [data, searchTerm])
 
-  const handleSearch = (e: React.FormEvent<HTMLInputElement>) => {
-    setSearchTerm(e.currentTarget.value)
-  }
+  useEffect(() => {
+    if (searchTerm && searchData) {
+      setFilteredPolicies(searchData?.internalPolicySearch?.internalPolicies || [])
+      return
+    }
 
-  const [searchTerm, setSearchTerm] = useState('')
+    const policies = data?.internalPolicies?.edges?.map((e) => e?.node)
+    if (policies) {
+      setFilteredPolicies(policies)
+    }
+  }, [searchData])
 
   const handleCreateNew = async () => {
     const { data, error } = await createPolicy({
@@ -81,6 +95,10 @@ export const PoliciesTable = () => {
       },
     },
     {
+      accessorKey: 'policyType',
+      header: 'Type',
+    },
+    {
       accessorKey: 'description',
       header: 'Description',
     },
@@ -109,16 +127,91 @@ export const PoliciesTable = () => {
 
   return (
     <>
-      <div className={searchRow()}>
-        <div className={searchField()}>
-          <Input placeholder="search" disabled value={searchTerm} onChange={handleSearch} />
-        </div>
-        <Button icon={<PlusIcon />} iconPosition="left" onClick={handleCreateNew} disabled={creating}>
-          Create New
-        </Button>
-      </div>
+      <PolicyDataTableToolbar className="my-5" creating={creating} handleCreateNew={handleCreateNew} setFilters={setFilters} setSort={setSort} searchTerm={searchTerm} setSearchTerm={setSearchTerm} />
 
       <DataTable columns={columns} data={filteredPolicies} loading={fetching} />
     </>
+  )
+}
+
+const InternalPolicyFilterableFields: FilterField[] = [
+  { key: 'background', label: 'Background', type: 'text' },
+  { key: 'name', label: 'Name', type: 'text' },
+  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'displayID', label: 'Display ID', type: 'text' },
+  { key: 'hasBlockedGroups', label: 'Has Blocked Groups', type: 'boolean' },
+  { key: 'hasControlObjectives', label: 'Has Control Objectives', type: 'boolean' },
+  { key: 'hasControls', label: 'Has Controls', type: 'boolean' },
+  { key: 'hasEditors', label: 'Has Editors', type: 'boolean' },
+  { key: 'hasNarratives', label: 'Has Narratives', type: 'boolean' },
+  { key: 'hasOwner', label: 'Has Owner', type: 'boolean' },
+  { key: 'hasProcedures', label: 'Has Procedures', type: 'boolean' },
+  { key: 'hasPrograms', label: 'Has Programs', type: 'boolean' },
+  { key: 'policyType', label: 'Type', type: 'text' },
+  { key: 'purposeAndScope', label: 'Purpose and Scope', type: 'text' },
+  { key: 'reviewDue', label: 'Review Due', type: 'date' },
+  { key: 'status', label: 'Status', type: 'text' },
+  { key: 'version', label: 'Version', type: 'text' },
+
+  { key: 'createdAt', label: 'Date Created', type: 'date' },
+  { key: 'createdBy', label: 'Created By', type: 'text' },
+  { key: 'deletedAt', label: 'Date Deleted', type: 'date' },
+  { key: 'deletedBy', label: 'Deleted By', type: 'text' },
+  { key: 'updatedAt', label: 'Date Updated', type: 'date' },
+  { key: 'updatedBy', label: 'Updated By', type: 'text' },
+]
+
+const InternalPolicySortableFields = [
+  { key: 'name', label: 'Name' },
+  { key: 'displayId', label: 'Display ID' },
+  { key: 'createdAt', label: 'Date Created' },
+  { key: 'updatedAt', label: 'Date Updated' },
+]
+
+type PolicyDataTableToolbarProps = {
+  className?: string
+  creating: boolean
+  searching?: boolean
+  searchTerm: string
+  setSearchTerm: (searchTerm: string) => void
+  setFilters: (filters: Record<string, any>) => void
+  setSort: (sort: Record<string, any>) => void
+  handleCreateNew: () => void
+}
+const PolicyDataTableToolbar: React.FC<PolicyDataTableToolbarProps> = ({ className, creating, searching, searchTerm, handleCreateNew, setFilters, setSort, setSearchTerm }) => {
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <div className="grow flex flex-row items-center gap-2">
+        <TableFilter filterFields={InternalPolicyFilterableFields} onFilterChange={setFilters} />
+        {/* <TableSort sortFields={InternalPolicySortableFields} onSortChange={setSort} /> */}
+        <SearchInput value={searchTerm} onChange={setSearchTerm} searching={searching} />
+      </div>
+
+      <div className="grow flex flex-row items-center gap-2 justify-end">
+        <Button icon={<PlusCircle />} iconPosition="left" onClick={handleCreateNew} disabled={creating}>
+          Create new
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+type SearchInputProps = {
+  value: string
+  onChange: (query: string) => void
+  searching?: boolean
+}
+const SearchInput = ({ value, onChange, searching }: SearchInputProps) => {
+  // prevent icon from flashing on quick calls
+  const isSearching = useDebounce(searching, 200)
+
+  return (
+    <Input
+      icon={isSearching ? <LoaderCircle className="animate-spin" size={16} /> : <SearchIcon size={16} />}
+      placeholder="Search"
+      value={value}
+      onChange={(event) => onChange(event.currentTarget.value)}
+      className="h-min py-1 px-2"
+    />
   )
 }

--- a/apps/console/src/components/shared/table-filter/table-filter.tsx
+++ b/apps/console/src/components/shared/table-filter/table-filter.tsx
@@ -158,7 +158,7 @@ export const TableFilter: React.FC<TableFilterProps> = ({ filterFields, onFilter
       <PopoverTrigger asChild>
         <button className="gap-2 flex items-center py-1.5 px-3 border rounded-lg">
           <ListFilter size={16} />
-          <p className="text-sm">Add Filter</p>
+          <p className="text-sm whitespace-nowrap">Add Filter</p>
           <div className="border h-4" />
           <p className="text-sm">{filters.filter((filter) => filter.value !== '').length}</p>
         </button>

--- a/packages/codegen/query/policy.graphql
+++ b/packages/codegen/query/policy.graphql
@@ -58,22 +58,34 @@ query GetAllInternalPoliciesWithDetails {
   }
 }
 
-query GetInternalPoliciesList {
-  internalPolicies {
+fragment InternalPolicyList on InternalPolicy {
+  id
+  displayID
+  name
+  description
+  policyType
+  tags
+  version
+  updatedAt
+  updatedBy
+  createdAt
+  createdBy
+}
+
+query GetInternalPoliciesList($where: InternalPolicyWhereInput) {
+  internalPolicies(where: $where) {
     edges {
       node {
-        id
-        displayID
-        name
-        description
-        policyType
-        tags
-        version
-        updatedAt
-        updatedBy
-        createdAt
-        createdBy
+        ...InternalPolicyList
       }
+    }
+  }
+}
+
+query SearchInternalPolicies($query: String!) {
+  internalPolicySearch(query: $query) {
+    internalPolicies {
+      ...InternalPolicyList
     }
   }
 }

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -26781,7 +26781,24 @@ export type GetAllInternalPoliciesWithDetailsQuery = {
   }
 }
 
-export type GetInternalPoliciesListQueryVariables = Exact<{ [key: string]: never }>
+export type InternalPolicyListFragment = {
+  __typename?: 'InternalPolicy'
+  id: string
+  displayID: string
+  name: string
+  description?: string | null
+  policyType?: string | null
+  tags?: Array<string> | null
+  version?: string | null
+  updatedAt?: any | null
+  updatedBy?: string | null
+  createdAt?: any | null
+  createdBy?: string | null
+}
+
+export type GetInternalPoliciesListQueryVariables = Exact<{
+  where?: InputMaybe<InternalPolicyWhereInput>
+}>
 
 export type GetInternalPoliciesListQuery = {
   __typename?: 'Query'
@@ -26805,6 +26822,31 @@ export type GetInternalPoliciesListQuery = {
       } | null
     } | null> | null
   }
+}
+
+export type SearchInternalPoliciesQueryVariables = Exact<{
+  query: Scalars['String']['input']
+}>
+
+export type SearchInternalPoliciesQuery = {
+  __typename?: 'Query'
+  internalPolicySearch?: {
+    __typename?: 'InternalPolicySearchResult'
+    internalPolicies?: Array<{
+      __typename?: 'InternalPolicy'
+      id: string
+      displayID: string
+      name: string
+      description?: string | null
+      policyType?: string | null
+      tags?: Array<string> | null
+      version?: string | null
+      updatedAt?: any | null
+      updatedBy?: string | null
+      createdAt?: any | null
+      createdBy?: string | null
+    }> | null
+  } | null
 }
 
 export type GetAllInternalPoliciesQueryVariables = Exact<{ [key: string]: never }>
@@ -27378,6 +27420,21 @@ export const InternalPolicyUpdateFieldsFragmentDoc = gql`
     policyType
     purposeAndScope
     details
+  }
+`
+export const InternalPolicyListFragmentDoc = gql`
+  fragment InternalPolicyList on InternalPolicy {
+    id
+    displayID
+    name
+    description
+    policyType
+    tags
+    version
+    updatedAt
+    updatedBy
+    createdAt
+    createdBy
   }
 `
 export const InternalPolicyByIdFragmentDoc = gql`
@@ -28203,29 +28260,34 @@ export function useGetAllInternalPoliciesWithDetailsQuery(options?: Omit<Urql.Us
   return Urql.useQuery<GetAllInternalPoliciesWithDetailsQuery, GetAllInternalPoliciesWithDetailsQueryVariables>({ query: GetAllInternalPoliciesWithDetailsDocument, ...options })
 }
 export const GetInternalPoliciesListDocument = gql`
-  query GetInternalPoliciesList {
-    internalPolicies {
+  query GetInternalPoliciesList($where: InternalPolicyWhereInput) {
+    internalPolicies(where: $where) {
       edges {
         node {
-          id
-          displayID
-          name
-          description
-          policyType
-          tags
-          version
-          updatedAt
-          updatedBy
-          createdAt
-          createdBy
+          ...InternalPolicyList
         }
       }
     }
   }
+  ${InternalPolicyListFragmentDoc}
 `
 
 export function useGetInternalPoliciesListQuery(options?: Omit<Urql.UseQueryArgs<GetInternalPoliciesListQueryVariables>, 'query'>) {
   return Urql.useQuery<GetInternalPoliciesListQuery, GetInternalPoliciesListQueryVariables>({ query: GetInternalPoliciesListDocument, ...options })
+}
+export const SearchInternalPoliciesDocument = gql`
+  query SearchInternalPolicies($query: String!) {
+    internalPolicySearch(query: $query) {
+      internalPolicies {
+        ...InternalPolicyList
+      }
+    }
+  }
+  ${InternalPolicyListFragmentDoc}
+`
+
+export function useSearchInternalPoliciesQuery(options: Omit<Urql.UseQueryArgs<SearchInternalPoliciesQueryVariables>, 'query'>) {
+  return Urql.useQuery<SearchInternalPoliciesQuery, SearchInternalPoliciesQueryVariables>({ query: SearchInternalPoliciesDocument, ...options })
 }
 export const GetAllInternalPoliciesDocument = gql`
   query GetAllInternalPolicies {

--- a/packages/ui/src/data-table/data-table.tsx
+++ b/packages/ui/src/data-table/data-table.tsx
@@ -133,7 +133,6 @@ export function DataTable<TData, TValue>({
                 key={row.id}
                 data-state={row.getIsSelected() && 'selected'}
               >
-                {' '}
                 {row.getVisibleCells().map((cell) => (
                   // @ts-ignore
                   <TableCell key={cell.id} className={cell.column.columnDef.meta?.className || ''}>


### PR DESCRIPTION
Adds searching and filter to policiies datatable.

Sorting is in but commented out since the API does not support any ordering info for internal policies yet

There are 2 GraphQL calls that can be made. It will use the search query if there's a search term, otherwise it will use the list query and apply any filters. Since the search query doesn't support where conditions, the filters do not apply to that.

![CleanShot 2025-02-27 at 21 59 41](https://github.com/user-attachments/assets/2421d999-17f3-45fa-b7d0-2ca66c274c3c)
