### PR TITLE
login updates: privacy policy + TOS

### DIFF
--- a/apps/console/src/components/pages/auth/login/login.tsx
+++ b/apps/console/src/components/pages/auth/login/login.tsx
@@ -437,17 +437,15 @@ export const LoginPage = () => {
           </div>
         </SimpleForm>
         <div className="flex gap-6 mt-9">
+          By signing in, you agree to our
+          <Link href={`${OPENLANE_WEBSITE_URL}/legal/terms-of-service`} className="text-xs opacity-90">
+            Terms of Service
+          </Link>{' '}
+          and
           <Link href={`${OPENLANE_WEBSITE_URL}/legal/privacy`} className="text-xs opacity-90">
             Privacy Policy
           </Link>
-          <Link href={`${OPENLANE_WEBSITE_URL}/legal/terms-of-service`} className="text-xs opacity-90">
-            Terms of Service
-          </Link>
         </div>
-        <p className="text-xs mt-5">
-          This site is protected by reCAPTCHA and the <br />
-          Google Privacy Policy and Terms of Service apply.
-        </p>
         {showLoginError && <MessageBox className={'p-4 ml-1'} message={signInErrorMessage} />}
       </div>
     </>

--- a/apps/console/src/components/pages/auth/login/login.tsx
+++ b/apps/console/src/components/pages/auth/login/login.tsx
@@ -436,16 +436,18 @@ export const LoginPage = () => {
             </Link>
           </div>
         </SimpleForm>
-        <div className="flex gap-6 mt-9">
+
+        <div className="text-xs opacity-90 flex gap-1 mt-9">
           By signing in, you agree to our
-          <Link href={`${OPENLANE_WEBSITE_URL}/legal/terms-of-service`} className="text-xs opacity-90">
+          <Link href={`${OPENLANE_WEBSITE_URL}/legal/terms-of-service`} className="text-xs opacity-90 hover:opacity-80 transition hover:underline">
             Terms of Service
           </Link>{' '}
           and
-          <Link href={`${OPENLANE_WEBSITE_URL}/legal/privacy`} className="text-xs opacity-90">
+          <Link href={`${OPENLANE_WEBSITE_URL}/legal/privacy`} className="text-xs opacity-90 hover:opacity-80 transition hover:underline">
             Privacy Policy
           </Link>
         </div>
+
         {showLoginError && <MessageBox className={'p-4 ml-1'} message={signInErrorMessage} />}
       </div>
     </>

--- a/apps/console/src/components/pages/auth/login/login.tsx
+++ b/apps/console/src/components/pages/auth/login/login.tsx
@@ -333,16 +333,32 @@ export const LoginPage = () => {
         <p className="text-base mt-8">Connect to Openlane with</p>
 
         <div className={buttons()}>
-          <Button className="bg-secondary !px-3.5" variant="outlineLight" size="md" icon={<GoogleIcon />} iconPosition="left" onClick={() => google()} disabled={signInLoading}>
+          <Button
+            className="bg-secondary !px-3.5 hover:opacity-60 transition"
+            variant="outlineLight"
+            size="md"
+            icon={<GoogleIcon />}
+            iconPosition="left"
+            onClick={() => google()}
+            disabled={signInLoading}
+          >
             <p className="text-sm font-normal">Google</p>
           </Button>
 
-          <Button className="bg-secondary !px-3.5" variant="outlineLight" size="md" icon={<Github className="text-input-text" />} iconPosition="left" onClick={() => github()} disabled={signInLoading}>
+          <Button
+            className="bg-secondary !px-3.5 hover:opacity-60 transition"
+            variant="outlineLight"
+            size="md"
+            icon={<Github className="text-input-text" />}
+            iconPosition="left"
+            onClick={() => github()}
+            disabled={signInLoading}
+          >
             <p className="text-sm font-normal">GitHub</p>
           </Button>
 
           <Button
-            className="bg-secondary !px-3.5"
+            className="bg-secondary !px-3.5 hover:opacity-60 transition"
             variant="outlineLight"
             icon={<KeyRoundIcon className="text-input-text" />}
             iconPosition="left"
@@ -411,13 +427,13 @@ export const LoginPage = () => {
                     <div className={input()}>
                       <PasswordInput variant="light" name="password" placeholder="password" autoComplete="current-password" className="bg-transparent !text-text" />
                     </div>
-                    <Link href="/forgot-password" className="text-base text-xs text-blue-500 mt-1 mb-1 text-right hover:opacity-80 transition">
-                      Forgot password?
-                    </Link>
                     <button className="p-4 btn-secondary justify-between items-center rounded-md text-sm h-10 font-bold flex mt-2" type="submit" disabled={signInLoading}>
                       <span>Login</span>
                       <ArrowRightCircle size={16} />
                     </button>
+                    <Link href="/forgot-password" className="text-base text-xs underline hover:text-blue-500 mt-1 mb-1 text-right hover:opacity-80 transition">
+                      Forgot password?
+                    </Link>
                   </>
                 }
 
@@ -429,21 +445,23 @@ export const LoginPage = () => {
               </div>
             </>
           )}
-          <div className="flex text-base">
-            <span>New to Openlane? &nbsp;</span>
-            <Link href={`/signup${token ? `?token=${token}` : ''}`} className="text-base text-blue-500 hover:opacity-80 transition">
-              Sign up for an account
-            </Link>
-          </div>
+          {!shouldShowSSOButton() && !shouldShowPasswordField() && (
+            <div className="flex text-base mt-4">
+              <span>New to Openlane? &nbsp;</span>
+              <Link href={`/signup${token ? `?token=${token}` : ''}`} className="text-base underline hover:text-blue-500 hover:opacity-80 transition">
+                Sign up for an account
+              </Link>
+            </div>
+          )}
         </SimpleForm>
 
         <div className="text-xs opacity-90 flex gap-1 mt-9">
           By signing in, you agree to our
-          <Link href={`${OPENLANE_WEBSITE_URL}/legal/terms-of-service`} className="text-xs opacity-90 hover:opacity-80 transition hover:underline">
+          <Link href={`${OPENLANE_WEBSITE_URL}/legal/terms-of-service`} className="text-xs underline hover:text-blue-500 hover:opacity-80 transition">
             Terms of Service
           </Link>{' '}
           and
-          <Link href={`${OPENLANE_WEBSITE_URL}/legal/privacy`} className="text-xs opacity-90 hover:opacity-80 transition hover:underline">
+          <Link href={`${OPENLANE_WEBSITE_URL}/legal/privacy`} className="text-xs underline hover:text-blue-500 hover:opacity-80 transition">
             Privacy Policy
           </Link>
         </div>

--- a/apps/console/src/components/pages/auth/signup/signup.tsx
+++ b/apps/console/src/components/pages/auth/signup/signup.tsx
@@ -179,11 +179,6 @@ export const SignupPage = () => {
         </Link>
       </div>
 
-      <p className="text-xs mt-5">
-        This site is protected by reCAPTCHA and the <br />
-        Google Privacy Policy and Terms of Service apply.
-      </p>
-
       {showError && <MessageBox maxWidth={320} className="p-4 ml-1" message={registrationErrorMessage} />}
     </div>
   )

--- a/apps/console/src/components/pages/auth/signup/signup.tsx
+++ b/apps/console/src/components/pages/auth/signup/signup.tsx
@@ -18,8 +18,6 @@ import Github from '@/assets/Github'
 import { loginStyles } from '../login/login.styles'
 import { OPENLANE_WEBSITE_URL } from '@/constants'
 
-// const TEMP_PASSKEY_EMAIL = 'tempuser1@test.com'
-
 export const SignupPage = () => {
   const searchParams = useSearchParams()
   const token = searchParams?.get('token')
@@ -168,13 +166,13 @@ export const SignupPage = () => {
         </div>
       </SimpleForm>
 
-      <div className="flex gap-6 mt-9">
-        By signing in, you agree to our
-        <Link href={`${OPENLANE_WEBSITE_URL}/legal/terms-of-service`} className="text-xs opacity-90">
+      <div className="text-xs opacity-90 flex gap-1 mt-9">
+        By signing up, you agree to our
+        <Link href={`${OPENLANE_WEBSITE_URL}/legal/terms-of-service`} className="text-xs opacity-90 hover:opacity-80 transition hover:underline">
           Terms of Service
         </Link>{' '}
         and
-        <Link href={`${OPENLANE_WEBSITE_URL}/legal/privacy`} className="text-xs opacity-90">
+        <Link href={`${OPENLANE_WEBSITE_URL}/legal/privacy`} className="text-xs opacity-90 hover:opacity-80 transition hover:underline">
           Privacy Policy
         </Link>
       </div>

--- a/apps/console/src/components/pages/auth/signup/signup.tsx
+++ b/apps/console/src/components/pages/auth/signup/signup.tsx
@@ -41,39 +41,17 @@ export const SignupPage = () => {
     return allowedLoginDomains.some((domain) => payload.email.endsWith(domain))
   }
 
-  // async function registerPasskey() {
-  //   try {
-  //     const options = await getPasskeyRegOptions({ email: TEMP_PASSKEY_EMAIL })
-  //     setSessionCookie(options.session)
-  //     const attestationResponse = await startRegistration(options.publicKey)
-  //     const verificationResult = await verifyRegistration({ attestationResponse })
-
-  //     if (verificationResult.success) {
-  //       await signIn('passkey', {
-  //         email: TEMP_PASSKEY_EMAIL,
-  //         session: verificationResult.session,
-  //         accessToken: verificationResult.access_token,
-  //         refreshToken: verificationResult.refresh_token,
-  //       })
-  //     } else {
-  //       setRegistrationErrorMessage(`Error: ${verificationResult.error}`)
-  //     }
-  //   } catch (error) {
-  //     setRegistrationErrorMessage(`{${error || ''}}`)
-  //   }
-  // }
-
   return (
     <div className="flex flex-col self-center">
       <p className="text-2xl font-medium">Create your account</p>
       <p className="text-base mt-8">Connect to Openlane with</p>
 
       <div className={buttons()}>
-        <Button className="bg-secondary !px-3.5 w-full" variant="outlineLight" size="md" icon={<GoogleIcon />} iconPosition="left" onClick={google}>
+        <Button className="bg-secondary !px-3.5 w-full hover:opacity-60 transition" variant="outlineLight" size="md" icon={<GoogleIcon />} iconPosition="left" onClick={google}>
           <p className="text-sm font-normal">Google</p>
         </Button>
 
-        <Button className="bg-secondary !px-3.5 w-full" variant="outlineLight" size="md" icon={<Github className="text-input-text" />} iconPosition="left" onClick={github}>
+        <Button className="bg-secondary !px-3.5 w-full hover:opacity-60 transition" variant="outlineLight" size="md" icon={<Github className="text-input-text" />} iconPosition="left" onClick={github}>
           <p className="text-sm font-normal">GitHub</p>
         </Button>
       </div>
@@ -151,28 +129,30 @@ export const SignupPage = () => {
               <PasswordInput variant="light" name="confirmedPassword" placeholder="confirm password" autoComplete="new-password" className="bg-transparent !text-text" />
             </div>
 
-            <button className="p-4 text-button-text bg-brand justify-between items-center rounded-md text-sm h-10 font-bold flex mt-2" type="submit" disabled={isLoading}>
+            <button className="p-4  btn-secondary justify-between items-center rounded-md text-sm h-10 font-bold flex mt-2" type="submit" disabled={isLoading}>
               <span>{isLoading ? 'Creating account...' : 'Sign up'}</span>
               <ArrowRightCircle size={16} />
             </button>
           </>
         )}
 
-        <div className="flex text-base mt-4">
-          <span>Have an account?&nbsp;</span>
-          <Link href="/login" className="text-base text-blue-500 hover:opacity-80 transition">
-            Login to your account
-          </Link>
-        </div>
+        {!isPasswordActive && (
+          <div className="flex text-base mt-4">
+            <span>Have an account?&nbsp;</span>
+            <Link href="/login" className="text-base underline hover:text-blue-500 hover:opacity-80 transition">
+              Login to your account
+            </Link>
+          </div>
+        )}
       </SimpleForm>
 
       <div className="text-xs opacity-90 flex gap-1 mt-9">
         By signing up, you agree to our
-        <Link href={`${OPENLANE_WEBSITE_URL}/legal/terms-of-service`} className="text-xs opacity-90 hover:opacity-80 transition hover:underline">
+        <Link href={`${OPENLANE_WEBSITE_URL}/legal/terms-of-service`} className="text-xs underline hover:text-blue-500 hover:opacity-80 transition">
           Terms of Service
         </Link>{' '}
         and
-        <Link href={`${OPENLANE_WEBSITE_URL}/legal/privacy`} className="text-xs opacity-90 hover:opacity-80 transition hover:underline">
+        <Link href={`${OPENLANE_WEBSITE_URL}/legal/privacy`} className="text-xs underline hover:text-blue-500 hover:opacity-80 transition">
           Privacy Policy
         </Link>
       </div>

--- a/apps/console/src/components/pages/auth/signup/signup.tsx
+++ b/apps/console/src/components/pages/auth/signup/signup.tsx
@@ -169,11 +169,13 @@ export const SignupPage = () => {
       </SimpleForm>
 
       <div className="flex gap-6 mt-9">
-        <Link href={`${OPENLANE_WEBSITE_URL}/legal/privacy`} className="text-xs opacity-90">
-          Privacy Policy
-        </Link>
+        By signing in, you agree to our
         <Link href={`${OPENLANE_WEBSITE_URL}/legal/terms-of-service`} className="text-xs opacity-90">
           Terms of Service
+        </Link>{' '}
+        and
+        <Link href={`${OPENLANE_WEBSITE_URL}/legal/privacy`} className="text-xs opacity-90">
+          Privacy Policy
         </Link>
       </div>
 


### PR DESCRIPTION
- updates text around TOS and privacy policy
- moves forgot password link because I keep accidentally clicking it all the time to type my password when things move after webfinger
- hides the "switch to signin/login" text after the input boxes are there to keep it clean
- uses underline + hover blue for links 

<img width="792" height="579" alt="image" src="https://github.com/user-attachments/assets/3b4cbf00-c5dc-4d2a-81bb-1859814363c6" />
<img width="636" height="613" alt="image" src="https://github.com/user-attachments/assets/c879b50e-5dc7-4ecd-baec-a54f89e75159" />
<img width="594" height="493" alt="image" src="https://github.com/user-attachments/assets/60b39c90-8032-4f4f-94a4-ee71a361ef0a" />
