### PR TITLE
verify login has an empty dashboard instead of the onboarding

### DIFF
--- a/apps/console/next-auth.d.ts
+++ b/apps/console/next-auth.d.ts
@@ -12,7 +12,7 @@ declare module 'next-auth' {
       activeOrganizationId: string
       image: string
       isTfaEnabled: boolean
-      isOnboarding: booleann
+      isOnboarding: boolean
     }
   }
   interface User extends DefaultUser {
@@ -20,7 +20,7 @@ declare module 'next-auth' {
     refreshToken: string
     session: string
     isTfaEnabled: boolean
-    isOnboarding: booleann
+    isOnboarding: boolean
   }
   interface Profile extends DefaultProfile {
     display_name: string

--- a/apps/console/src/components/pages/auth/verify/verifier.tsx
+++ b/apps/console/src/components/pages/auth/verify/verifier.tsx
@@ -24,7 +24,7 @@ export const TokenVerifier = () => {
       const refreshToken = verified?.refresh_token
 
       signIn('credentials', {
-        callbackUrl: '/dashboard',
+        callbackUrl: '/',
         accessToken,
         refreshToken,
         session: verified.session,


### PR DESCRIPTION
This will ensure we use the logic to send the user to `/onboarding` instead of `/dashboard` if they only have a personal org. 