### PR TITLE
bug: associate objects correct to task evidence

### DIFF
--- a/apps/console/src/components/pages/protected/controls/control-evidence/control-evidence-renew-dialog.tsx
+++ b/apps/console/src/components/pages/protected/controls/control-evidence/control-evidence-renew-dialog.tsx
@@ -37,7 +37,6 @@ const ControlEvidenceRenewDialog: React.FC<TControlEvidenceRenewDialog> = ({ evi
         name: evidence.name,
         description: evidence.description ?? '',
         tags: evidence.tags ?? [],
-        ownerID: evidence.ownerID,
         collectionProcedure: evidence.collectionProcedure ?? '',
         source: evidence.source ?? '',
         ...(evidence.url ? { url: evidence.url } : {}),

--- a/apps/console/src/components/pages/protected/developers/personal-access-token-create-dialog.tsx
+++ b/apps/console/src/components/pages/protected/developers/personal-access-token-create-dialog.tsx
@@ -8,7 +8,6 @@ import { Button } from '@repo/ui/button'
 import { Checkbox } from '@repo/ui/checkbox'
 import { AlertTriangleIcon, CirclePlusIcon, CopyIcon } from 'lucide-react'
 import { useNotification } from '@/hooks/useNotification'
-import { useSession } from 'next-auth/react'
 import { useOrganization } from '@/hooks/useOrganization'
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@repo/ui/form'
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from '@repo/ui/dropdown-menu'
@@ -33,7 +32,6 @@ enum STEP {
 const PersonalApiKeyDialog = ({ triggerText }: PersonalApiKeyDialogProps) => {
   const path = usePathname()
   const isOrg = path.includes('/organization-settings')
-  const { data: sessionData } = useSession()
   const { allOrgs: orgs } = useOrganization()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { mutateAsync: createPersonalAccessToken } = useCreatePersonalAccessToken()
@@ -101,7 +99,6 @@ const PersonalApiKeyDialog = ({ triggerText }: PersonalApiKeyDialogProps) => {
           description: values.description,
           expiresAt: values.noExpire ? null : values.expiryDate,
           scopes: values.scopes,
-          ownerID: sessionData?.user.userId,
         }
 
         const response = await createApiToken({

--- a/apps/console/src/components/pages/protected/evidence/evidence-create-form.tsx
+++ b/apps/console/src/components/pages/protected/evidence/evidence-create-form.tsx
@@ -12,7 +12,6 @@ import { Button } from '@repo/ui/button'
 import { CalendarPopover } from '@repo/ui/calendar-popover'
 
 import { CreateEvidenceInput } from '@repo/codegen/src/schema'
-import { useSession } from 'next-auth/react'
 import EvidenceUploadForm from '@/components/pages/protected/evidence/upload/evidence-upload-form'
 import { useNotification } from '@/hooks/useNotification'
 import { Option } from '@repo/ui/multiple-selector'
@@ -42,7 +41,6 @@ const EvidenceCreateForm: React.FC<TProps> = ({ formData, onEvidenceCreateSucces
   const [tagValues, setTagValues] = useState<Option[]>([])
   const [resetEvidenceFiles, setResetEvidenceFiles] = useState(false)
   const [evidenceObjectTypes, setEvidenceObjectTypes] = useState<TObjectAssociationMap>()
-  const { data: sessionData } = useSession()
   const { mutateAsync: createEvidence, isPending } = useCreateEvidence()
   const [associationResetTrigger, setAssociationResetTrigger] = useState(0)
   const { setCrumbs } = useContext(BreadcrumbContext)
@@ -58,10 +56,12 @@ const EvidenceCreateForm: React.FC<TProps> = ({ formData, onEvidenceCreateSucces
         tags: data.tags,
         creationDate: data.creationDate,
         renewalDate: data.renewalDate,
-        ownerID: sessionData?.user.userId,
         collectionProcedure: data.collectionProcedure,
         source: data.source,
         fileIDs: data.fileIDs,
+        controlIDs: data.controlIDs,
+        taskIDs: data.taskIDs,
+        subcontrolIDs: data.subcontrolIDs,
         ...(programId ? { programIDs: [programId] } : {}),
         ...(data.url ? { url: data.url } : {}),
         ...evidenceObjectTypes,

--- a/apps/console/src/components/pages/protected/evidence/hooks/use-form-schema.ts
+++ b/apps/console/src/components/pages/protected/evidence/hooks/use-form-schema.ts
@@ -28,7 +28,6 @@ const formSchema = z.object({
   internalPolicyIDs: z.array(z.any()).optional().nullable(),
   procedureIDs: z.array(z.any()).optional().nullable(),
   riskIDs: z.array(z.any()).optional().nullable(),
-  ownerID: z.string().optional().nullable(),
   status: z
     .nativeEnum(EvidenceEvidenceStatus, {
       errorMap: () => ({ message: 'Invalid status' }),

--- a/apps/console/src/components/pages/protected/standards/add-to-organization-dialog.tsx
+++ b/apps/console/src/components/pages/protected/standards/add-to-organization-dialog.tsx
@@ -8,7 +8,6 @@ import { useCloneControls } from '@/lib/graphql-hooks/standards'
 import { useNotification } from '@/hooks/useNotification'
 import { useQueryClient } from '@tanstack/react-query'
 import { useGetAllPrograms } from '@/lib/graphql-hooks/programs'
-import { useOrganization } from '@/hooks/useOrganization'
 import { parseErrorMessage } from '@/utils/graphQlErrorMatcher'
 
 type SelectedControl = { id: string; refCode: string }
@@ -23,7 +22,6 @@ type AddToOrganizationDialogProps = {
 
 const AddToOrganizationDialog: React.FC<AddToOrganizationDialogProps> = ({ open, onOpenChange, selectedControls, standardId, standardName }) => {
   const [selectedProgram, setSelectedProgram] = useState<string | undefined>(undefined)
-  const { currentOrgId } = useOrganization()
   const { data: programsData } = useGetAllPrograms()
   const { mutateAsync: cloneControls, isPending } = useCloneControls()
   const { successNotification, errorNotification } = useNotification()
@@ -37,7 +35,6 @@ const AddToOrganizationDialog: React.FC<AddToOrganizationDialogProps> = ({ open,
     try {
       await cloneControls({
         input: {
-          ownerID: currentOrgId,
           programID: selectedProgram,
           ...(standardId ? { standardID: standardId } : { controlIDs }),
         },

--- a/apps/console/src/components/pages/protected/tasks/create-task/utils.ts
+++ b/apps/console/src/components/pages/protected/tasks/create-task/utils.ts
@@ -53,12 +53,13 @@ export const generateEvidenceFormData = (taskData: TaskQuery['task'] | undefined
     displayID: taskData!.displayID,
     tags: taskData!.tags ?? undefined,
     objectAssociations: {
-      controlObjectiveIDs: taskData?.controlObjectives?.edges?.map((item) => item?.node?.id).filter((id): id is string => !!id) || [],
+      controlIDs: taskData?.controls?.edges?.map((item) => item?.node?.id).filter((id): id is string => !!id) || [],
       subcontrolIDs: taskData?.subcontrols?.edges?.map((item) => item?.node?.id).filter((id): id is string => !!id) || [],
       programIDs: taskData?.programs?.edges?.map((item) => item?.node?.id).filter((id): id is string => !!id) || [],
+      taskIDs: taskData.id ? [taskData.id] : [],
     },
     objectAssociationsDisplayIDs: [
-      ...(taskData?.controlObjectives?.edges?.map((item) => item?.node?.displayID).filter((id): id is string => !!id) || []),
+      ...(taskData?.controls?.edges?.map((item) => item?.node?.refCode).filter((id): id is string => !!id) || []),
       ...(taskData?.subcontrols?.edges?.map((item) => item?.node?.refCode).filter((id): id is string => !!id) || []),
       ...(taskData?.programs?.edges?.map((item) => item?.node?.displayID).filter((id): id is string => !!id) || []),
       taskData.displayID,

--- a/packages/codegen/query/evidence.ts
+++ b/packages/codegen/query/evidence.ts
@@ -60,7 +60,6 @@ const EVIDENCE_FIELDS = gql`
     displayID
     id
     name
-    ownerID
     renewalDate
     source
     status
@@ -126,7 +125,6 @@ export const GET_RENEW_EVIDENCE = gql`
       displayID
       id
       name
-      ownerID
       renewalDate
       source
       status

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -41939,7 +41939,6 @@ export type EvidenceFieldsFragment = {
   displayID: string
   id: string
   name: string
-  ownerID?: string | null
   renewalDate?: any | null
   source?: string | null
   status?: EvidenceEvidenceStatus | null
@@ -41970,7 +41969,6 @@ export type GetEvidenceQuery = {
     displayID: string
     id: string
     name: string
-    ownerID?: string | null
     renewalDate?: any | null
     source?: string | null
     status?: EvidenceEvidenceStatus | null
@@ -42005,7 +42003,6 @@ export type GetRenewEvidenceQuery = {
     displayID: string
     id: string
     name: string
-    ownerID?: string | null
     renewalDate?: any | null
     source?: string | null
     status?: EvidenceEvidenceStatus | null


### PR DESCRIPTION
- fixes edges being sent when creating evidence from a task
- removes uncessary input of `ownerID` from objects; these are automatically set based on the user's JWT and should not be needed on creation. 