### PR TITLE
fixing permission being called with no id

### DIFF
--- a/apps/console/src/components/pages/protected/tasks/create-task/sidebar/task-details-sheet.tsx
+++ b/apps/console/src/components/pages/protected/tasks/create-task/sidebar/task-details-sheet.tsx
@@ -43,7 +43,7 @@ const TaskDetailsSheet = () => {
   const { data: session } = useSession()
   const searchParams = useSearchParams()
   const id = searchParams.get('id')
-  const { data: permission } = useAccountRole(session, ObjectEnum.TASK, id! as string)
+  const { data: permission } = useAccountRole(session, ObjectEnum.TASK, id)
   const isEditAllowed = canEdit(permission?.roles)
   const { data, isLoading: fetching } = useTask(id as string)
   const taskData = data?.task


### PR DESCRIPTION
this fixes permission calls that are inside sheet or modal (prerendered)