### PR TITLE
Disable future date selection when creating an evidence

### DIFF
--- a/apps/console/src/components/pages/protected/evidence/evidence-create-form.tsx
+++ b/apps/console/src/components/pages/protected/evidence/evidence-create-form.tsx
@@ -257,7 +257,7 @@ const EvidenceCreateForm: React.FC<TProps> = ({ formData, onEvidenceCreateSucces
                             Creation Date
                             <SystemTooltip icon={<InfoIcon size={14} className="mx-1 mt-1" />} content={<p>The date the evidence was collected, generally the current date but can be adjusted.</p>} />
                           </FormLabel>
-                          <CalendarPopover field={field} defaultToday required />
+                          <CalendarPopover field={field} defaultToday required disabledFrom={new Date()} />
                           {form.formState.errors.creationDate && <p className="text-red-500 text-sm">{form.formState.errors.creationDate.message}</p>}
                         </FormItem>
                       )}

--- a/packages/ui/src/calendar-popover/calendar-popover.tsx
+++ b/packages/ui/src/calendar-popover/calendar-popover.tsx
@@ -94,7 +94,7 @@ const CalendarPopover = <T extends FieldValues>({ field, defaultToday, required,
 
         <Calendar
           mode="single"
-          disabled={(date) => (disabledFrom ? date < disabledFrom : false)}
+          disabled={(date) => (disabledFrom ? date > disabledFrom : false)}
           selected={value ?? undefined}
           onSelect={(calendarValue) => {
             calendarValue && handleForm(calendarValue)


### PR DESCRIPTION
also fixed a logic issue that made `disabledFrom` not apply

![CleanShot 2025-06-01 at 23 45 57](https://github.com/user-attachments/assets/dcdf139a-7a8c-45ed-949f-3889ca76b13f)


Requires https://github.com/theopenlane/core/pull/796