### PR TITLE
link policies on dashboard, comment out templates until ready, consis…

### DIFF
--- a/apps/console/src/app/(protected)/controls/[id]/[subcontrolId]/page.tsx
+++ b/apps/console/src/app/(protected)/controls/[id]/[subcontrolId]/page.tsx
@@ -308,7 +308,7 @@ const ControlDetailsPage: React.FC = () => {
 
   return (
     <>
-      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'}: Subcontrols - ${data.subcontrol.refCode}`}</title>
+      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'} | Subcontrols - ${data.subcontrol.refCode}`}</title>
       <FormProvider {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <SlideBarLayout sidebarTitle="Details" sidebarContent={sidebarContent} menu={menuComponent} slideOpen={isEditing}>

--- a/apps/console/src/app/(protected)/controls/[id]/page.tsx
+++ b/apps/console/src/app/(protected)/controls/[id]/page.tsx
@@ -329,7 +329,7 @@ const ControlDetailsPage: React.FC = () => {
 
   return (
     <>
-      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'}: Controls - ${data.control.refCode}`}</title>
+      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'} | Controls - ${data.control.refCode}`}</title>
       <FormProvider {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <SlideBarLayout sidebarTitle="Details" sidebarContent={sidebarContent} menu={menuComponent} slideOpen={isEditing}>

--- a/apps/console/src/app/(protected)/layout.tsx
+++ b/apps/console/src/app/(protected)/layout.tsx
@@ -4,6 +4,7 @@ import { auth } from '@/lib/auth/auth'
 import { sessionCookieName } from '@repo/dally/auth'
 import { getDashboardData } from '../api/getDashboardData/route'
 import { cookies } from 'next/headers'
+import { capitalizeFirstLetter } from '@/lib/auth/utils/strings'
 
 interface OrganizationNode {
   id: string
@@ -29,8 +30,8 @@ export async function generateMetadata(): Promise<Metadata> {
       const org = organizations.find(({ node }) => node.id === organizationId)
       return {
         title: {
-          template: `${org?.node.displayName}: %s`,
-          default: '',
+          template: `${capitalizeFirstLetter(org?.node.displayName || '')} | %s`,
+          default: '%s',
         },
       }
     }
@@ -38,8 +39,8 @@ export async function generateMetadata(): Promise<Metadata> {
 
   return {
     title: {
-      template: 'Openlane: %s',
-      default: '',
+      template: 'Openlane | %s',
+      default: 'Openlane',
     },
   }
 }

--- a/apps/console/src/app/(protected)/standards/[id]/page.tsx
+++ b/apps/console/src/app/(protected)/standards/[id]/page.tsx
@@ -40,7 +40,7 @@ const StandardDetailsPage = () => {
 
   return (
     <>
-      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'}: Standards - ${standard?.shortName ?? standard?.name}`}</title>
+      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'} | Standards - ${standard?.shortName ?? standard?.name}`}</title>
       <div className="flex gap-14">
         <div className="flex flex-col gap-7 ">
           <PageHeading heading={data?.standard.name || 'Standard Details'} className="mb-3" />

--- a/apps/console/src/components/pages/protected/logs/logs-page.tsx
+++ b/apps/console/src/components/pages/protected/logs/logs-page.tsx
@@ -14,7 +14,12 @@ const LogsPage: React.FC = () => {
     ])
   }, [setCrumbs])
 
-  return <PageHeading heading="Audit Logs" eyebrow="Organization Settings" />
+  return (
+    <>
+      <PageHeading heading="Audit Logs" eyebrow="Organization Settings" />
+      <div>Coming Soon</div>
+    </>
+  )
 }
 
 export default LogsPage

--- a/apps/console/src/components/pages/protected/overview/pending-actions.tsx
+++ b/apps/console/src/components/pages/protected/overview/pending-actions.tsx
@@ -6,6 +6,8 @@ import React, { useState } from 'react'
 import { ColumnDef } from '@tanstack/table-core'
 import { Badge } from '@repo/ui/badge'
 import { Button } from '@repo/ui/button'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
 
 type PendingAction = {
   date: string
@@ -17,6 +19,18 @@ type PendingAction = {
 
 const PendingActions = () => {
   const [tab, setTab] = useState('waiting-on-you')
+
+  const searchParams = useSearchParams()
+  const programId = searchParams.get('id')
+
+  const filters = [
+    {
+      field: 'hasProgramsWith',
+      value: programId,
+      type: 'selectIs',
+      operator: 'EQ',
+    },
+  ]
 
   const pendingActions: PendingAction[] = [
     // {
@@ -70,6 +84,9 @@ const PendingActions = () => {
 
   const noData = pendingActions.length === 0 && approvalsWaitingFor.length === 0
 
+  const encodedFilters = encodeURIComponent(JSON.stringify(filters))
+  const policiesRedirectURL = programId ? `/policies?filters=${encodedFilters}` : '/policies'
+
   return (
     <Card className=" rounded-lg border flex-1">
       <CardTitle className="text-lg font-semibold">Pending Actions</CardTitle>
@@ -79,9 +96,11 @@ const PendingActions = () => {
             <Inbox size={89} strokeWidth={1} className="text-border" />
             <h3 className="mt-4 text-lg font-semibold">No pending actions</h3>
             <p className="text-sm text-muted-foreground mt-1">Maybe it&apos;s time to review some policies and procedures that haven&apos;t been updated in a while?</p>
-            <Button variant="outline" className="mt-4">
-              Take me there
-            </Button>
+            <Link href={policiesRedirectURL} className="mt-4">
+              <Button variant="outline" className="mt-4">
+                Take me there
+              </Button>
+            </Link>
           </div>
         ) : (
           <Tabs defaultValue={tab} onValueChange={setTab}>

--- a/apps/console/src/components/pages/protected/policies/create/form/create-policy-form.tsx
+++ b/apps/console/src/components/pages/protected/policies/create/form/create-policy-form.tsx
@@ -237,7 +237,7 @@ const CreatePolicyForm: React.FC<TCreatePolicyFormProps> = ({ policy }) => {
 
   return (
     <>
-      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'}: Internal Policies - ${policy?.name}`}</title>
+      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'} | Internal Policies - ${policy?.name}`}</title>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(isEditable ? onSaveHandler : onCreateHandler)} className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-6">
           <div className="space-y-6">

--- a/apps/console/src/components/pages/protected/policies/view/view-policy-page.tsx
+++ b/apps/console/src/components/pages/protected/policies/view/view-policy-page.tsx
@@ -267,7 +267,7 @@ const ViewPolicyPage: React.FC<TViewPolicyPage> = ({ policyId }) => {
 
   return (
     <>
-      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'}: Internal Policies - ${policy.name}`}</title>
+      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'} | Internal Policies - ${policy.name}`}</title>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmitHandler)}>
           <SlideBarLayout sidebarTitle="Details" sidebarContent={sidebarContent} menu={menuComponent} slideOpen={isEditing}>

--- a/apps/console/src/components/pages/protected/procedures/view/view-procedure-page.tsx
+++ b/apps/console/src/components/pages/protected/procedures/view/view-procedure-page.tsx
@@ -251,7 +251,7 @@ const ViewProcedurePage: React.FC = () => {
 
   return (
     <>
-      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'}: Procedures - ${data.procedure.name}`}</title>
+      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'} | Procedures - ${data.procedure.name}`}</title>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmitHandler)}>
           <SlideBarLayout sidebarTitle="Details" sidebarContent={sidebarContent} menu={menuComponent} slideOpen={isEditing}>

--- a/apps/console/src/components/pages/protected/program/programs-page.tsx
+++ b/apps/console/src/components/pages/protected/program/programs-page.tsx
@@ -73,7 +73,7 @@ const ProgramsPage: React.FC = () => {
   }, [setCrumbs, basicInfoData, isLoading])
 
   useEffect(() => {
-    if (basicInfoData) document.title = `${currentOrganization?.node?.displayName}: Programs - ${basicInfoData.program.name}`
+    if (basicInfoData) document.title = `${currentOrganization?.node?.displayName ?? 'Openlane'} | Programs - ${basicInfoData.program.name}`
   }, [basicInfoData, currentOrganization?.node?.displayName])
 
   useEffect(() => {

--- a/apps/console/src/components/pages/protected/program/wizard/step-4-associate.tsx
+++ b/apps/console/src/components/pages/protected/program/wizard/step-4-associate.tsx
@@ -66,9 +66,9 @@ export const ObjectAssociationComponent = () => {
                     }
                   }}
                 />
-                <FormLabel htmlFor="useTemplate" className="ml-2 cursor-pointer">
+                {/* <FormLabel htmlFor="useTemplate" className="ml-2 cursor-pointer">
                   Use provided templates
-                </FormLabel>
+                </FormLabel> */}
               </div>
             )}
           />

--- a/apps/console/src/components/pages/protected/risks/view/view-risks-page.tsx
+++ b/apps/console/src/components/pages/protected/risks/view/view-risks-page.tsx
@@ -231,7 +231,7 @@ const ViewRisksPage: React.FC<TRisksPageProps> = ({ riskId }) => {
 
   return (
     <>
-      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'}: Risks - ${risk.name}`}</title>
+      <title>{`${currentOrganization?.node?.displayName ?? 'Openlane'} | Risks - ${risk.name}`}</title>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmitHandler)}>
           <SlideBarLayout sidebarTitle="Details" sidebarContent={sidebarContent} menu={menuComponent} slideOpen={isEditing}>

--- a/apps/console/src/components/pages/protected/tasks/create-task/sidebar/task-details-sheet.tsx
+++ b/apps/console/src/components/pages/protected/tasks/create-task/sidebar/task-details-sheet.tsx
@@ -40,6 +40,7 @@ import { Panel, PanelHeader } from '@repo/ui/panel'
 import { TObjectAssociationMap } from '@/components/shared/objectAssociation/types/TObjectAssociationMap'
 import { getHrefForObjectType } from '@/utils/getHrefForObjectType'
 import Link from 'next/link'
+import { capitalizeFirstLetter } from '@/lib/auth/utils/strings'
 
 const TaskDetailsSheet = () => {
   const [isEditing, setIsEditing] = useState(false)
@@ -715,8 +716,6 @@ const TaskDetailsSheet = () => {
 }
 
 export default TaskDetailsSheet
-
-const capitalizeFirstLetter = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
 
 const generateAssociationPayload = (original: TObjectAssociationMap, updated: TObjectAssociationMap) => {
   const payload: Record<string, string[]> = {}

--- a/apps/console/src/lib/auth/utils/strings.ts
+++ b/apps/console/src/lib/auth/utils/strings.ts
@@ -1,0 +1,1 @@
+export const capitalizeFirstLetter = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)

--- a/bun.lock
+++ b/bun.lock
@@ -1558,7 +1558,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@24.0.10", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA=="],
+    "@types/node": ["@types/node@24.0.11", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-CJV8eqrYnwQJGMrvcRhQmZfpyniDavB+7nAZYJc6w99hFYJyFN3INV1/2W3QfQrqM36WTLrijJ1fxxvGBmCSxA=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 


### PR DESCRIPTION
- adds link to policies on pending actions; this will be empty for a bit, but we can still link to policies (filter on program doesn't currently work, but added a ticket to the backlog to add this filter to the policies table)
- adds coming soon to audit logs, waiting on work from me
- (comments out) removes template option from program until we get those seeded
- uses `|` consistently on metadata, we had `:` sometimes