### PR TITLE
Feat/UI policies procedures delete

### DIFF
--- a/apps/console/src/components/pages/protected/policies/actions/actions.tsx
+++ b/apps/console/src/components/pages/protected/policies/actions/actions.tsx
@@ -4,26 +4,27 @@ import { Edit, MoreHorizontal, Trash2 } from 'lucide-react'
 import { useToast } from '@repo/ui/use-toast'
 import { pageStyles } from '../page.styles'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuTrigger } from '@repo/ui/dropdown-menu'
-import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogAction, AlertDialogCancel } from '@repo/ui/alert-dialog'
-import { Button } from '@repo/ui/button'
 import React, { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { useDeleteInternalPolicyMutation } from '@repo/codegen/src/schema'
+import { useGQLErrorToast } from '@/hooks/useGQLErrorToast'
+import { UseQueryExecute } from 'urql'
+import { ConfirmationDialog } from '@repo/ui/confirmation-dialog'
 
 type PolicyActionsProps = {
   policyId: string
-  // refetchPolicies: UseQueryExecute
+  refetchPolicies: UseQueryExecute
 }
 
 const ICON_SIZE = 12
 
-export const Actions = ({
-  policyId: policyId, // refetchPolicies: refetchPolicies,
-}: PolicyActionsProps) => {
+export const Actions = ({ policyId: policyId, refetchPolicies: refetchPolicies }: PolicyActionsProps) => {
   const router = useRouter()
+  const { toastGQLError } = useGQLErrorToast()
   const { actionIcon } = pageStyles()
   const { toast } = useToast()
 
-  // const [ _, deleteTemplate] = useDeletePolicyMutation()
+  const [_, deletePolicy] = useDeleteInternalPolicyMutation()
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
 
@@ -32,24 +33,19 @@ export const Actions = ({
   }
 
   const handleDeletePolicy = async () => {
-    // const response = await deletePolicy({ deletePolicyId: policyId })
+    const { error } = await deletePolicy({ deleteInternalPolicyId: policyId })
 
-    // if (response.error) {
-    //   toast({
-    //     title: 'There was a problem deleting the policy, please try again',
-    //     variant: 'destructive',
-    //   })
-    // }
+    if (error) {
+      toastGQLError({ title: 'Error deleting policy', error })
+      return
+    }
 
-    // if (response.data) {
+    refetchPolicies()
+
     toast({
-      title: 'Questionnaire deleted successfully',
+      title: 'Policy deleted',
       variant: 'success',
     })
-    // refetchPolicies({
-    //   requestPolicy: 'network-only',
-    // })
-    // }
   }
 
   return (
@@ -60,10 +56,11 @@ export const Actions = ({
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-10">
           <DropdownMenuGroup>
-            <DropdownMenuItem onSelect={handleEditPolicy}>
+            <DropdownMenuItem onSelect={handleEditPolicy} className="cursor-pointer">
               <Edit width={ICON_SIZE} /> Edit
             </DropdownMenuItem>
             <DropdownMenuItem
+              className="cursor-pointer"
               onClick={() => {
                 setIsDeleteDialogOpen(true)
               }}
@@ -74,32 +71,12 @@ export const Actions = ({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-            <AlertDialogDescription>This action cannot be undone, this will permanently remove the policy from the organization.</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel asChild>
-              <Button variant="outline">Cancel</Button>
-            </AlertDialogCancel>
-            <AlertDialogAction asChild>
-              <Button
-                variant="filled"
-                onClick={handleDeletePolicy}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    handleDeletePolicy()
-                  }
-                }}
-              >
-                Delete Policy
-              </Button>
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmationDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        onConfirm={handleDeletePolicy}
+        description="This action cannot be undone, this will permanently remove the policy from the organization."
+      />
     </>
   )
 }

--- a/apps/console/src/components/pages/protected/policies/policies-table.tsx
+++ b/apps/console/src/components/pages/protected/policies/policies-table.tsx
@@ -33,8 +33,12 @@ export const PoliciesTable = () => {
 
   const debouncedSearchTerm = useDebounce(searchTerm, 300)
 
-  const [{ data, fetching }, refetchList] = useGetInternalPoliciesListQuery({ variables: { where: filters } })
-  const [{ data: searchData, fetching: searching }, refetchSearch] = useSearchInternalPoliciesQuery({ variables: { query: debouncedSearchTerm }, pause: !debouncedSearchTerm })
+  const [{ data, fetching }, refetchList] = useGetInternalPoliciesListQuery({ variables: { where: filters }, requestPolicy: 'network-only' })
+  const [{ data: searchData, fetching: searching }, refetchSearch] = useSearchInternalPoliciesQuery({
+    variables: { query: debouncedSearchTerm },
+    pause: !debouncedSearchTerm,
+    requestPolicy: 'network-only',
+  })
 
   const refetch = useCallback(() => {
     refetchSearch({ requestPolicy: 'network-only' })

--- a/apps/console/src/components/pages/protected/policies/policies-table.tsx
+++ b/apps/console/src/components/pages/protected/policies/policies-table.tsx
@@ -6,7 +6,7 @@ import { LoaderCircle, PlusCircle, SearchIcon } from 'lucide-react'
 import { DataTable } from '@repo/ui/data-table'
 import { ColumnDef } from '@tanstack/react-table'
 import { format } from 'date-fns'
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { Input } from '@repo/ui/input'
 import { pageStyles } from './page.styles'
 import { Actions } from './actions/actions'
@@ -33,8 +33,14 @@ export const PoliciesTable = () => {
 
   const debouncedSearchTerm = useDebounce(searchTerm, 300)
 
-  const [{ data, fetching }] = useGetInternalPoliciesListQuery({ variables: { where: filters } })
-  const [{ data: searchData, fetching: searching }] = useSearchInternalPoliciesQuery({ variables: { query: debouncedSearchTerm }, pause: !debouncedSearchTerm })
+  const [{ data, fetching }, refetchList] = useGetInternalPoliciesListQuery({ variables: { where: filters } })
+  const [{ data: searchData, fetching: searching }, refetchSearch] = useSearchInternalPoliciesQuery({ variables: { query: debouncedSearchTerm }, pause: !debouncedSearchTerm })
+
+  const refetch = useCallback(() => {
+    console.log('refetching')
+    refetchSearch({ requestPolicy: 'network-only' })
+    refetchList({ requestPolicy: 'network-only' })
+  }, [refetchSearch, refetchList])
 
   useEffect(() => {
     if (data && !searchTerm) {
@@ -115,19 +121,23 @@ export const PoliciesTable = () => {
     {
       accessorKey: 'id',
       header: '',
-      cell: ({ cell }) => (
-        <Actions
-          policyId={cell.getValue() as string}
-          //  refetchPolicies={refetch}
-        />
-      ),
+      cell: ({ cell }) => <Actions policyId={cell.getValue() as string} refetchPolicies={refetch} />,
       size: 40,
     },
   ]
 
   return (
     <>
-      <PolicyDataTableToolbar className="my-5" creating={creating} handleCreateNew={handleCreateNew} setFilters={setFilters} setSort={setSort} searchTerm={searchTerm} setSearchTerm={setSearchTerm} />
+      <PolicyDataTableToolbar
+        className="my-5"
+        creating={creating}
+        searching={searching}
+        handleCreateNew={handleCreateNew}
+        setFilters={setFilters}
+        setSort={setSort}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+      />
 
       <DataTable columns={columns} data={filteredPolicies} loading={fetching} />
     </>

--- a/apps/console/src/components/pages/protected/policies/policies-table.tsx
+++ b/apps/console/src/components/pages/protected/policies/policies-table.tsx
@@ -37,7 +37,6 @@ export const PoliciesTable = () => {
   const [{ data: searchData, fetching: searching }, refetchSearch] = useSearchInternalPoliciesQuery({ variables: { query: debouncedSearchTerm }, pause: !debouncedSearchTerm })
 
   const refetch = useCallback(() => {
-    console.log('refetching')
     refetchSearch({ requestPolicy: 'network-only' })
     refetchList({ requestPolicy: 'network-only' })
   }, [refetchSearch, refetchList])

--- a/apps/console/src/components/pages/protected/policies/policy-edit-sidebar.tsx
+++ b/apps/console/src/components/pages/protected/policies/policy-edit-sidebar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useState, useCallback } from 'react'
 import { InternalPolicyByIdFragment, useDeleteInternalPolicyMutation } from '@repo/codegen/src/schema'
 import { Info, Binoculars, FileStack, ScrollText, Tag, CalendarCheck2, CalendarClock } from 'lucide-react'
 import { MetaPanel, formatTime } from '@/components/shared/meta-panel/meta-panel'
@@ -34,7 +34,7 @@ export const PolicyEditSidebar = ({ policy, form, handleSave }: PolicyEditSideba
 
   if (!policy) return null
 
-  const handleDelete = async () => {
+  const handleDelete = useCallback(async () => {
     const { error } = await deletePolicy({ deleteInternalPolicyId: policy.id })
 
     if (error) {
@@ -48,7 +48,7 @@ export const PolicyEditSidebar = ({ policy, form, handleSave }: PolicyEditSideba
     })
 
     router.push('/policies')
-  }
+  }, [deletePolicy, policy, router, toast, toastGQLError])
 
   const sidebarItems = useMemo(() => {
     return {

--- a/apps/console/src/components/pages/protected/procedures/actions/actions.tsx
+++ b/apps/console/src/components/pages/protected/procedures/actions/actions.tsx
@@ -4,26 +4,27 @@ import { Edit, MoreHorizontal, Trash2 } from 'lucide-react'
 import { useToast } from '@repo/ui/use-toast'
 import { pageStyles } from '../page.styles'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuTrigger } from '@repo/ui/dropdown-menu'
-import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogAction, AlertDialogCancel } from '@repo/ui/alert-dialog'
-import { Button } from '@repo/ui/button'
 import React, { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { useDeleteProcedureMutation } from '@repo/codegen/src/schema'
+import { useGQLErrorToast } from '@/hooks/useGQLErrorToast'
+import { UseQueryExecute } from 'urql'
+import { ConfirmationDialog } from '@repo/ui/confirmation-dialog'
 
 type ProcedureActionsProps = {
   procedureId: string
-  // refetchProcedures: UseQueryExecute
+  refetchProcedures: UseQueryExecute
 }
 
 const ICON_SIZE = 12
 
-export const Actions = ({
-  procedureId: procedureId, // refetchProcedures: refetchProcedures,
-}: ProcedureActionsProps) => {
+export const Actions = ({ procedureId: procedureId, refetchProcedures: refetchProcedures }: ProcedureActionsProps) => {
   const router = useRouter()
+  const { toastGQLError } = useGQLErrorToast()
   const { actionIcon } = pageStyles()
   const { toast } = useToast()
 
-  // const [ _, deleteTemplate] = useDeleteProcedureMutation()
+  const [_, deleteProcedure] = useDeleteProcedureMutation()
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
 
@@ -32,24 +33,19 @@ export const Actions = ({
   }
 
   const handleDeleteProcedure = async () => {
-    // const response = await deleteProcedure({ deleteProcedureId: procedureId })
+    const { error } = await deleteProcedure({ deleteProcedureId: procedureId })
 
-    // if (response.error) {
-    //   toast({
-    //     title: 'There was a problem deleting the procedure, please try again',
-    //     variant: 'destructive',
-    //   })
-    // }
+    if (error) {
+      toastGQLError({ title: 'Error deleting procedure', error })
+      return
+    }
 
-    // if (response.data) {
+    refetchProcedures()
+
     toast({
-      title: 'Questionnaire deleted successfully',
+      title: 'Procedure deleted',
       variant: 'success',
     })
-    // refetchProcedures({
-    //   requestProcedure: 'network-only',
-    // })
-    // }
   }
 
   return (
@@ -60,10 +56,11 @@ export const Actions = ({
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-10">
           <DropdownMenuGroup>
-            <DropdownMenuItem onSelect={handleEditProcedure}>
+            <DropdownMenuItem onSelect={handleEditProcedure} className="cursor-pointer">
               <Edit width={ICON_SIZE} /> Edit
             </DropdownMenuItem>
             <DropdownMenuItem
+              className="cursor-pointer"
               onClick={() => {
                 setIsDeleteDialogOpen(true)
               }}
@@ -74,32 +71,12 @@ export const Actions = ({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-            <AlertDialogDescription>This action cannot be undone, this will permanently remove the procedure from the organization.</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel asChild>
-              <Button variant="outline">Cancel</Button>
-            </AlertDialogCancel>
-            <AlertDialogAction asChild>
-              <Button
-                variant="filled"
-                onClick={handleDeleteProcedure}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    handleDeleteProcedure()
-                  }
-                }}
-              >
-                Delete Procedure
-              </Button>
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmationDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        onConfirm={handleDeleteProcedure}
+        description="This action cannot be undone, this will permanently remove the procedure from the organization."
+      />
     </>
   )
 }

--- a/apps/console/src/components/pages/protected/procedures/procedures-table.tsx
+++ b/apps/console/src/components/pages/protected/procedures/procedures-table.tsx
@@ -32,8 +32,8 @@ export const ProceduresTable = () => {
 
   const debouncedSearchTerm = useDebounce(searchTerm, 300)
 
-  const [{ data, fetching }, refetchList] = useGetProceduresListQuery({ variables: { where: filters } })
-  const [{ data: searchData, fetching: searching }, refetchSearch] = useSearchProceduresQuery({ variables: { query: debouncedSearchTerm }, pause: !debouncedSearchTerm })
+  const [{ data, fetching }, refetchList] = useGetProceduresListQuery({ variables: { where: filters }, requestPolicy: 'network-only' })
+  const [{ data: searchData, fetching: searching }, refetchSearch] = useSearchProceduresQuery({ variables: { query: debouncedSearchTerm }, pause: !debouncedSearchTerm, requestPolicy: 'network-only' })
 
   const refetch = useCallback(() => {
     refetchSearch({ requestPolicy: 'network-only' })

--- a/apps/console/src/components/pages/protected/procedures/procedures-table.tsx
+++ b/apps/console/src/components/pages/protected/procedures/procedures-table.tsx
@@ -6,9 +6,8 @@ import { LoaderCircle, PlusCircle, SearchIcon } from 'lucide-react'
 import { DataTable } from '@repo/ui/data-table'
 import { ColumnDef } from '@tanstack/react-table'
 import { format } from 'date-fns'
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { Input } from '@repo/ui/input'
-import { pageStyles } from './page.styles'
 import { Actions } from './actions/actions'
 import { useCreateProcedureMutation, useGetProceduresListQuery, useSearchProceduresQuery } from '@repo/codegen/src/schema'
 import Link from 'next/link'
@@ -33,8 +32,13 @@ export const ProceduresTable = () => {
 
   const debouncedSearchTerm = useDebounce(searchTerm, 300)
 
-  const [{ data, fetching }] = useGetProceduresListQuery({ variables: { where: filters } })
-  const [{ data: searchData, fetching: searching }] = useSearchProceduresQuery({ variables: { query: debouncedSearchTerm }, pause: !debouncedSearchTerm })
+  const [{ data, fetching }, refetchList] = useGetProceduresListQuery({ variables: { where: filters } })
+  const [{ data: searchData, fetching: searching }, refetchSearch] = useSearchProceduresQuery({ variables: { query: debouncedSearchTerm }, pause: !debouncedSearchTerm })
+
+  const refetch = useCallback(() => {
+    refetchSearch({ requestPolicy: 'network-only' })
+    refetchList({ requestPolicy: 'network-only' })
+  }, [refetchSearch, refetchList])
 
   useEffect(() => {
     if (data && !searchTerm) {
@@ -115,12 +119,7 @@ export const ProceduresTable = () => {
     {
       accessorKey: 'id',
       header: '',
-      cell: ({ cell }) => (
-        <Actions
-          procedureId={cell.getValue() as string}
-          //  refetchProcedures={refetch}
-        />
-      ),
+      cell: ({ cell }) => <Actions procedureId={cell.getValue() as string} refetchProcedures={refetch} />,
       size: 40,
     },
   ]

--- a/packages/codegen/query/procedure.graphql
+++ b/packages/codegen/query/procedure.graphql
@@ -92,3 +92,9 @@ query GetProcedureDetailsById($procedureId: ID!) {
     ...ProcedureByID
   }
 }
+
+mutation DeleteProcedure($deleteProcedureId: ID!) {
+  deleteProcedure(id: $deleteProcedureId) {
+    deletedID
+  }
+}

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -27060,6 +27060,12 @@ export type GetProcedureDetailsByIdQuery = {
   }
 }
 
+export type DeleteProcedureMutationVariables = Exact<{
+  deleteProcedureId: Scalars['ID']['input']
+}>
+
+export type DeleteProcedureMutation = { __typename?: 'Mutation'; deleteProcedure: { __typename?: 'ProcedureDeletePayload'; deletedID: string } }
+
 export type CreateProgramWithMembersMutationVariables = Exact<{
   input: CreateProgramWithMembersInput
 }>
@@ -28523,6 +28529,17 @@ export const GetProcedureDetailsByIdDocument = gql`
 
 export function useGetProcedureDetailsByIdQuery(options: Omit<Urql.UseQueryArgs<GetProcedureDetailsByIdQueryVariables>, 'query'>) {
   return Urql.useQuery<GetProcedureDetailsByIdQuery, GetProcedureDetailsByIdQueryVariables>({ query: GetProcedureDetailsByIdDocument, ...options })
+}
+export const DeleteProcedureDocument = gql`
+  mutation DeleteProcedure($deleteProcedureId: ID!) {
+    deleteProcedure(id: $deleteProcedureId) {
+      deletedID
+    }
+  }
+`
+
+export function useDeleteProcedureMutation() {
+  return Urql.useMutation<DeleteProcedureMutation, DeleteProcedureMutationVariables>(DeleteProcedureDocument)
 }
 export const CreateProgramWithMembersDocument = gql`
   mutation CreateProgramWithMembers($input: CreateProgramWithMembersInput!) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
     "./breadcrumb": "./src/breadcrumb/breadcrumb.tsx",
     "./calendar": "./src/calendar/calendar.tsx",
     "./cardpanel": "./src/cardpanel/card.tsx",
+    "./confirmation-dialog": "./src/confirmation-dialog/confirmation-dialog.tsx",
     "./checkbox": "./src/checkbox/checkbox.tsx",
     "./command": "./src/command.tsx",
     "./data-table": "./src/data-table/data-table.tsx",

--- a/packages/ui/src/confirmation-dialog/confirmation-dialog.tsx
+++ b/packages/ui/src/confirmation-dialog/confirmation-dialog.tsx
@@ -1,0 +1,41 @@
+import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogAction, AlertDialogCancel } from '@repo/ui/alert-dialog'
+import { Button } from '@repo/ui/button'
+
+type ConfirmationAlertProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+  title?: string
+  description?: string
+}
+
+export const ConfirmationDialog = ({ open, onOpenChange, onConfirm, title, description }: ConfirmationAlertProps) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title || 'Are you absolutely sure?'}</AlertDialogTitle>
+          <AlertDialogDescription>{description || 'This action cannot be undone.'}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel asChild>
+            <Button variant="outline">Cancel</Button>
+          </AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <Button
+              variant="destructive"
+              onClick={onConfirm}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  onConfirm()
+                }
+              }}
+            >
+              Delete
+            </Button>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}


### PR DESCRIPTION
- new ui component: `ConfirmationDialog` - I noticed we were building up a collection of them, so overtime you can migrate to this one
- Delete on both table and edit screens for policies and procedures.

![CleanShot 2025-02-28 at 16 34 36](https://github.com/user-attachments/assets/948609d3-fc81-4d66-8ac8-166a0e724f88)
![CleanShot 2025-02-28 at 16 35 05](https://github.com/user-attachments/assets/fc2c6af9-b5dc-457e-9906-c862ec115773)
