### PR TITLE
truncate long group names, add tooltip for visibility

### DIFF
--- a/apps/console/src/components/pages/protected/controls/authority-card.tsx
+++ b/apps/console/src/components/pages/protected/controls/authority-card.tsx
@@ -10,6 +10,7 @@ import { useFormContext, Controller } from 'react-hook-form'
 import { Option } from '@repo/ui/multiple-selector'
 import { Popover, PopoverContent, PopoverTrigger } from '@repo/ui/popover'
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@repo/ui/command'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@repo/ui/tooltip'
 
 interface AuthorityCardProps {
   controlOwner: ControlDetailsFieldsFragment['controlOwner']
@@ -36,7 +37,6 @@ const AuthorityCard: React.FC<AuthorityCardProps> = ({ controlOwner, delegate, i
           {isEditing ? (
             <SearchableSingleSelect
               fieldName="controlOwnerID"
-              formLabel="Owner"
               placeholder="Select a group"
               options={groups.map((g) => ({
                 label: g.displayName,
@@ -44,13 +44,19 @@ const AuthorityCard: React.FC<AuthorityCardProps> = ({ controlOwner, delegate, i
               }))}
             />
           ) : (
-            <div className="flex gap-2">
-              <Avatar entity={controlOwner as Group} variant="small" />
-              <span>{controlOwner?.displayName || 'No Owner'}</span>
-            </div>
+            <TooltipProvider disableHoverableContent>
+              <Tooltip>
+                <Avatar entity={controlOwner as Group} variant="small" />
+                <TooltipTrigger className="w-[200px] cursor-default">
+                  <div className="flex gap-2">
+                    <span className="truncate">{controlOwner?.displayName || 'No Owner'} </span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{controlOwner?.displayName || 'No Owner'}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
         </div>
-
         {/* Delegate */}
         <div className="flex justify-between items-center">
           <div className="flex gap-2 items-center">
@@ -61,7 +67,6 @@ const AuthorityCard: React.FC<AuthorityCardProps> = ({ controlOwner, delegate, i
           {isEditing ? (
             <SearchableSingleSelect
               fieldName="delegateID"
-              formLabel="Delegate"
               placeholder="Select a group"
               options={groups.map((g) => ({
                 label: g.displayName,
@@ -69,10 +74,17 @@ const AuthorityCard: React.FC<AuthorityCardProps> = ({ controlOwner, delegate, i
               }))}
             />
           ) : (
-            <div className="flex gap-2">
-              <Avatar entity={delegate as Group} variant="small" />
-              <span>{delegate?.displayName || 'No Delegate'}</span>
-            </div>
+            <TooltipProvider disableHoverableContent>
+              <Tooltip>
+                <Avatar entity={delegate as Group} variant="small" />
+                <TooltipTrigger className="w-[200px] cursor-default">
+                  <div className="flex gap-2">
+                    <span className="truncate">{delegate?.displayName || 'No Delegate'} </span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{delegate?.displayName || 'No Delegate'}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
         </div>
       </div>
@@ -84,7 +96,7 @@ export default AuthorityCard
 
 interface SearchableSingleSelectProps {
   fieldName: string
-  formLabel: string
+  formLabel?: string
   placeholder?: string
   options: Option[]
 }
@@ -102,11 +114,11 @@ export const SearchableSingleSelect: React.FC<SearchableSingleSelectProps> = ({ 
 
         return (
           <div className="w-[200px]">
-            <label className="text-sm font-medium block mb-1">{formLabel}</label>
+            {formLabel && <label className="text-sm font-medium block mb-1">{formLabel}</label>}
             <Popover open={open} onOpenChange={setOpen}>
               <PopoverTrigger asChild className="flex">
                 <div className="w-full flex text-sm h-10 px-3 !py-0 justify-between border bg-input-background rounded-md items-center cursor-pointer ">
-                  <span>{selected?.label || placeholder}</span>
+                  <span className="truncate">{selected?.label || placeholder}</span>
                   <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                 </div>
               </PopoverTrigger>

--- a/apps/console/src/components/pages/protected/policies/view/cards/authority-card.tsx
+++ b/apps/console/src/components/pages/protected/policies/view/cards/authority-card.tsx
@@ -11,6 +11,7 @@ import { Option } from '@repo/ui/multiple-selector'
 import { Avatar } from '@/components/shared/avatar/avatar.tsx'
 import { useGetAllGroups } from '@/lib/graphql-hooks/groups.ts'
 import { EditPolicyMetadataFormData } from '@/components/pages/protected/policies/view/hooks/use-form-schema.ts'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@repo/ui/tooltip'
 
 type TAuthorityCardProps = {
   form: UseFormReturn<EditPolicyMetadataFormData>
@@ -47,12 +48,17 @@ const AuthorityCard: React.FC<TAuthorityCardProps> = ({ form, isEditing, approve
           )}
 
           {!isEditing && (
-            <div className="w-[200px]">
-              <div className="flex gap-2">
+            <TooltipProvider disableHoverableContent>
+              <Tooltip>
                 <Avatar entity={approver as Group} variant="small" />
-                <span>{approver?.displayName || 'No Approver'}</span>
-              </div>
-            </div>
+                <TooltipTrigger className="w-[200px] cursor-default">
+                  <div className="flex gap-2">
+                    <span className="truncate">{approver?.displayName || 'No Approver'} </span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{approver?.displayName || 'No Approver'}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
         </div>
 
@@ -76,12 +82,17 @@ const AuthorityCard: React.FC<TAuthorityCardProps> = ({ form, isEditing, approve
           )}
 
           {!isEditing && (
-            <div className="w-[200px]">
-              <div className="flex gap-2">
+            <TooltipProvider disableHoverableContent>
+              <Tooltip>
                 <Avatar entity={delegate as Group} variant="small" />
-                <span>{delegate?.displayName || 'No Delegate'}</span>
-              </div>
-            </div>
+                <TooltipTrigger className="w-[200px] cursor-default">
+                  <div className="flex gap-2">
+                    <span className="truncate">{delegate?.displayName || 'No Delegate'} </span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{delegate?.displayName || 'No Delegate'}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
         </div>
       </div>
@@ -111,7 +122,7 @@ export const SearchableSingleSelect: React.FC<SearchableSingleSelectProps> = ({ 
             <Popover open={open} onOpenChange={setOpen}>
               <PopoverTrigger asChild className="flex">
                 <div className="w-full flex text-sm h-10 px-3 !py-0 justify-between border bg-input-background  rounded-md items-center cursor-pointer ">
-                  <span>{selected?.label || placeholder}</span>
+                  <span className="truncate">{selected?.label || placeholder}</span>
                   <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                 </div>
               </PopoverTrigger>

--- a/apps/console/src/components/pages/protected/procedures/view/cards/authority-card.tsx
+++ b/apps/console/src/components/pages/protected/procedures/view/cards/authority-card.tsx
@@ -11,6 +11,7 @@ import { Option } from '@repo/ui/multiple-selector'
 import { Avatar } from '@/components/shared/avatar/avatar.tsx'
 import { useGetAllGroups } from '@/lib/graphql-hooks/groups.ts'
 import { EditProcedureMetadataFormData } from '@/components/pages/protected/procedures/view/hooks/use-form-schema.ts'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@repo/ui/tooltip'
 
 type TAuthorityCardProps = {
   form: UseFormReturn<EditProcedureMetadataFormData>
@@ -47,12 +48,17 @@ const AuthorityCard: React.FC<TAuthorityCardProps> = ({ form, isEditing, approve
           )}
 
           {!isEditing && (
-            <div className="w-[200px]">
-              <div className="flex gap-2">
+            <TooltipProvider disableHoverableContent>
+              <Tooltip>
                 <Avatar entity={approver as Group} variant="small" />
-                <span>{approver?.displayName || 'No Approver'}</span>
-              </div>
-            </div>
+                <TooltipTrigger className="w-[200px] cursor-default">
+                  <div className="flex gap-2">
+                    <span className="truncate">{approver?.displayName || 'No Approver'} </span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{approver?.displayName || 'No Approver'}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
         </div>
 
@@ -76,12 +82,17 @@ const AuthorityCard: React.FC<TAuthorityCardProps> = ({ form, isEditing, approve
           )}
 
           {!isEditing && (
-            <div className="w-[200px]">
-              <div className="flex gap-2">
+            <TooltipProvider disableHoverableContent>
+              <Tooltip>
                 <Avatar entity={delegate as Group} variant="small" />
-                <span>{delegate?.displayName || 'No Delegate'}</span>
-              </div>
-            </div>
+                <TooltipTrigger className="w-[200px] cursor-default">
+                  <div className="flex gap-2">
+                    <span className="truncate">{delegate?.displayName || 'No Delegate'} </span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{delegate?.displayName || 'No Delegate'}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
         </div>
       </div>
@@ -111,7 +122,7 @@ export const SearchableSingleSelect: React.FC<SearchableSingleSelectProps> = ({ 
             <Popover open={open} onOpenChange={setOpen}>
               <PopoverTrigger asChild className="flex">
                 <div className="w-full flex text-sm h-10 px-3 !py-0 justify-between border bg-input-background rounded-md items-center cursor-pointer ">
-                  <span>{selected?.label || placeholder}</span>
+                  <span className="truncate">{selected?.label || placeholder}</span>
                   <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                 </div>
               </PopoverTrigger>


### PR DESCRIPTION
Keeps it to a single line:
<img width="255" alt="image" src="https://github.com/user-attachments/assets/285cced9-ecd4-4214-b3b1-587557ab2438" />

Same with Edit:
<img width="202" alt="image" src="https://github.com/user-attachments/assets/fdc340dd-953f-4ea4-becb-eae60dcdf490" />

Full name still in dropdown:
<img width="451" alt="image" src="https://github.com/user-attachments/assets/50b43d2e-17ed-4bf7-8ae1-6a9f03f42083" />
