### PR TITLE
feat: nav for personal org + onboarding

### DIFF
--- a/apps/console/src/components/shared/header/header.tsx
+++ b/apps/console/src/components/shared/header/header.tsx
@@ -34,9 +34,7 @@ export default function Header() {
     return (
       <div className={header()}>
         <nav className={nav()}>
-          <div className="flex justify-start items-center">
-            <OrganizationSelector />
-          </div>
+          <div className="flex justify-start items-center"></div>
           <div className={userNav()}>
             <UserMenu />
           </div>

--- a/apps/console/src/components/shared/organization-selector/organization-selector.tsx
+++ b/apps/console/src/components/shared/organization-selector/organization-selector.tsx
@@ -96,10 +96,6 @@ export const OrganizationSelector = () => {
   }
   if (!orgs) return <Loading />
 
-  if (orgs.length < 2) {
-    return null
-  }
-
   return (
     <div className={container()}>
       <div>

--- a/apps/console/src/components/shared/sidebar/sidebar.tsx
+++ b/apps/console/src/components/shared/sidebar/sidebar.tsx
@@ -5,8 +5,8 @@ import { cn } from '@repo/ui/lib/utils'
 import { sidebarStyles } from './sidebar.styles'
 import { SideNav } from './sidebar-nav/sidebar-nav'
 import { generateNavItems, PersonalNavItems } from '@/routes/dashboard'
-import { useSession } from 'next-auth/react'
 import { useOrganization } from '@/hooks/useOrganization'
+import { usePathname } from 'next/navigation'
 // import { useOrganizationRole } from '@/lib/authz/access-api'
 // import { canEdit } from '@/lib/authz/utils'
 
@@ -15,12 +15,9 @@ interface SidebarProps {
 }
 
 export default function Sidebar({ className }: SidebarProps) {
-  const { data: session } = useSession()
   const { isOpen } = useSidebar()
   const { currentOrgId, allOrgs } = useOrganization()
-
-  // const { data: orgPermission } = useOrganizationRole(session)
-  // const editAllowed = canEdit(orgPermission?.roles)
+  const path = usePathname()
 
   const activeOrg = allOrgs.filter((org) => org?.node?.id === currentOrgId).map((org) => org?.node)[0]
 
@@ -30,12 +27,11 @@ export default function Sidebar({ className }: SidebarProps) {
     isOpen,
   })
 
-  if (session?.user?.isOnboarding) {
+  if (path === '/onboarding') {
     return null
   }
 
   const navItems = generateNavItems()
-  // editAllowed
 
   return (
     <div className={cn(nav(), className)}>

--- a/apps/console/src/middleware.ts
+++ b/apps/console/src/middleware.ts
@@ -8,8 +8,11 @@ export default auth(async (req) => {
   //IF YOU ADD PUBLIC PAGE, ITS REQUIRED TO CHANGE IT IN Providers.tsx
   const publicPages = ['/login', '/tfa', '/invite', '/subscriber-verify', '/verify', '/resend-verify', '/waitlist', '/unsubscribe', '/forgot-password', '/password-reset', '/signup']
 
+  const personalOrgPages = ['/onboarding', '/organization', '/user-settings/profile']
+
   const path = req.nextUrl.pathname
   const isPublicPage = publicPages.includes(path)
+  const validForPersonalOrg = personalOrgPages.includes(path)
   const isInvite = path === '/invite'
   const isUnsubscribe = path === '/unsubscribe'
   const isWaitlist = path === '/waitlist'
@@ -37,7 +40,7 @@ export default auth(async (req) => {
   }
 
   if (isOnboarding) {
-    return path !== '/' ? NextResponse.next() : NextResponse.redirect(new URL('/onboarding', req.url))
+    return path !== '/' && validForPersonalOrg ? NextResponse.next() : NextResponse.redirect(new URL('/onboarding', req.url))
   }
 
   return NextResponse.next()

--- a/apps/console/src/route-list.json
+++ b/apps/console/src/route-list.json
@@ -198,5 +198,9 @@
   {
     "route": "/organization-settings/integrations",
     "name": "Integrations"
+  },
+  {
+    "route": "/trust-center/settings",
+    "name": "Settings"
   }
 ]

--- a/apps/console/src/routes/dashboard.tsx
+++ b/apps/console/src/routes/dashboard.tsx
@@ -115,6 +115,7 @@ export const generateNavItems = () // canEdit?: boolean
       {
         title: 'Authentication',
         href: '/organization-settings/authentication',
+        hidden: true, // the only thing here is domain restricted which currently has a bug
       },
       {
         title: 'Members',
@@ -176,6 +177,7 @@ export const generateNavItems = () // canEdit?: boolean
     children: [
       {
         title: 'Settings',
+        hidden: true,
         href: '/trust-center/settings',
       },
     ],


### PR DESCRIPTION
- esnures nav exists on personal orgs if you go away from onboarding
- restricts personal orgs from accessing anything outside of org creation and profile settings
- shows org selector on personal org if not on `/onboarding`
- hides authentication page for now; need to fix a bug that locks you out when setting this