### PR TITLE
remove extra padding related to plate editors

### DIFF
--- a/apps/console/src/app/(protected)/controls/[id]/[subcontrolId]/page.tsx
+++ b/apps/console/src/app/(protected)/controls/[id]/[subcontrolId]/page.tsx
@@ -262,7 +262,7 @@ const ControlDetailsPage: React.FC = () => {
   )
 
   const mainContent = (
-    <div className="space-y-6 p-6">
+    <div className="space-y-6 p-2">
       <TitleField isEditing={!isSourceFramework && isEditing} />
       <DescriptionField isEditing={!isSourceFramework && isEditing} initialValue={initialValues.description} />
       <ControlEvidenceTable

--- a/apps/console/src/app/(protected)/controls/[id]/page.tsx
+++ b/apps/console/src/app/(protected)/controls/[id]/page.tsx
@@ -270,7 +270,7 @@ const ControlDetailsPage: React.FC = () => {
   )
 
   const mainContent = (
-    <div className="space-y-6 p-6">
+    <div className="space-y-6 p-2">
       <TitleField isEditing={!isSourceFramework && isEditing} />
       <DescriptionField isEditing={!isSourceFramework && isEditing} initialValue={initialValues.description} />
       <ControlEvidenceTable

--- a/apps/console/src/components/pages/protected/controls/control-implementation/control-implementation-card.tsx
+++ b/apps/console/src/components/pages/protected/controls/control-implementation/control-implementation-card.tsx
@@ -105,7 +105,7 @@ export const ControlImplementationCard = ({ obj }: Props) => {
                         <span>{hoveredControl.shortName}</span>
 
                         <span className="font-medium">Details</span>
-                        <div>{convertToReadOnly(hoveredControl.description, 0)}</div>
+                        <div>{convertToReadOnly(hoveredControl.description)}</div>
                       </div>
                     </PopoverContent>
                   )}
@@ -143,7 +143,7 @@ export const ControlImplementationCard = ({ obj }: Props) => {
                           </Link>
 
                           <span className="font-medium">Details</span>
-                          <div>{convertToReadOnly(hoveredSubcontrol.parentDescription, 0)}</div>
+                          <div>{convertToReadOnly(hoveredSubcontrol.parentDescription)}</div>
                         </div>
                       </PopoverContent>
                     )}

--- a/apps/console/src/components/pages/protected/controls/control-objectives/control-objective-card.tsx
+++ b/apps/console/src/components/pages/protected/controls/control-objectives/control-objective-card.tsx
@@ -72,7 +72,7 @@ export const ControlObjectiveCard = ({ obj }: Props) => {
           </div>
         </div>
 
-        <div className="mt-5">{convertToReadOnly(obj.desiredOutcome || '', 0)}</div>
+        <div className="mt-5">{convertToReadOnly(obj.desiredOutcome || '')}</div>
       </div>
 
       <div className="w-px bg-border self-stretch mx-6" />
@@ -109,7 +109,7 @@ export const ControlObjectiveCard = ({ obj }: Props) => {
                           <span>{hoveredControl.shortName}</span>
 
                           <span className="font-medium">Details</span>
-                          <div>{convertToReadOnly(hoveredControl.description, 0)}</div>
+                          <div>{convertToReadOnly(hoveredControl.description)}</div>
                         </div>
                       </PopoverContent>
                     )}
@@ -149,7 +149,7 @@ export const ControlObjectiveCard = ({ obj }: Props) => {
                           </Link>
 
                           <span className="font-medium">Details</span>
-                          <div>{convertToReadOnly(hoveredSubcontrol.parentDescription, 0)}</div>
+                          <div>{convertToReadOnly(hoveredSubcontrol.parentDescription)}</div>
                         </div>
                       </PopoverContent>
                     )}

--- a/apps/console/src/components/pages/protected/controls/map-controls/shared/control-chip.tsx
+++ b/apps/console/src/components/pages/protected/controls/map-controls/shared/control-chip.tsx
@@ -154,7 +154,7 @@ const ControlTooltipContent: React.FC<{ control: NonNullable<ControlChipProps['c
           <PencilLine size={12} />
           <span className="font-medium">Description</span>
         </div>
-        <div className="line-clamp-4 text-justify">{convertToReadOnly(details.description || '', 0)}</div>
+        <div className="line-clamp-4 text-justify">{convertToReadOnly(details.description || '')}</div>
       </div>
     </div>
   )

--- a/apps/console/src/components/pages/protected/policies/view/fields/details-field.tsx
+++ b/apps/console/src/components/pages/protected/policies/view/fields/details-field.tsx
@@ -26,7 +26,7 @@ const DetailsField: React.FC<TDetailsFieldProps> = ({ isEditing, form, policy })
       />
     </div>
   ) : (
-    <div className="!mt-4 bg-none p-2">{policy?.details && plateEditorHelper.convertToReadOnly(policy.details as string, 0)}</div>
+    <div className="!mt-4 bg-none">{policy?.details && plateEditorHelper.convertToReadOnly(policy.details as string)}</div>
   )
 }
 

