### PR TITLE
fix: recovery codes displaying after 2fa setup

### DIFF
--- a/apps/console/src/components/pages/protected/profile/user-settings/qrcode-dialog.tsx
+++ b/apps/console/src/components/pages/protected/profile/user-settings/qrcode-dialog.tsx
@@ -53,12 +53,18 @@ const QRCodeDialog = ({ qrcode, secret, refetch, onClose, regeneratedCodes }: QR
 
       if (response.ok) {
         successNotification({ title: 'OTP validated successfully' })
-        await updateTfaSetting({
+        const resp = await updateTfaSetting({
           input: {
             verified: true,
           },
         })
-        setRecoveryCodes(data?.updateTFASetting.recoveryCodes || null)
+
+        // ensure recovery codes are available
+        if (!resp?.updateTFASetting?.recoveryCodes) {
+          errorNotification({ title: 'Failed to retrieve recovery codes' })
+        }
+
+        setRecoveryCodes(resp?.updateTFASetting?.recoveryCodes || null)
         setModalClosable(false)
 
         queryClient.invalidateQueries({ queryKey: ['tfaSettings'] })


### PR DESCRIPTION
- fixes no recovery codes because `data` was the verifyOTP; not `updateTfaSettings` response
- adds a check to ensure there isn't a silent failure in the future