### PR TITLE
update column icon, use outline style, add hover

### DIFF
--- a/apps/console/src/app/(protected)/controls/[id]/[subcontrolId]/page.tsx
+++ b/apps/console/src/app/(protected)/controls/[id]/[subcontrolId]/page.tsx
@@ -226,7 +226,7 @@ const ControlDetailsPage: React.FC = () => {
                 <Menu
                   content={
                     <>
-                      <div className="flex items-center space-x-2 cursor-pointer" onClick={(e) => handleEdit(e)}>
+                      <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={(e) => handleEdit(e)}>
                         <PencilIcon size={16} strokeWidth={2} />
                         <span>Edit</span>
                       </div>

--- a/apps/console/src/app/(protected)/controls/[id]/[subcontrolId]/page.tsx
+++ b/apps/console/src/app/(protected)/controls/[id]/[subcontrolId]/page.tsx
@@ -226,7 +226,7 @@ const ControlDetailsPage: React.FC = () => {
                 <Menu
                   content={
                     <>
-                      <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={(e) => handleEdit(e)}>
+                      <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={(e) => handleEdit(e)}>
                         <PencilIcon size={16} strokeWidth={2} />
                         <span>Edit</span>
                       </div>

--- a/apps/console/src/app/(protected)/controls/[id]/page.tsx
+++ b/apps/console/src/app/(protected)/controls/[id]/page.tsx
@@ -243,7 +243,7 @@ const ControlDetailsPage: React.FC = () => {
                         }}
                       />
                       <Link href={`/controls/${id}/create-subcontrol`}>
-                        <div className="flex items-center space-x-2 hover:bg-muted ">
+                        <div className="flex items-center space-x-2 hover:bg-muted">
                           <CirclePlus size={16} strokeWidth={2} />
                           <span>Subcontrol</span>
                         </div>
@@ -254,7 +254,7 @@ const ControlDetailsPage: React.FC = () => {
                 <Menu
                   content={
                     <>
-                      <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={(e) => handleEdit(e)}>
+                      <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={(e) => handleEdit(e)}>
                         <PencilIcon size={16} strokeWidth={2} />
                         <span>Edit</span>
                       </div>

--- a/apps/console/src/app/(protected)/controls/[id]/page.tsx
+++ b/apps/console/src/app/(protected)/controls/[id]/page.tsx
@@ -243,7 +243,7 @@ const ControlDetailsPage: React.FC = () => {
                         }}
                       />
                       <Link href={`/controls/${id}/create-subcontrol`}>
-                        <div className="flex items-center space-x-2">
+                        <div className="flex items-center space-x-2 hover:bg-muted ">
                           <CirclePlus size={16} strokeWidth={2} />
                           <span>Subcontrol</span>
                         </div>
@@ -254,7 +254,7 @@ const ControlDetailsPage: React.FC = () => {
                 <Menu
                   content={
                     <>
-                      <div className="flex items-center space-x-2 cursor-pointer" onClick={(e) => handleEdit(e)}>
+                      <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={(e) => handleEdit(e)}>
                         <PencilIcon size={16} strokeWidth={2} />
                         <span>Edit</span>
                       </div>

--- a/apps/console/src/app/(protected)/risks/table/risks-table-toolbar.tsx
+++ b/apps/console/src/app/(protected)/risks/table/risks-table-toolbar.tsx
@@ -55,13 +55,13 @@ const RisksTableToolbar: React.FC<TProps> = ({ onFilterChange, searching, search
       <Menu
         content={
           <>
-            <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={handleExport}>
+            <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={handleExport}>
               <DownloadIcon size={16} strokeWidth={2} />
               <span>Export</span>
             </div>
             <BulkCSVCreateRiskDialog
               trigger={
-                <div className="flex items-center space-x-2 hover:bg-muted ">
+                <div className="flex items-center space-x-2 hover:bg-muted">
                   <Upload size={16} strokeWidth={2} />
                   <span>Bulk Upload</span>
                 </div>

--- a/apps/console/src/app/(protected)/risks/table/risks-table-toolbar.tsx
+++ b/apps/console/src/app/(protected)/risks/table/risks-table-toolbar.tsx
@@ -55,13 +55,13 @@ const RisksTableToolbar: React.FC<TProps> = ({ onFilterChange, searching, search
       <Menu
         content={
           <>
-            <div className="flex items-center space-x-2 cursor-pointer" onClick={handleExport}>
+            <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={handleExport}>
               <DownloadIcon size={16} strokeWidth={2} />
               <span>Export</span>
             </div>
             <BulkCSVCreateRiskDialog
               trigger={
-                <div className="flex items-center space-x-2">
+                <div className="flex items-center space-x-2 hover:bg-muted ">
                   <Upload size={16} strokeWidth={2} />
                   <span>Bulk Upload</span>
                 </div>

--- a/apps/console/src/components/pages/protected/controls/table/controls-table-toolbar.tsx
+++ b/apps/console/src/components/pages/protected/controls/table/controls-table-toolbar.tsx
@@ -68,13 +68,13 @@ const ControlsTableToolbar: React.FC<TProps> = ({ onFilterChange, searching, sea
           content={
             <>
               <Link href="/controls/create-control">
-                <div className="flex items-center space-x-2">
+                <div className="flex items-center space-x-2 hover:bg-muted">
                   <CirclePlus size={16} strokeWidth={2} />
                   <span>Control</span>
                 </div>
               </Link>
               <Link href="/controls/create-subcontrol">
-                <div className="flex items-center space-x-2">
+                <div className="flex items-center space-x-2 hover:bg-muted">
                   <CirclePlus size={16} strokeWidth={2} />
                   <span>Subcontrol</span>
                 </div>
@@ -85,13 +85,13 @@ const ControlsTableToolbar: React.FC<TProps> = ({ onFilterChange, searching, sea
         <Menu
           content={
             <>
-              <div className="flex items-center space-x-2 cursor-pointer" onClick={handleExport}>
+              <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={handleExport}>
                 <DownloadIcon size={16} strokeWidth={2} />
                 <span>Export</span>
               </div>
               <BulkCSVCreateControlDialog
                 trigger={
-                  <div className="flex items-center space-x-2">
+                  <div className="flex items-center space-x-2 hover:bg-muted">
                     <Upload size={16} strokeWidth={2} />
                     <span>Bulk Upload</span>
                   </div>

--- a/apps/console/src/components/pages/protected/policies/table/policies-table-toolbar.tsx
+++ b/apps/console/src/components/pages/protected/policies/table/policies-table-toolbar.tsx
@@ -68,7 +68,7 @@ const PoliciesTableToolbar: React.FC<TPoliciesTableToolbarProps> = ({
           <Menu
             trigger={CreateBtn}
             content={
-              <div className="flex items-center space-x-2 cursor-pointer" onClick={handleCreateNew}>
+              <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={handleCreateNew}>
                 <CirclePlus size={16} strokeWidth={2} />
                 <span>Policy</span>
               </div>
@@ -81,14 +81,14 @@ const PoliciesTableToolbar: React.FC<TPoliciesTableToolbarProps> = ({
               {canCreate(permission?.roles, AccessEnum.CanCreateInternalPolicy) && (
                 <BulkCSVCreatePolicyDialog
                   trigger={
-                    <div className="flex items-center space-x-2">
+                    <div className="flex items-center space-x-2 hover:bg-muted ">
                       <Import size={16} strokeWidth={2} />
                       <span>Import existing document</span>
                     </div>
                   }
                 />
               )}
-              <div className="flex items-center space-x-2 cursor-pointer" onClick={handleExport}>
+              <div className="flex items-center space-x-2  hover:bg-muted cursor-pointer" onClick={handleExport}>
                 <DownloadIcon size={16} strokeWidth={2} />
                 <span>Export</span>
               </div>

--- a/apps/console/src/components/pages/protected/policies/table/policies-table-toolbar.tsx
+++ b/apps/console/src/components/pages/protected/policies/table/policies-table-toolbar.tsx
@@ -68,7 +68,7 @@ const PoliciesTableToolbar: React.FC<TPoliciesTableToolbarProps> = ({
           <Menu
             trigger={CreateBtn}
             content={
-              <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={handleCreateNew}>
+              <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={handleCreateNew}>
                 <CirclePlus size={16} strokeWidth={2} />
                 <span>Policy</span>
               </div>
@@ -81,14 +81,14 @@ const PoliciesTableToolbar: React.FC<TPoliciesTableToolbarProps> = ({
               {canCreate(permission?.roles, AccessEnum.CanCreateInternalPolicy) && (
                 <BulkCSVCreatePolicyDialog
                   trigger={
-                    <div className="flex items-center space-x-2 hover:bg-muted ">
+                    <div className="flex items-center space-x-2 hover:bg-muted">
                       <Import size={16} strokeWidth={2} />
                       <span>Import existing document</span>
                     </div>
                   }
                 />
               )}
-              <div className="flex items-center space-x-2  hover:bg-muted cursor-pointer" onClick={handleExport}>
+              <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={handleExport}>
                 <DownloadIcon size={16} strokeWidth={2} />
                 <span>Export</span>
               </div>

--- a/apps/console/src/components/pages/protected/policies/view/view-policy-page.tsx
+++ b/apps/console/src/components/pages/protected/policies/view/view-policy-page.tsx
@@ -177,14 +177,14 @@ const ViewPolicyPage: React.FC<TViewPolicyPage> = ({ policyId }) => {
                       content={
                         <>
                           {editAllowed && (
-                            <div className="flex items-center space-x-2 cursor-pointer" onClick={handleEdit}>
+                            <div className="flex items-center space-x-2  hover:bg-muted cursor-pointer" onClick={handleEdit}>
                               <PencilIcon size={16} strokeWidth={2} />
                               <span>Edit</span>
                             </div>
                           )}
                           {deleteAllowed && (
                             <>
-                              <div className="flex items-center space-x-2 cursor-pointer" onClick={() => setIsDeleteDialogOpen(true)}>
+                              <div className="flex items-center space-x-2  hover:bg-muted cursor-pointer" onClick={() => setIsDeleteDialogOpen(true)}>
                                 <Trash2 size={16} strokeWidth={2} />
                                 <span>Delete</span>
                               </div>

--- a/apps/console/src/components/pages/protected/policies/view/view-policy-page.tsx
+++ b/apps/console/src/components/pages/protected/policies/view/view-policy-page.tsx
@@ -177,14 +177,14 @@ const ViewPolicyPage: React.FC<TViewPolicyPage> = ({ policyId }) => {
                       content={
                         <>
                           {editAllowed && (
-                            <div className="flex items-center space-x-2  hover:bg-muted cursor-pointer" onClick={handleEdit}>
+                            <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={handleEdit}>
                               <PencilIcon size={16} strokeWidth={2} />
                               <span>Edit</span>
                             </div>
                           )}
                           {deleteAllowed && (
                             <>
-                              <div className="flex items-center space-x-2  hover:bg-muted cursor-pointer" onClick={() => setIsDeleteDialogOpen(true)}>
+                              <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={() => setIsDeleteDialogOpen(true)}>
                                 <Trash2 size={16} strokeWidth={2} />
                                 <span>Delete</span>
                               </div>

--- a/apps/console/src/components/pages/protected/procedures/table/procedures-table-toolbar.tsx
+++ b/apps/console/src/components/pages/protected/procedures/table/procedures-table-toolbar.tsx
@@ -68,7 +68,7 @@ const ProceduresTableToolbar: React.FC<TProceduresTableToolbarProps> = ({
           <Menu
             trigger={CreateBtn}
             content={
-              <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={handleCreateNew}>
+              <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={handleCreateNew}>
                 <CirclePlus size={16} strokeWidth={2} />
                 <span>Procedure</span>
               </div>
@@ -81,7 +81,7 @@ const ProceduresTableToolbar: React.FC<TProceduresTableToolbarProps> = ({
               {canCreate(permission?.roles, AccessEnum.CanCreateInternalPolicy) && (
                 <BulkCSVCreateProcedureDialog
                   trigger={
-                    <div className="flex items-center space-x-2 hover:bg-muted ">
+                    <div className="flex items-center space-x-2 hover:bg-muted">
                       <Import size={16} strokeWidth={2} />
                       <span>Import existing document</span>
                     </div>

--- a/apps/console/src/components/pages/protected/procedures/table/procedures-table-toolbar.tsx
+++ b/apps/console/src/components/pages/protected/procedures/table/procedures-table-toolbar.tsx
@@ -68,7 +68,7 @@ const ProceduresTableToolbar: React.FC<TProceduresTableToolbarProps> = ({
           <Menu
             trigger={CreateBtn}
             content={
-              <div className="flex items-center space-x-2 cursor-pointer" onClick={handleCreateNew}>
+              <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={handleCreateNew}>
                 <CirclePlus size={16} strokeWidth={2} />
                 <span>Procedure</span>
               </div>
@@ -81,14 +81,14 @@ const ProceduresTableToolbar: React.FC<TProceduresTableToolbarProps> = ({
               {canCreate(permission?.roles, AccessEnum.CanCreateInternalPolicy) && (
                 <BulkCSVCreateProcedureDialog
                   trigger={
-                    <div className="flex items-center space-x-2">
+                    <div className="flex items-center space-x-2 hover:bg-muted ">
                       <Import size={16} strokeWidth={2} />
                       <span>Import existing document</span>
                     </div>
                   }
                 />
               )}
-              <div className="flex items-center space-x-2 cursor-pointer" onClick={handleExport}>
+              <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={handleExport}>
                 <DownloadIcon size={16} strokeWidth={2} />
                 <span>Export</span>
               </div>

--- a/apps/console/src/components/pages/protected/procedures/view/view-procedure-page.tsx
+++ b/apps/console/src/components/pages/protected/procedures/view/view-procedure-page.tsx
@@ -181,14 +181,14 @@ const ViewProcedurePage: React.FC<TViewProcedurePage> = ({ procedureId }) => {
                         content={
                           <>
                             {editAllowed && (
-                              <div className="flex items-center space-x-2 cursor-pointer" onClick={handleEdit}>
+                              <div className="flex items-center space-x-2  hover:bg-muted cursor-pointer" onClick={handleEdit}>
                                 <PencilIcon size={16} strokeWidth={2} />
                                 <span>Edit</span>
                               </div>
                             )}
                             {deleteAllowed && (
                               <>
-                                <div className="flex items-center space-x-2 cursor-pointer" onClick={() => setIsDeleteDialogOpen(true)}>
+                                <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={() => setIsDeleteDialogOpen(true)}>
                                   <Trash2 size={16} strokeWidth={2} />
                                   <span>Delete</span>
                                 </div>

--- a/apps/console/src/components/pages/protected/procedures/view/view-procedure-page.tsx
+++ b/apps/console/src/components/pages/protected/procedures/view/view-procedure-page.tsx
@@ -181,7 +181,7 @@ const ViewProcedurePage: React.FC<TViewProcedurePage> = ({ procedureId }) => {
                         content={
                           <>
                             {editAllowed && (
-                              <div className="flex items-center space-x-2  hover:bg-muted cursor-pointer" onClick={handleEdit}>
+                              <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={handleEdit}>
                                 <PencilIcon size={16} strokeWidth={2} />
                                 <span>Edit</span>
                               </div>

--- a/apps/console/src/components/pages/protected/questionnaire/create.tsx
+++ b/apps/console/src/components/pages/protected/questionnaire/create.tsx
@@ -30,7 +30,7 @@ export const CreateDropdown = () => {
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           {canCreate(permission?.roles, AccessEnum.CanCreateTemplate) && (
-            <div className="flex items-center space-x-2 cursor-pointer" onClick={handleCreateNew}>
+            <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={handleCreateNew}>
               <CirclePlus size={16} strokeWidth={2} />
               <span>Questionnaire</span>
             </div>

--- a/apps/console/src/components/pages/protected/tasks/table/task-table-toolbar.tsx
+++ b/apps/console/src/components/pages/protected/tasks/table/task-table-toolbar.tsx
@@ -93,13 +93,13 @@ const TaskTableToolbar: React.FC<TProps> = (props: TProps) => {
             <>
               <BulkCSVCreateTaskDialog
                 trigger={
-                  <div className="flex items-center space-x-2 hover:bg-muted ">
+                  <div className="flex items-center space-x-2 hover:bg-muted">
                     <Upload size={16} strokeWidth={2} />
                     <span>Bulk Upload</span>
                   </div>
                 }
               />
-              <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={props.handleExport}>
+              <div className="flex items-center space-x-2 hover:bg-muted cursor-pointer" onClick={props.handleExport}>
                 <DownloadIcon size={16} strokeWidth={2} />
                 <span>Export</span>
               </div>

--- a/apps/console/src/components/pages/protected/tasks/table/task-table-toolbar.tsx
+++ b/apps/console/src/components/pages/protected/tasks/table/task-table-toolbar.tsx
@@ -93,13 +93,13 @@ const TaskTableToolbar: React.FC<TProps> = (props: TProps) => {
             <>
               <BulkCSVCreateTaskDialog
                 trigger={
-                  <div className="flex items-center space-x-2">
+                  <div className="flex items-center space-x-2 hover:bg-muted ">
                     <Upload size={16} strokeWidth={2} />
                     <span>Bulk Upload</span>
                   </div>
                 }
               />
-              <div className="flex items-center space-x-2 cursor-pointer" onClick={props.handleExport}>
+              <div className="flex items-center space-x-2 hover:bg-muted  cursor-pointer" onClick={props.handleExport}>
                 <DownloadIcon size={16} strokeWidth={2} />
                 <span>Export</span>
               </div>

--- a/apps/console/src/components/shared/column-visibility-menu/column-visibility-menu.tsx
+++ b/apps/console/src/components/shared/column-visibility-menu/column-visibility-menu.tsx
@@ -17,9 +17,7 @@ const ColumnVisibilityMenu: React.FC<TColumnVisibilityMenuProps> = ({ mappedColu
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button icon={<EyeIcon />} iconPosition="left" variant="outline" size="md" className="ml-auto mr-2">
-          Select Columns
-        </Button>
+        <Button icon={<EyeIcon />} iconPosition="left" variant="outline" size="md" className="h-8 !px-0 !pl-2"></Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         {mappedColumns.map((column, index) => {

--- a/apps/console/src/components/shared/icon-enum/common-enum.tsx
+++ b/apps/console/src/components/shared/icon-enum/common-enum.tsx
@@ -1,9 +1,9 @@
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, EllipsisVertical } from 'lucide-react'
 import { Button } from '@repo/ui/button'
 import React from 'react'
 
 export const CreateBtn = (
-  <Button className="h-8 !px-2 !pl-3" icon={<ChevronDown />}>
+  <Button variant="outline" className="h-8 !px-2 !pl-3" icon={<ChevronDown />}>
     Create
   </Button>
 )

--- a/apps/console/src/components/shared/icon-enum/common-enum.tsx
+++ b/apps/console/src/components/shared/icon-enum/common-enum.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, EllipsisVertical } from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
 import { Button } from '@repo/ui/button'
 import React from 'react'
 

--- a/apps/console/src/components/shared/icon-enum/task-enum.tsx
+++ b/apps/console/src/components/shared/icon-enum/task-enum.tsx
@@ -11,7 +11,7 @@ export const TaskStatusIconMapper: Record<TaskTaskStatus, React.ReactNode> = {
 }
 
 export const TaskIconBtn = (
-  <div className="flex items-center space-x-2">
+  <div className="flex items-center space-x-2 hover:bg-muted">
     <CirclePlus size={16} strokeWidth={2} />
     <span>Task</span>
   </div>

--- a/apps/console/src/components/shared/menu/menu.tsx
+++ b/apps/console/src/components/shared/menu/menu.tsx
@@ -11,7 +11,7 @@ interface MenuProps {
 const Menu: React.FC<MenuProps> = ({ trigger, content }) => {
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>{trigger ?? <Button className="h-8 !px-2 !pl-0" icon={<EllipsisVertical size={16} />} />}</DropdownMenuTrigger>
+      <DropdownMenuTrigger asChild>{trigger ?? <Button variant="outline" className="h-8 !px-2 !pl-0" icon={<EllipsisVertical size={16} />} />}</DropdownMenuTrigger>
       <DropdownMenuContent className="border shadow-md" align="end">
         <div className="flex flex-col space-y-2">{content}</div>
       </DropdownMenuContent>


### PR DESCRIPTION
- Select column button was slightly bigger and was pretty big for its functinoality, changing to just the eye icon (we may want to add a tooltip, although I think its pretty obvious?
- Change all table buttons to outline variant for consistency
- Adds hover to dropdowns

![image](https://github.com/user-attachments/assets/3a984114-5685-49df-8c84-73a69ee03d2e)
