### PR TITLE
update routes

### DIFF
--- a/apps/console/src/route-list.json
+++ b/apps/console/src/route-list.json
@@ -26,11 +26,13 @@
   },
   {
     "route": "/automation/campaigns",
-    "name": "Campaigns"
+    "name": "Campaigns",
+    "hidden": true
   },
   {
     "route": "/automation/communications",
-    "name": "Communications"
+    "name": "Communications",
+    "hidden": true
   },
   {
     "route": "/automation/exposure",
@@ -43,27 +45,33 @@
   },
   {
     "route": "/automation/workflows",
-    "name": "Workflows"
+    "name": "Workflows",
+    "hidden": true
   },
   {
     "route": "/automation/workflows/editor",
-    "name": "Editor"
+    "name": "Editor",
+    "hidden": true
   },
   {
     "route": "/automation/workflows/inbox",
-    "name": "Inbox"
+    "name": "Inbox",
+    "hidden": true
   },
   {
     "route": "/automation/workflows/instances",
-    "name": "Instances"
+    "name": "Instances",
+    "hidden": true
   },
   {
     "route": "/automation/workflows/templates",
-    "name": "Templates"
+    "name": "Templates",
+    "hidden": true
   },
   {
     "route": "/automation/workflows/wizard",
-    "name": "Wizard"
+    "name": "Wizard",
+    "hidden": true
   },
   {
     "route": "/controls",

--- a/apps/console/src/route-list.json
+++ b/apps/console/src/route-list.json
@@ -25,6 +25,14 @@
     "name": "Template Viewer"
   },
   {
+    "route": "/automation/campaigns",
+    "name": "Campaigns"
+  },
+  {
+    "route": "/automation/communications",
+    "name": "Communications"
+  },
+  {
     "route": "/automation/exposure",
     "name": "Exposure",
     "hidden": true
@@ -32,6 +40,30 @@
   {
     "route": "/automation/tasks",
     "name": "Tasks"
+  },
+  {
+    "route": "/automation/workflows",
+    "name": "Workflows"
+  },
+  {
+    "route": "/automation/workflows/editor",
+    "name": "Editor"
+  },
+  {
+    "route": "/automation/workflows/inbox",
+    "name": "Inbox"
+  },
+  {
+    "route": "/automation/workflows/instances",
+    "name": "Instances"
+  },
+  {
+    "route": "/automation/workflows/templates",
+    "name": "Templates"
+  },
+  {
+    "route": "/automation/workflows/wizard",
+    "name": "Wizard"
   },
   {
     "route": "/controls",
@@ -67,12 +99,32 @@
     "keywords": ["audit", "files"]
   },
   {
+    "route": "/exposure",
+    "name": "Exposure"
+  },
+  {
     "route": "/exposure/findings",
     "name": "Findings"
   },
   {
+    "route": "/exposure/overview",
+    "name": "Overview"
+  },
+  {
     "route": "/exposure/remediations",
     "name": "Remediations"
+  },
+  {
+    "route": "/exposure/reviews",
+    "name": "Reviews"
+  },
+  {
+    "route": "/exposure/risks",
+    "name": "Risks"
+  },
+  {
+    "route": "/exposure/risks/create",
+    "name": "Create Risk"
   },
   {
     "route": "/exposure/scans",
@@ -81,6 +133,10 @@
   {
     "route": "/exposure/vulnerabilities",
     "name": "Vulnerabilities"
+  },
+  {
+    "route": "/notifications",
+    "name": "Notifications"
   },
   {
     "route": "/onboarding",
@@ -142,39 +198,6 @@
     "name": "Procedures"
   },
   {
-    "route": "/workflows",
-    "name": "Workflows",
-    "keywords": ["automation", "approvals", "workflow definitions"]
-  },
-  {
-    "route": "/workflows/templates",
-    "name": "Workflow Templates",
-    "keywords": ["automation", "templates", "workflow presets"]
-  },
-  {
-    "route": "/workflows/inbox",
-    "name": "Workflow Inbox",
-    "keywords": ["approvals", "inbox", "workflow assignments"]
-  },
-  {
-    "route": "/workflows/instances",
-    "name": "Workflow Instances",
-    "keywords": ["automation", "instances", "workflow runs"]
-  },
-  {
-    "route": "/workflows/wizard",
-    "name": "Workflow Wizard",
-    "keywords": ["automation", "wizard", "workflow builder"]
-  },
-  {
-    "route": "/workflows/editor",
-    "name": "Workflow Editor"
-  },
-  {
-    "route": "/workflows/definitions",
-    "name": "Workflow Definition"
-  },
-  {
     "route": "/procedures/create",
     "name": "Create Procedure"
   },
@@ -212,8 +235,20 @@
     "name": "Assets"
   },
   {
+    "route": "/registry/contacts",
+    "name": "Contacts"
+  },
+  {
     "route": "/registry/personnel",
     "name": "Personnel"
+  },
+  {
+    "route": "/registry/platforms",
+    "name": "Platforms"
+  },
+  {
+    "route": "/registry/system-details",
+    "name": "System Details"
   },
   {
     "route": "/registry/vendors",
@@ -222,14 +257,6 @@
   {
     "route": "/registry/vulnerabilities",
     "name": "Vulnerabilities"
-  },
-  {
-    "route": "/exposure/risks",
-    "name": "Risks"
-  },
-  {
-    "route": "/exposure/risks/create",
-    "name": "Create Risk"
   },
   {
     "route": "/standards",
@@ -244,6 +271,10 @@
     "route": "/trust-center/branding",
     "name": "Branding",
     "hidden": true
+  },
+  {
+    "route": "/trust-center/controls",
+    "name": "Controls"
   },
   {
     "route": "/trust-center/customer-logos",


### PR DESCRIPTION
✅ Route list synced.
   Added (16):
     + /automation/campaigns
     + /automation/communications
     + /automation/workflows
     + /automation/workflows/editor
     + /automation/workflows/inbox
     + /automation/workflows/instances
     + /automation/workflows/templates
     + /automation/workflows/wizard
     + /exposure
     + /exposure/overview
     + /exposure/reviews
     + /notifications
     + /registry/contacts
     + /registry/platforms
     + /registry/system-details
     + /trust-center/controls
   Removed (7):
     - /workflows
     - /workflows/templates
     - /workflows/inbox
     - /workflows/instances
     - /workflows/wizard
     - /workflows/editor
     - /workflows/definitions
   Total: 79