### PR TITLE
feat: passkey without entering email

### DIFF
--- a/apps/console/src/app/(auth)/unsubscribe/layout.tsx
+++ b/apps/console/src/app/(auth)/unsubscribe/layout.tsx
@@ -13,17 +13,6 @@ const layout = ({ children }: { children: ReactNode }) => {
         <div className="flex flex-col text-center text-sm mt-20">
           <Link href="/login">Back to login</Link>
         </div>
-        <div className="text-[10px] text-gray-500 mt-5 text-center">
-          This site is protected by reCAPTCHA and the Google{' '}
-          <a className="text-blue-500 underline" href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">
-            Privacy Policy
-          </a>{' '}
-          and{' '}
-          <a className="text-blue-500 underline" href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer">
-            Terms of Service
-          </a>{' '}
-          apply.
-        </div>
       </div>
     </main>
   )

--- a/apps/console/src/components/pages/auth/login/login.styles.tsx
+++ b/apps/console/src/components/pages/auth/login/login.styles.tsx
@@ -2,8 +2,8 @@ import { tv, type VariantProps } from 'tailwind-variants'
 
 const loginStyles = tv({
   slots: {
-    separator: 'my-10 bold',
-    buttons: 'flex flex-col gap-8',
+    separator: 'my-6 bold',
+    buttons: 'flex flex-col gap-4',
     keyIcon: '',
     form: 'flex flex-col gap-4 space-y-2',
     input: 'flex flex-col gap-2',

--- a/apps/console/src/components/pages/auth/signup/signup.styles.tsx
+++ b/apps/console/src/components/pages/auth/signup/signup.styles.tsx
@@ -2,8 +2,8 @@ import { tv, type VariantProps } from 'tailwind-variants'
 
 const signupStyles = tv({
   slots: {
-    separator: 'my-10',
-    buttons: 'flex flex-col gap-8',
+    separator: 'my-6',
+    buttons: 'flex flex-col gap-4',
     keyIcon: '',
     form: 'flex flex-col gap-4 space-y-2',
     input: 'flex flex-col gap-2',

--- a/apps/console/src/components/pages/auth/signup/signup.tsx
+++ b/apps/console/src/components/pages/auth/signup/signup.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { SimpleForm } from '@repo/ui/simple-form'
 import { MessageBox } from '@repo/ui/message-box'
 import { Button } from '@repo/ui/button'
-import { ArrowUpRight } from 'lucide-react'
+import { ArrowUpRight, Fingerprint } from 'lucide-react'
 import { getPasskeyRegOptions, registerUser, verifyRegistration, type RegisterUser } from '@/lib/user'
 import { GoogleIcon } from '@repo/ui/icons/google'
 import { GithubIcon } from '@repo/ui/icons/github'
@@ -20,8 +20,7 @@ import { startRegistration } from '@simplewebauthn/browser'
 import Link from 'next/link'
 import { allowedLoginDomains, recaptchaSiteKey } from '@repo/dally/auth'
 
-const TEMP_PASSKEY_EMAIL = 'tempuser@test.com'
-const TEMP_PASSKEY_NAME = 'Temp User'
+const TEMP_PASSKEY_EMAIL = 'tempuser1@test.com'
 
 export const SignupPage = () => {
   const searchParams = useSearchParams()
@@ -65,7 +64,6 @@ export const SignupPage = () => {
     try {
       const options = await getPasskeyRegOptions({
         email: TEMP_PASSKEY_EMAIL,
-        name: TEMP_PASSKEY_NAME,
       })
       setSessionCookie(options.session)
       const attestationResponse = await startRegistration(options.publicKey)
@@ -76,7 +74,6 @@ export const SignupPage = () => {
       if (verificationResult.success) {
         await signIn('passkey', {
           email: TEMP_PASSKEY_EMAIL,
-          name: TEMP_PASSKEY_NAME,
           session: verificationResult.session,
           accessToken: verificationResult.access_token,
           refreshToken: verificationResult.refresh_token,
@@ -123,7 +120,7 @@ export const SignupPage = () => {
         {/* <Button
           variant="outlineLight"
           size="md"
-          icon={<KeyRoundIcon className={keyIcon()} />}
+          icon={<Fingerprint className={keyIcon()} />}
           iconPosition="left"
           onClick={registerPasskey}
         >

--- a/apps/console/src/components/pages/protected/profile/user-settings/profile-name-form.tsx
+++ b/apps/console/src/components/pages/protected/profile/user-settings/profile-name-form.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { GetUserProfileQueryVariables } from '@repo/codegen/src/schema'
 import { Input, InputRow } from '@repo/ui/input'
 import { Panel, PanelHeader } from '@repo/ui/panel'
 import { useSession } from 'next-auth/react'
@@ -97,7 +96,7 @@ const ProfileNameForm = () => {
       <PanelHeader heading="Your Profile" noBorder />
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
-          <InputRow className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <InputRow className="gap-8">
             <FormField
               control={form.control}
               name="firstName"
@@ -146,6 +145,8 @@ const ProfileNameForm = () => {
                 </FormItem>
               )}
             />
+          </InputRow>
+          <InputRow className="gap-8">
             <FormField
               control={form.control}
               name="displayName"

--- a/apps/console/src/components/pages/protected/profile/user-settings/profile-page.tsx
+++ b/apps/console/src/components/pages/protected/profile/user-settings/profile-page.tsx
@@ -195,6 +195,9 @@ const ProfilePage = () => {
         uploadCallback={handleUploadAvatar || 'N/A'}
         placeholderImage={userData?.user.avatarFile?.presignedURL || sessionData?.user?.image}
       />
+      <Suspense fallback={<Loader />}>
+        <DefaultOrgForm />
+      </Suspense>
       <Panel>
         <PanelHeader heading="Two Factor Authentication" noBorder />
         <div className="flex w-full justify-between">
@@ -228,10 +231,6 @@ const ProfilePage = () => {
       )}
 
       <PasskeySection userData={userData} />
-
-      <Suspense fallback={<Loader />}>
-        <DefaultOrgForm />
-      </Suspense>
     </>
   )
 }


### PR DESCRIPTION
- Moves the passkey to it's own button, no longer requires entering your email first -
- Re-organize profile page a bit

<img width="672" alt="image" src="https://github.com/user-attachments/assets/278d5eba-e0f7-4173-ac75-97c02e9d03cf" />



depends on: https://github.com/theopenlane/core/pull/686