### PR TITLE
consistent save, cancel/discard wording on buttons

### DIFF
--- a/apps/console/src/components/pages/protected/controls/control-implementation/form/create-control-implementation-form.tsx
+++ b/apps/console/src/components/pages/protected/controls/control-implementation/form/create-control-implementation-form.tsx
@@ -130,10 +130,10 @@ export const CreateControlImplementationForm = ({ onSuccess, defaultValues }: { 
         {isEditing ? (
           <>
             <Button className="h-8 !px-4" icon={<Pencil />} iconPosition="left">
-              Save edit
+              Save
             </Button>
             <Button variant="back" className="h-8 !px-4" type="button" onClick={onSuccess}>
-              Discard edit
+              Cancel
             </Button>
             <Button variant="destructive" className="h-8 !px-4" icon={<Trash2 />} iconPosition="left" type="button" onClick={handleDelete}>
               Delete

--- a/apps/console/src/components/pages/protected/controls/control-objectives/form/create-control-objective-form.tsx
+++ b/apps/console/src/components/pages/protected/controls/control-objectives/form/create-control-objective-form.tsx
@@ -129,10 +129,10 @@ export const CreateControlObjectiveForm = ({ onSuccess, defaultValues }: { onSuc
         {isEditing ? (
           <>
             <Button className="h-8 !px-4" icon={<Pencil />} iconPosition="left">
-              Save edit
+              Save
             </Button>
             <Button variant="back" className="h-8 !px-4" type="button" onClick={onSuccess}>
-              Discard edit
+              Cancel
             </Button>
             <Button variant="destructive" className="h-8 !px-4" icon={<Trash2 />} iconPosition="left" type="button" onClick={handleDelete}>
               Delete

--- a/apps/console/src/components/pages/protected/dashboard/basic-info.tsx
+++ b/apps/console/src/components/pages/protected/dashboard/basic-info.tsx
@@ -124,7 +124,7 @@ const BasicInformation = () => {
             {isEditing && (
               <div className="flex gap-2">
                 <Button className="!h-8 !p-2" variant="outline" type="submit" icon={<Pencil />} iconPosition="left" disabled={isPending}>
-                  Save edit
+                  Save
                 </Button>
                 <Button type="button" variant="back" className="!h-8 !p-2" onClick={handleCancel}>
                   Cancel

--- a/apps/console/src/components/pages/protected/dashboard/timeline-readiness.tsx
+++ b/apps/console/src/components/pages/protected/dashboard/timeline-readiness.tsx
@@ -116,7 +116,7 @@ const TimelineReadiness = () => {
             {isEditing && (
               <div className="flex gap-2">
                 <Button className="!h-8 !p-2" variant="outline" type="submit" icon={<Pencil />} iconPosition="left" disabled={isPending}>
-                  Save edit
+                  Save
                 </Button>
                 <Button type="button" variant="back" className="!h-8 !p-2" onClick={handleCancel}>
                   Cancel


### PR DESCRIPTION
Using `Save` over `Save edit` and `Cancel` over `Discard` - we had both in different places