### PR TITLE
fixing custom framework undefined link

### DIFF
--- a/apps/console/src/components/pages/protected/controls/map-controls/shared/control-chip.tsx
+++ b/apps/console/src/components/pages/protected/controls/map-controls/shared/control-chip.tsx
@@ -105,9 +105,13 @@ const ControlTooltipContent: React.FC<{ control: NonNullable<ControlChipProps['c
           <span className="font-medium">Standard</span>
         </div>
         <div className="w-full border-b">
-          <Link href={standardHref} className=" size-fit pb-2 hover:underline flex items-center gap-1" target="_blank" rel="noopener">
-            <span className="pl-3 text-brand ">{control.referenceFramework || 'CUSTOM'}</span> <ExternalLink size={12} />
-          </Link>
+          {control.referenceFramework ? (
+            <Link href={standardHref} className=" size-fit pb-2 hover:underline flex items-center gap-1" target="_blank" rel="noopener">
+              <span className="pl-3 text-brand ">{control.referenceFramework}</span> <ExternalLink size={12} />
+            </Link>
+          ) : (
+            <span className="pl-3 text-brand ">CUSTOM</span>
+          )}
         </div>
 
         <div className="flex items-center gap-1 border-b pb-2">

--- a/apps/console/src/components/pages/protected/controls/map-controls/shared/control-chip.tsx
+++ b/apps/console/src/components/pages/protected/controls/map-controls/shared/control-chip.tsx
@@ -104,13 +104,13 @@ const ControlTooltipContent: React.FC<{ control: NonNullable<ControlChipProps['c
           <FileText size={12} />
           <span className="font-medium">Standard</span>
         </div>
-        <div className="w-full border-b">
+        <div className="flex items-center gap-1 border-b pb-2">
           {control.referenceFramework ? (
             <Link href={standardHref} className=" size-fit pb-2 hover:underline flex items-center gap-1" target="_blank" rel="noopener">
               <span className="pl-3 text-brand ">{control.referenceFramework}</span> <ExternalLink size={12} />
             </Link>
           ) : (
-            <span className="pl-3 text-brand ">CUSTOM</span>
+            <span className="pl-3 text-brand">CUSTOM</span>
           )}
         </div>
 
@@ -118,13 +118,13 @@ const ControlTooltipContent: React.FC<{ control: NonNullable<ControlChipProps['c
           <Folder size={12} />
           <span className="font-medium">Category</span>
         </div>
-        <span className="pl-3 pb-2 border-b">{details.category}</span>
+        <span className="flex pl-3 gap-1 border-b pb-2">{details.category || '-'}</span>
 
         <div className="flex items-center gap-1 border-b pb-2">
           <FolderPlus size={12} />
           <span className="font-medium">Subcategory</span>
         </div>
-        <span className="pl-3 pb-2 border-b">{details.subcategory}</span>
+        <span className="flex pl-3 gap-1 border-b pb-2">{details.subcategory || '-'}</span>
       </div>
 
       <div className="flex flex-col pt-2">

--- a/bun.lock
+++ b/bun.lock
@@ -2276,7 +2276,7 @@
 
     "dot-case": ["dot-case@3.0.4", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w=="],
 
-    "dotenv": ["dotenv@17.0.1", "", {}, "sha512-GLjkduuAL7IMJg/ZnOPm9AnWKJ82mSE2tzXLaJ/6hD6DhwGfZaXG77oB8qbReyiczNxnbxQKyh0OE5mXq0bAHA=="],
+    "dotenv": ["dotenv@17.1.0", "", {}, "sha512-tG9VUTJTuju6GcXgbdsOuRhupE8cb4mRgY5JLRCh4MtGoVo3/gfGUtOMwmProM6d0ba2mCFvv+WrpYJV6qgJXQ=="],
 
     "dotenv-cli": ["dotenv-cli@8.0.0", "", { "dependencies": { "cross-spawn": "^7.0.6", "dotenv": "^16.3.0", "dotenv-expand": "^10.0.0", "minimist": "^1.2.6" }, "bin": { "dotenv": "cli.js" } }, "sha512-aLqYbK7xKOiTMIRf1lDPbI+Y+Ip/wo5k3eyp6ePysVaSqbyxjyK3dK35BTxG+rmd7djf5q2UPs4noPNH+cj0Qw=="],
 


### PR DESCRIPTION
custom framework do not have `standardID` so we need to remove link,

alignment and empty string fallback

![image](https://github.com/user-attachments/assets/4bf6d4ab-7b9f-4aee-a694-be83ccdfea61)
