### PR TITLE
Invitation token not persisted to sign up page

### DIFF
--- a/apps/console/src/components/pages/auth/login/login.tsx
+++ b/apps/console/src/components/pages/auth/login/login.tsx
@@ -236,7 +236,7 @@ export const LoginPage = () => {
           )}
           <div className="flex text-base">
             <span>New to Openlane? &nbsp;</span>
-            <Link href="/signup" className=" text-base text-blue-500  hover:opacity-80 transition">
+            <Link href={`/signup${token ? `?token=${token}` : ''}`} className="text-base text-blue-500 hover:opacity-80 transition">
               Sign up for an account
             </Link>
           </div>


### PR DESCRIPTION
When a new user tries to go through the invitation flow, the token is lost when navigating from the login page to the sign up page