### PR TITLE
bug: dont add to blocked groups

### DIFF
--- a/apps/console/src/components/pages/programs/settings/groups/program-settings-assign-groups-dialog.tsx
+++ b/apps/console/src/components/pages/programs/settings/groups/program-settings-assign-groups-dialog.tsx
@@ -166,7 +166,6 @@ export const ProgramSettingsAssignGroupDialog = () => {
       await updateProgram({
         updateProgramId: programId,
         input: {
-          addBlockedGroupIDs: selectedGroups.map((g) => g.id),
           addEditorIDs,
           addViewerIDs,
         },

--- a/apps/console/src/components/pages/programs/settings/groups/program-settings-groups.tsx
+++ b/apps/console/src/components/pages/programs/settings/groups/program-settings-groups.tsx
@@ -219,7 +219,7 @@ export const ProgramSettingsGroups = () => {
                 Removing <b>{selectedGroup.name}</b> from the program will revoke all group members permissions to this program.
               </>
             }
-            confirmationText="Delete"
+            confirmationText="Remove"
             confirmationTextVariant="destructive"
             onConfirm={() => handleRemove(selectedGroup.id, selectedGroup.role)}
           />

--- a/apps/console/src/components/pages/programs/settings/users/program-settings-users.tsx
+++ b/apps/console/src/components/pages/programs/settings/users/program-settings-users.tsx
@@ -186,7 +186,7 @@ export const ProgramSettingsUsers = () => {
                 Removing <b>{selectedUser.user.displayName}</b> from the program will revoke the users permissions to this program.
               </>
             }
-            confirmationText="Delete"
+            confirmationText="Remove"
             confirmationTextVariant="destructive"
             onConfirm={handleRemove}
           />


### PR DESCRIPTION
This logic was adding the group to both the view or edit _and_ the blocked group:

```
{
  "updateProgramId": "01JXRC74QTVW677CQHYWWR5JFY",
  "input": {
    "addBlockedGroupIDs": [
      "01JXR8G8TRJQ8PSN9CB9YS8W7K"
    ],
    "addEditorIDs": [],
    "addViewerIDs": [
      "01JXR8G8TRJQ8PSN9CB9YS8W7K"
    ]
  }
}
```

Removed the map to blocked, since that shouldn't be used unless we added `Blocked` to the dropdown