--- a/apps/console/src/components/pages/protected/policies/view/view-policy-page.tsx
+++ b/apps/console/src/components/pages/protected/policies/view/view-policy-page.tsx
@@ -255,7 +255,7 @@ const ViewPolicyPage: React.FC<TViewPolicyPage> = ({ policyId }) => {
   )
 
   const mainContent = (
-    <div className="space-y-6 p-6">
+    <div className="p-2">
       <TitleField isEditing={isEditing} form={form} />
       <DetailsField isEditing={isEditing} form={form} policy={policy} />
     </div>

--- a/apps/console/src/components/pages/protected/procedures/view/fields/details-field.tsx
+++ b/apps/console/src/components/pages/protected/procedures/view/fields/details-field.tsx
@@ -26,7 +26,7 @@ const DetailsField: React.FC<TDetailsFieldProps> = ({ isEditing, form, procedure
       />
     </div>
   ) : (
-    <div className="!mt-4 bg-none p-2">{procedure?.details && plateEditorHelper.convertToReadOnly(procedure.details as string, 0)}</div>
+    <div className="!mt-4 bg-none">{procedure?.details && plateEditorHelper.convertToReadOnly(procedure.details as string)}</div>
   )
 }
 

--- a/apps/console/src/components/pages/protected/procedures/view/view-procedure-page.tsx
+++ b/apps/console/src/components/pages/protected/procedures/view/view-procedure-page.tsx
@@ -239,7 +239,7 @@ const ViewProcedurePage: React.FC = () => {
   )
 
   const mainContent = (
-    <div className="space-y-6 p-6">
+    <div className="p-2">
       <TitleField isEditing={isEditing} form={form} />
       <DetailsField isEditing={isEditing} form={form} procedure={procedure} />
     </div>

--- a/apps/console/src/components/pages/protected/risks/view/fields/business-cost-field.tsx
+++ b/apps/console/src/components/pages/protected/risks/view/fields/business-cost-field.tsx
@@ -31,7 +31,7 @@ const BusinessCostField: React.FC<TBusinessCostFieldProps> = ({ isEditing, form,
       <label htmlFor="risk" className="block text-lg font-medium text-muted-foreground mb-1">
         Business Costs
       </label>
-      <div className="!mt-4 bg-none max-h-[55vh] overflow-auto p-2">{risk?.businessCosts && plateEditorHelper.convertToReadOnly(risk.businessCosts as string, 0)}</div>
+      <div className="!mt-4 bg-none max-h-[55vh] overflow-auto">{risk?.businessCosts && plateEditorHelper.convertToReadOnly(risk.businessCosts as string)}</div>
     </Card>
   )
 }

--- a/apps/console/src/components/pages/protected/risks/view/fields/details-field.tsx
+++ b/apps/console/src/components/pages/protected/risks/view/fields/details-field.tsx
@@ -31,7 +31,7 @@ const DetailsField: React.FC<TDetailsFieldProps> = ({ isEditing, form, risk }) =
       <label htmlFor="risk" className="block text-lg font-medium text-muted-foreground mb-1">
         Details
       </label>
-      <div className="!mt-4 bg-none max-h-[55vh] overflow-auto p-2">{risk?.details && plateEditorHelper.convertToReadOnly(risk.details as string, 0)}</div>
+      <div className="!mt-4 bg-none max-h-[55vh] overflow-auto">{risk?.details && plateEditorHelper.convertToReadOnly(risk.details as string)}</div>
     </Card>
   )
 }

--- a/apps/console/src/components/pages/protected/risks/view/fields/mitigation-field.tsx
+++ b/apps/console/src/components/pages/protected/risks/view/fields/mitigation-field.tsx
@@ -31,7 +31,7 @@ const MitigationField: React.FC<TMitigationFieldProps> = ({ isEditing, form, ris
       <label htmlFor="risk" className="block text-lg font-medium text-muted-foreground mb-1">
         Mitigation
       </label>
-      <div className="!mt-4 bg-none max-h-[55vh] overflow-auto p-2">{risk?.mitigation && plateEditorHelper.convertToReadOnly(risk.mitigation as string, 0)}</div>
+      <div className="!mt-4 bg-none max-h-[55vh] overflow-auto">{risk?.mitigation && plateEditorHelper.convertToReadOnly(risk.mitigation as string)}</div>
     </Card>
   )
 }

