### PR TITLE
Only show trial expires if in a trial ISS-527

### DIFF
--- a/apps/console/src/components/pages/protected/organization/billing/billing-summary.tsx
+++ b/apps/console/src/components/pages/protected/organization/billing/billing-summary.tsx
@@ -152,7 +152,7 @@ const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart }: Pr
             {/* Expiration */}
             <Badge variant={badge.variant}>{badge.text}</Badge>
           </div>
-          {trialExpiresAt ? (
+          {trialExpiresAt && stripeSubscriptionStatus === 'trialing' ? (
             <div className="flex items-center gap-2">
               <p className="text-sm font-medium text-text-informational">Trial status:</p>
               <p className="text-sm text-text-informational">{formattedExpiresDate}</p>


### PR DESCRIPTION
stripeSubscriptionStatus === 'trialing' we show  Trial status, if not we show Next billing