### PR TITLE
fixing editing updates field when changed

### DIFF
--- a/apps/console/src/components/pages/protected/tasks/create-task/sidebar/task-details-sheet.tsx
+++ b/apps/console/src/components/pages/protected/tasks/create-task/sidebar/task-details-sheet.tsx
@@ -124,7 +124,7 @@ const TaskDetailsSheet = () => {
   }
 
   const handleUpdateField = async (input: UpdateTaskInput) => {
-    if (!id) {
+    if (!id || isEditing) {
       return
     }
     try {


### PR DESCRIPTION
problem: when we were in edit mode, changing form values would trigger gql  request instead of on save