--- a/apps/console/src/components/pages/protected/risks/view/view-risks-page.tsx
+++ b/apps/console/src/components/pages/protected/risks/view/view-risks-page.tsx
@@ -221,7 +221,7 @@ const ViewRisksPage: React.FC<TRisksPageProps> = ({ riskId }) => {
   )
 
   const mainContent = (
-    <div className="space-y-6 p-6">
+    <div className="space-y-6 p-2">
       <TitleField isEditing={isEditing} form={form} />
       <DetailsField isEditing={isEditing} form={form} risk={risk} />
       <BusinessCostField isEditing={isEditing} form={form} risk={risk} />

--- a/apps/console/src/components/pages/protected/standards/control-details-sheet.tsx
+++ b/apps/console/src/components/pages/protected/standards/control-details-sheet.tsx
@@ -76,13 +76,13 @@ const ControlDetailsSheet = () => {
           ?.map((e) =>
             e?.node
               ? {
-                  type: 'Control',
-                  id: e.node.id,
-                  refCode: e.node.refCode,
-                  referenceFramework: e.node.referenceFramework,
-                  mappingType: node.mappingType,
-                  relation: node.relation,
-                }
+                type: 'Control',
+                id: e.node.id,
+                refCode: e.node.refCode,
+                referenceFramework: e.node.referenceFramework,
+                mappingType: node.mappingType,
+                relation: node.relation,
+              }
               : null,
           )
           .filter(Boolean) as typeof oppositeNodes),
@@ -90,14 +90,14 @@ const ControlDetailsSheet = () => {
           ?.map((e) =>
             e?.node
               ? {
-                  type: 'Subcontrol',
-                  id: e.node.id,
-                  refCode: e.node.refCode,
-                  referenceFramework: e.node.referenceFramework,
-                  controlId: e.node.control.id,
-                  mappingType: node.mappingType,
-                  relation: node.relation,
-                }
+                type: 'Subcontrol',
+                id: e.node.id,
+                refCode: e.node.refCode,
+                referenceFramework: e.node.referenceFramework,
+                controlId: e.node.control.id,
+                mappingType: node.mappingType,
+                relation: node.relation,
+              }
               : null,
           )
           .filter(Boolean) as typeof oppositeNodes),
@@ -108,13 +108,13 @@ const ControlDetailsSheet = () => {
           ?.map((e) =>
             e?.node
               ? {
-                  type: 'Control',
-                  id: e.node.id,
-                  refCode: e.node.refCode,
-                  referenceFramework: e.node.referenceFramework,
-                  mappingType: node.mappingType,
-                  relation: node.relation,
-                }
+                type: 'Control',
+                id: e.node.id,
+                refCode: e.node.refCode,
+                referenceFramework: e.node.referenceFramework,
+                mappingType: node.mappingType,
+                relation: node.relation,
+              }
               : null,
           )
           .filter(Boolean) as typeof oppositeNodes),
@@ -122,14 +122,14 @@ const ControlDetailsSheet = () => {
           ?.map((e) =>
             e?.node
               ? {
-                  type: 'Subcontrol',
-                  id: e.node.id,
-                  refCode: e.node.refCode,
-                  referenceFramework: e.node.referenceFramework,
-                  controlId: e.node.control.id,
-                  mappingType: node.mappingType,
-                  relation: node.relation,
-                }
+                type: 'Subcontrol',
+                id: e.node.id,
+                refCode: e.node.refCode,
+                referenceFramework: e.node.referenceFramework,
+                controlId: e.node.control.id,
+                mappingType: node.mappingType,
+                relation: node.relation,
+              }
               : null,
           )
           .filter(Boolean) as typeof oppositeNodes),
@@ -164,7 +164,7 @@ const ControlDetailsSheet = () => {
       >
         <SheetTitle className="text-2xl text-start">{data?.control.refCode}</SheetTitle>
         <div className="flex flex-col gap-8">
-          {data?.control.description && <div className="mt-5">{plateEditorHelper.convertToReadOnly(data?.control.description as string, 0)}</div>}
+          {data?.control.description && <div className="mt-5">{plateEditorHelper.convertToReadOnly(data?.control.description as string)}</div>}
           <div className="flex flex-col gap-2.5">
             <p className="mb-1.5 text-xl">Properties</p>
             <Property label="Framework" value="SOC 2" />

--- a/apps/console/src/components/pages/protected/tasks/create-task/sidebar/task-details-sheet.tsx
+++ b/apps/console/src/components/pages/protected/tasks/create-task/sidebar/task-details-sheet.tsx
@@ -67,8 +67,8 @@ const TaskDetailsSheet = () => {
   const { form } = useFormSchema()
   const where: UserWhereInput | undefined = taskData?.comments
     ? {
-        idIn: taskData.comments.edges?.map((item) => item?.node?.createdBy).filter((id): id is string => typeof id === 'string'),
-      }
+      idIn: taskData.comments.edges?.map((item) => item?.node?.createdBy).filter((id): id is string => typeof id === 'string'),
+    }
     : undefined
   const { data: userData } = useGetUsers(where)
 
@@ -474,7 +474,7 @@ const TaskDetailsSheet = () => {
                     )}
                   />
                 ) : (
-                  <>{!!taskData?.details && <div>{plateEditorHelper.convertToReadOnly(taskData.details, 0, { paddingTop: 16, paddingRight: 16, paddingBottom: 16, paddingLeft: 0 })}</div>}</>
+                  <>{!!taskData?.details && <div>{plateEditorHelper.convertToReadOnly(taskData.details, 0, { paddingTop: 16, paddingRight: 0, paddingBottom: 16, paddingLeft: 0 })}</div>}</>
                 )}
               </form>
             </Form>
