### PR TITLE
Close dialog after task bulk import

### DIFF
--- a/apps/console/src/components/pages/protected/tasks/create-task/dialog/bulk-csv-create-task-dialog.tsx
+++ b/apps/console/src/components/pages/protected/tasks/create-task/dialog/bulk-csv-create-task-dialog.tsx
@@ -26,6 +26,7 @@ const BulkCSVCreateTaskDialog = () => {
         title: 'Tasks Created',
         description: `Tasks has been successfully created`,
       })
+      setIsOpen(false)
     } catch (error) {
       errorNotification({
         title: 'Error',


### PR DESCRIPTION
Since I worked on the task importing on the backend earlier today. a weird behaviour I found 