@@ -508,7 +508,7 @@ const TaskDetailsSheet = () => {
             )}
 
             <div>
-              <div className="flex flex-col gap-4 mt-5">
+              <div className="flex flex-col gap-4">
                 <div className="flex items-center gap-4">
                   <CircleUser height={16} width={16} className="text-accent-secondary" />
                   <p className="text-sm w-[120px]">Assigner</p>

--- a/apps/console/src/components/pages/protected/tasks/create-task/sidebar/task-details-sheet.tsx
+++ b/apps/console/src/components/pages/protected/tasks/create-task/sidebar/task-details-sheet.tsx
@@ -480,7 +480,7 @@ const TaskDetailsSheet = () => {
             </Form>
 
             {!isEditing && (
-              <div className="flex gap-4">
+              <div className="flex gap-4 pb-4 pt-2">
                 {taskData && (
                   <EvidenceCreateFormDialog
                     formData={{

--- a/apps/console/src/components/pages/protected/tasks/table/columns.tsx
+++ b/apps/console/src/components/pages/protected/tasks/table/columns.tsx
@@ -69,7 +69,7 @@ export const getTaskColumns = ({ userMap, convertToReadOnly }: ColumnOptions): C
   {
     accessorKey: 'details',
     header: 'Details',
-    cell: ({ cell }) => convertToReadOnly?.(cell.getValue() as string, 0) || '',
+    cell: ({ cell }) => convertToReadOnly?.(cell.getValue() as string) || '',
     size: 200,
   },
   {

--- a/apps/console/src/components/shared/objectAssociation/object-association-chip.tsx
+++ b/apps/console/src/components/shared/objectAssociation/object-association-chip.tsx
@@ -59,7 +59,7 @@ const ObjectAssociationChip: React.FC<ObjectChipProps> = ({ object, className = 
                 <PencilLine size={12} />
                 <span className="font-medium">Description</span>
               </div>
-              <div className="line-clamp-4 text-justify">{displayDescription ? convertToReadOnly(displayDescription, 0) : 'No description available'}</div>
+              <div className="line-clamp-4 text-justify">{displayDescription ? convertToReadOnly(displayDescription) : 'No description available'}</div>
             </div>
           </div>
         </TooltipContent>

--- a/apps/console/src/components/shared/objectAssociation/object-association-table.tsx
+++ b/apps/console/src/components/shared/objectAssociation/object-association-table.tsx
@@ -77,7 +77,7 @@ const ObjectAssociationTable = ({ data, onIDsChange, initialData, refCodeInitial
       header: 'Description',
       cell: ({ row }) => {
         const { description, details } = row.original
-        return <span className="line-clamp-2 overflow-hidden">{convertToReadOnly(description || details || '', 0)}</span>
+        return <span className="line-clamp-2 overflow-hidden">{convertToReadOnly(description || details || '')}</span>
       },
     },
   ]

--- a/apps/console/src/components/shared/plate/usePlateEditor.tsx
+++ b/apps/console/src/components/shared/plate/usePlateEditor.tsx
@@ -23,7 +23,7 @@ const usePlateEditor = () => {
       })
     },
     // Converts html data into deserializable PlateJs value, and rendering read only static view
-    convertToReadOnly: (data: string, padding: number = 16, style?: React.CSSProperties) => {
+    convertToReadOnly: (data: string, padding: number = 0, style?: React.CSSProperties) => {
       const editor = createSlateEditor({
         plugins: [...BaseEditorKit],
       })


### PR DESCRIPTION
- Eliminates extra padding around policy + procedure views
- Changes default padding on readOnly editor to 0 (which most places were already setting, and ones that weren't I was going to change

Before:
<img width="1443" height="577" alt="image" src="https://github.com/user-attachments/assets/08b852f3-9ac8-4e97-84ee-353ab088316f" />

After:
<img width="1309" height="659" alt="image" src="https://github.com/user-attachments/assets/294b7246-3336-478b-839a-130478372976" />
