### PR TITLE
feat: allow updating of existing creds + settings based 

### DIFF
--- a/apps/console/src/app/api/integrations/config/route.ts
+++ b/apps/console/src/app/api/integrations/config/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: NextRequest) {
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
-        installationId: payload.installationId,
+        integrationId: payload.installationId,
         credentialRef: payload.credentialRef,
         body: payload.body ?? {},
         userInput: payload.userInput ?? {},

--- a/apps/console/src/components/pages/protected/organization-settings/integrations/installed-integration-card.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/integrations/installed-integration-card.tsx
@@ -8,7 +8,7 @@ import { Card } from '@repo/ui/cardpanel'
 import { Separator } from '@repo/ui/separator'
 import { ConfirmationDialog } from '@repo/ui/confirmation-dialog'
 import { type IntegrationMetadata, type IntegrationNode, type IntegrationProvider } from '@/lib/integrations/types'
-import { getInstalledIntegrationConfig, installedIntegrationDisplayName, providerSupportsHealth, resolveConnectionEntry, resolveCredentialEntry } from '@/lib/integrations/utils'
+import { getInstalledIntegrationConfig, installedIntegrationDisplayName, providerSupportsHealth, resolveConnectionEntry, resolveCredentialEntry, resolveManageUrl } from '@/lib/integrations/utils'
 import { providerHasUserInputSchema } from '@/lib/integrations/flow'
 import { useDisconnectIntegration, useIntegrationHealth } from '@/lib/query-hooks/integrations'
 import { useGetOrgUserList } from '@/lib/graphql-hooks/member'
@@ -42,12 +42,7 @@ const InstalledIntegrationCard = ({ integration, providers }: InstalledIntegrati
   const lastHealthCheck = meta?.lastSuccessfulHealthCheck ?? ''
   const credentialEntry = resolveCredentialEntry(provider, credentialRefName)
   const connectionEntry = resolveConnectionEntry(provider, credentialRefName || undefined)
-  const manageUrl =
-    connectionEntry?.auth != null && externalId
-      ? externalName
-        ? `https://github.com/organizations/${externalName}/settings/installations/${externalId}`
-        : `https://github.com/settings/installations/${externalId}`
-      : null
+  const manageUrl = resolveManageUrl(provider, connectionEntry, externalId, externalName)
 
   const disconnectMutation = useDisconnectIntegration()
   const healthQuery = useIntegrationHealth(integration.id, supportsHealth)

--- a/apps/console/src/components/pages/protected/organization-settings/integrations/installed-integration-card.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/integrations/installed-integration-card.tsx
@@ -1,14 +1,14 @@
 'use client'
 
 import React, { useState } from 'react'
-import { Activity, Settings, UserIcon } from 'lucide-react'
+import { Activity, ExternalLink, Settings, UserIcon } from 'lucide-react'
 import { Button } from '@repo/ui/button'
 import { Badge } from '@repo/ui/badge'
 import { Card } from '@repo/ui/cardpanel'
 import { Separator } from '@repo/ui/separator'
 import { ConfirmationDialog } from '@repo/ui/confirmation-dialog'
 import { type IntegrationMetadata, type IntegrationNode, type IntegrationProvider } from '@/lib/integrations/types'
-import { getInstalledIntegrationConfig, installedIntegrationDisplayName, providerSupportsHealth, resolveCredentialEntry } from '@/lib/integrations/utils'
+import { getInstalledIntegrationConfig, installedIntegrationDisplayName, providerSupportsHealth, resolveConnectionEntry, resolveCredentialEntry } from '@/lib/integrations/utils'
 import { providerHasUserInputSchema } from '@/lib/integrations/flow'
 import { useDisconnectIntegration, useIntegrationHealth } from '@/lib/query-hooks/integrations'
 import { useGetOrgUserList } from '@/lib/graphql-hooks/member'
@@ -41,6 +41,13 @@ const InstalledIntegrationCard = ({ integration, providers }: InstalledIntegrati
   const credentialRefName = meta?.credentialRef ?? ''
   const lastHealthCheck = meta?.lastSuccessfulHealthCheck ?? ''
   const credentialEntry = resolveCredentialEntry(provider, credentialRefName)
+  const connectionEntry = resolveConnectionEntry(provider, credentialRefName || undefined)
+  const manageUrl =
+    connectionEntry?.auth != null && externalId
+      ? externalName
+        ? `https://github.com/organizations/${externalName}/settings/installations/${externalId}`
+        : `https://github.com/settings/installations/${externalId}`
+      : null
 
   const disconnectMutation = useDisconnectIntegration()
   const healthQuery = useIntegrationHealth(integration.id, supportsHealth)
@@ -125,13 +132,26 @@ const InstalledIntegrationCard = ({ integration, providers }: InstalledIntegrati
               Configure
             </Button>
           ) : null}
+          {manageUrl ? (
+            <Button variant="secondary" icon={<ExternalLink className="size-4" />} iconPosition="left" onClick={() => window.open(manageUrl, '_blank', 'noreferrer')}>
+              Manage Installation
+            </Button>
+          ) : null}
           <Button variant="secondary" onClick={() => setConfirmOpen(true)} disabled={disconnectMutation.isPending}>
             {disconnectMutation.isPending ? 'Disconnecting...' : 'Disconnect'}
           </Button>
         </div>
       </Card>
 
-      <IntegrationConfigurationDialog open={configOpen} onOpenChange={setConfigOpen} provider={provider} installationId={integration.id} credentialRef={credentialRefName || undefined} />
+      <IntegrationConfigurationDialog
+        open={configOpen}
+        onOpenChange={setConfigOpen}
+        provider={provider}
+        installationId={integration.id}
+        credentialRef={credentialRefName || undefined}
+        config={integration.config ?? undefined}
+        credentials={integration.credentials ?? undefined}
+      />
 
       <ConfirmationDialog
         open={confirmOpen}

--- a/apps/console/src/components/pages/protected/organization-settings/integrations/integration-configuration-dialog.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/integrations/integration-configuration-dialog.tsx
@@ -4,13 +4,15 @@ import React, { useEffect, useMemo } from 'react'
 import { FormProvider } from 'react-hook-form'
 import { Button } from '@repo/ui/button'
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from '@repo/ui/sheet'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@repo/ui/tabs'
 import { useQueryClient } from '@tanstack/react-query'
 import { useNotification } from '@/hooks/useNotification'
 import { getProviderHelperContent } from '@/lib/integrations/provider-helper-content'
-import { type IntegrationProvider } from '@/lib/integrations/types'
+import { type IntegrationProvider, type IntegrationSchemaNode } from '@/lib/integrations/types'
 import { disabledOperationConfigKeys, resolveConnectionEntry, resolveCredentialEntry, resolveSchemaRoot } from '@/lib/integrations/utils'
 import { connectViaAuth, saveIntegrationConfiguration } from '@/lib/integrations/flow'
 import { IntegrationSchemaSections, normalizeIntegrationFormPayloads, useIntegrationSchemaForm } from './schema-form'
+import { Callout } from '@/components/shared/callout/callout'
 
 type Props = {
   open: boolean
@@ -18,21 +20,29 @@ type Props = {
   provider?: IntegrationProvider
   installationId?: string
   credentialRef?: string
+  config?: Record<string, unknown>
+  credentials?: Record<string, unknown>
   onAuthFlowStarted?: (provider: IntegrationProvider) => void
 }
 
-const IntegrationConfigurationDialog = ({ open, onOpenChange, provider, installationId, credentialRef, onAuthFlowStarted }: Props) => {
+const IntegrationConfigurationDialog = ({ open, onOpenChange, provider, installationId, credentialRef, config, credentials, onAuthFlowStarted }: Props) => {
   const { successNotification, errorNotification } = useNotification()
   const queryClient = useQueryClient()
   const isExistingInstallation = Boolean(installationId)
 
   const activeCredentialEntry = useMemo(() => resolveCredentialEntry(provider, credentialRef), [provider, credentialRef])
-
   const activeCredentialRef = credentialRef ?? activeCredentialEntry?.ref
   const providerHelper = getProviderHelperContent(provider)
+  const disabledConfigKeys = useMemo(() => disabledOperationConfigKeys(provider), [provider])
 
-  const credentialSchema = useMemo(() => resolveSchemaRoot(activeCredentialEntry?.schema), [activeCredentialEntry?.schema])
-  const userInputSchema = useMemo(() => resolveSchemaRoot(provider?.userInputSchema), [provider?.userInputSchema])
+  const credentialSchema = useMemo(
+    () => resolveSchemaRoot((isExistingInstallation && credentials ? credentials : activeCredentialEntry?.schema) as IntegrationSchemaNode | undefined),
+    [isExistingInstallation, credentials, activeCredentialEntry?.schema],
+  )
+  const userInputSchema = useMemo(
+    () => resolveSchemaRoot((isExistingInstallation && config ? config : provider?.userInputSchema) as IntegrationSchemaNode | undefined),
+    [isExistingInstallation, config, provider?.userInputSchema],
+  )
   const userInputSectionMeta = useMemo(
     () => ({
       title: 'Installation Settings',
@@ -42,91 +52,126 @@ const IntegrationConfigurationDialog = ({ open, onOpenChange, provider, installa
     }),
     [isExistingInstallation],
   )
-  const { formMethods, initialValues, sections } = useIntegrationSchemaForm({
-    credentialSchema,
-    userInputSchema,
-    userInputSectionMeta,
-  })
 
-  const disabledConfigKeys = useMemo(() => disabledOperationConfigKeys(provider), [provider])
+  // Combined form — used for new installations where creds and settings are submitted together
+  const combined = useIntegrationSchemaForm({ credentialSchema, userInputSchema, userInputSectionMeta })
 
-  const {
-    handleSubmit,
-    reset,
-    formState: { isSubmitting },
-  } = formMethods
+  // Separate forms — used for existing installation tabs so each section validates independently
+  const credForm = useIntegrationSchemaForm({ credentialSchema })
+  const settingsForm = useIntegrationSchemaForm({ userInputSchema, userInputSectionMeta })
+
+  const { reset: resetCombined } = combined.formMethods
+  const { reset: resetCred } = credForm.formMethods
+  const { reset: resetSettings } = settingsForm.formMethods
 
   useEffect(() => {
-    if (!open) {
-      return
-    }
+    if (!open) return
+    resetCombined(combined.initialValues)
+  }, [combined.initialValues, open, resetCombined])
 
-    reset(initialValues)
-  }, [initialValues, open, reset])
+  useEffect(() => {
+    if (!open) return
+    resetCred(credForm.initialValues)
+  }, [credForm.initialValues, open, resetCred])
 
+  useEffect(() => {
+    if (!open) return
+    resetSettings(settingsForm.initialValues)
+  }, [settingsForm.initialValues, open, resetSettings])
+
+  // New installation: submit credentials + settings together
   const onSubmit = async (formValues: Record<string, unknown>) => {
-    if (!provider) {
-      return
-    }
+    if (!provider) return
 
     const { credentialPayload, hasCredentialPayload, hasUserInputPayload, missingRequired, userInputPayload } = normalizeIntegrationFormPayloads(credentialSchema, userInputSchema, formValues)
 
     if (missingRequired.length > 0) {
-      errorNotification({
-        title: `Missing required fields for ${provider.displayName}`,
-        description: missingRequired.join(', '),
-      })
+      errorNotification({ title: `Missing required fields for ${provider.displayName}`, description: missingRequired.join(', ') })
       return
     }
 
     try {
-      if (isExistingInstallation && !hasCredentialPayload && !hasUserInputPayload) {
-        onOpenChange(false)
-        return
-      }
-
       const connectionHasAuth = resolveConnectionEntry(provider, activeCredentialRef)?.auth != null
 
-      if (connectionHasAuth && !hasCredentialPayload && !isExistingInstallation) {
+      if (!isExistingInstallation && connectionHasAuth && !hasCredentialPayload) {
         await connectViaAuth(provider, {
           credentialRef: activeCredentialRef,
           installationId,
           userInput: userInputPayload.payload,
           onRedirect: () => onAuthFlowStarted?.(provider),
         })
-
-        successNotification({
-          title: `Continue connecting ${provider.displayName}`,
-          description: `Redirecting to ${provider.displayName} to finish setup.`,
-        })
-
+        successNotification({ title: `Continue connecting ${provider.displayName}`, description: `Redirecting to ${provider.displayName} to finish setup.` })
         onOpenChange(false)
         return
       }
 
-      await saveIntegrationConfiguration({
-        definitionId: provider.id,
-        installationId,
-        credentialRef: activeCredentialRef,
-        body: credentialPayload.payload,
-        userInput: userInputPayload.payload,
-      })
+      if (!hasCredentialPayload && !hasUserInputPayload) {
+        onOpenChange(false)
+        return
+      }
 
+      await saveIntegrationConfiguration({ definitionId: provider.id, installationId, credentialRef: activeCredentialRef, body: credentialPayload.payload, userInput: userInputPayload.payload })
       queryClient.invalidateQueries({ queryKey: ['integrations'] })
-
-      successNotification({
-        title: isExistingInstallation ? `${provider.displayName} updated` : `${provider.displayName} configured`,
-        description: isExistingInstallation ? 'Integration settings were updated successfully.' : 'Integration credentials were saved successfully.',
-      })
-
+      successNotification({ title: `${provider.displayName} configured`, description: 'Integration credentials were saved successfully.' })
       onOpenChange(false)
     } catch (error) {
-      errorNotification({
-        title: `Failed to ${isExistingInstallation ? 'update' : 'configure'} ${provider.displayName}`,
-        description: error instanceof Error ? error.message : 'Unexpected error while saving integration settings.',
-      })
+      errorNotification({ title: `Failed to configure ${provider.displayName}`, description: error instanceof Error ? error.message : 'Unexpected error while saving.' })
     }
   }
+
+  // Existing installation: save credentials only
+  const onSubmitCredentials = async (formValues: Record<string, unknown>) => {
+    if (!provider) return
+
+    const { credentialPayload, hasCredentialPayload, missingRequired } = normalizeIntegrationFormPayloads(credentialSchema, undefined, formValues)
+
+    if (!hasCredentialPayload) {
+      onOpenChange(false)
+      return
+    }
+
+    if (missingRequired.length > 0) {
+      errorNotification({ title: `Missing required credential fields for ${provider.displayName}`, description: missingRequired.join(', ') })
+      return
+    }
+
+    try {
+      await saveIntegrationConfiguration({ definitionId: provider.id, installationId, credentialRef: activeCredentialRef, body: credentialPayload.payload, userInput: {} })
+      queryClient.invalidateQueries({ queryKey: ['integrations'] })
+      successNotification({ title: `${provider.displayName} credentials updated`, description: 'Credentials were updated successfully.' })
+      onOpenChange(false)
+    } catch (error) {
+      errorNotification({ title: `Failed to update credentials for ${provider.displayName}`, description: error instanceof Error ? error.message : 'Unexpected error while saving credentials.' })
+    }
+  }
+
+  // Existing installation: save settings only
+  const onSubmitSettings = async (formValues: Record<string, unknown>) => {
+    if (!provider) return
+
+    const { hasUserInputPayload, missingRequired, userInputPayload } = normalizeIntegrationFormPayloads(undefined, userInputSchema, formValues)
+
+    if (!hasUserInputPayload) {
+      onOpenChange(false)
+      return
+    }
+
+    if (missingRequired.length > 0) {
+      errorNotification({ title: `Missing required settings for ${provider.displayName}`, description: missingRequired.join(', ') })
+      return
+    }
+
+    try {
+      await saveIntegrationConfiguration({ definitionId: provider.id, installationId, credentialRef: activeCredentialRef, body: {}, userInput: userInputPayload.payload })
+      queryClient.invalidateQueries({ queryKey: ['integrations'] })
+      successNotification({ title: `${provider.displayName} settings updated`, description: 'Settings were updated successfully.' })
+      onOpenChange(false)
+    } catch (error) {
+      errorNotification({ title: `Failed to update settings for ${provider.displayName}`, description: error instanceof Error ? error.message : 'Unexpected error while saving settings.' })
+    }
+  }
+
+  const showTabs = isExistingInstallation && credForm.sections.length > 0 && settingsForm.sections.length > 0
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -135,29 +180,79 @@ const IntegrationConfigurationDialog = ({ open, onOpenChange, provider, installa
           <SheetTitle>{isExistingInstallation ? `Update ${provider?.displayName ?? 'Integration'}` : `Configure ${provider?.displayName ?? 'Integration'}`}</SheetTitle>
           <SheetDescription>
             {isExistingInstallation
-              ? 'Update the credentials and installation settings for this integration - these values will overwrite the existing once we have confirmed them.'
+              ? credForm.sections.length > 0
+                ? 'Update the credentials and installation settings for this integration.'
+                : 'Update the installation settings for this integration.'
               : 'Provide the credentials and any required settings needed to connect this integration.'}
           </SheetDescription>
         </SheetHeader>
 
-        <FormProvider {...formMethods}>
-          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-1 flex-col overflow-hidden">
-            <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
-              {providerHelper}
-              {sections.length === 0 ? <p className="text-sm text-muted-foreground">No additional input is required for this integration.</p> : null}
-              <IntegrationSchemaSections sections={sections} hideFieldKeys={disabledConfigKeys} />
-            </div>
+        {showTabs ? (
+          <Tabs defaultValue="credentials" variant="solid" className="flex flex-1 flex-col overflow-hidden">
+            <TabsList className="w-full grid grid-cols-2">
+              <TabsTrigger value="credentials">Credentials</TabsTrigger>
+              <TabsTrigger value="settings">Settings</TabsTrigger>
+            </TabsList>
 
-            <SheetFooter className="border-t px-6 py-4 sm:flex-row sm:justify-end">
-              <Button type="button" variant="secondary" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={isSubmitting || !provider}>
-                {isSubmitting ? 'Saving...' : isExistingInstallation ? 'Save Changes' : 'Save Configuration'}
-              </Button>
-            </SheetFooter>
-          </form>
-        </FormProvider>
+            <TabsContent value="credentials" className="flex flex-1 flex-col overflow-hidden mt-[10px]">
+              <FormProvider {...credForm.formMethods}>
+                <form onSubmit={credForm.formMethods.handleSubmit(onSubmitCredentials)} className="flex flex-1 flex-col overflow-hidden">
+                  <div className="flex-1 space-y-4 overflow-y-auto px-6 py-5">
+                    {providerHelper}
+                    <Callout variant="warning" title="Updating Credentials" className="mb-[30px]">
+                      We only load non-sensitive values. When saving, the entire form is validated—so you'll need to re-enter any required values that aren’t pre-filled (like secrets).
+                    </Callout>
+                    <IntegrationSchemaSections sections={credForm.sections} hideDescriptions hideFieldKeys={disabledConfigKeys} />
+                  </div>
+                  <SheetFooter className="shrink-0 border-t px-6 py-4 sm:flex-row sm:justify-end">
+                    <Button type="button" variant="secondary" onClick={() => onOpenChange(false)} disabled={credForm.formMethods.formState.isSubmitting}>
+                      Cancel
+                    </Button>
+                    <Button type="submit" disabled={credForm.formMethods.formState.isSubmitting || !provider}>
+                      {credForm.formMethods.formState.isSubmitting ? 'Saving...' : 'Save Credentials'}
+                    </Button>
+                  </SheetFooter>
+                </form>
+              </FormProvider>
+            </TabsContent>
+
+            <TabsContent value="settings" className="flex flex-1 flex-col overflow-hidden">
+              <FormProvider {...settingsForm.formMethods}>
+                <form onSubmit={settingsForm.formMethods.handleSubmit(onSubmitSettings)} className="flex flex-1 flex-col overflow-hidden">
+                  <div className="flex-1 space-y-4 overflow-y-auto px-6 py-5">
+                    <IntegrationSchemaSections sections={settingsForm.sections} hideDescriptions hideFieldKeys={disabledConfigKeys} />
+                  </div>
+                  <SheetFooter className="shrink-0 border-t px-6 py-4 sm:flex-row sm:justify-end">
+                    <Button type="button" variant="secondary" onClick={() => onOpenChange(false)} disabled={settingsForm.formMethods.formState.isSubmitting}>
+                      Cancel
+                    </Button>
+                    <Button type="submit" disabled={settingsForm.formMethods.formState.isSubmitting || !provider}>
+                      {settingsForm.formMethods.formState.isSubmitting ? 'Saving...' : 'Save Settings'}
+                    </Button>
+                  </SheetFooter>
+                </form>
+              </FormProvider>
+            </TabsContent>
+          </Tabs>
+        ) : (
+          <FormProvider {...combined.formMethods}>
+            <form onSubmit={combined.formMethods.handleSubmit(onSubmit)} className="flex flex-1 flex-col overflow-hidden">
+              <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
+                {providerHelper}
+                {combined.sections.length === 0 ? <p className="text-sm text-muted-foreground">No additional input is required for this integration.</p> : null}
+                <IntegrationSchemaSections sections={combined.sections} hideFieldKeys={disabledConfigKeys} />
+              </div>
+              <SheetFooter className="shrink-0 border-t px-6 py-4 sm:flex-row sm:justify-end">
+                <Button type="button" variant="secondary" onClick={() => onOpenChange(false)} disabled={combined.formMethods.formState.isSubmitting}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={combined.formMethods.formState.isSubmitting || !provider}>
+                  {combined.formMethods.formState.isSubmitting ? 'Saving...' : 'Save Configuration'}
+                </Button>
+              </SheetFooter>
+            </form>
+          </FormProvider>
+        )}
       </SheetContent>
     </Sheet>
   )

--- a/apps/console/src/components/pages/protected/organization-settings/integrations/integration-definition-page.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/integrations/integration-definition-page.tsx
@@ -56,11 +56,11 @@ const IntegrationDefinitionPage = ({ definitionId }: IntegrationDefinitionPagePr
   const [schemaCredentialIndex, setSchemaCredentialIndex] = useState(-1)
 
   useEffect(() => {
-    if (credentialEntries.length === 1) {
+    if (credentialEntries.length === 1 && installedInstances.length === 0) {
       setSelectedCredentialIndex(0)
       setSchemaCredentialIndex(0)
     }
-  }, [credentialEntries.length])
+  }, [credentialEntries.length, installedInstances.length])
 
   const handleSelectCredential = (index: number) => {
     setSelectedCredentialIndex(index)

--- a/apps/console/src/components/pages/protected/organization-settings/integrations/schema-form.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/integrations/schema-form.tsx
@@ -41,6 +41,7 @@ type UseIntegrationSchemaFormOptions = {
   userInputSchema?: IntegrationSchemaNode
   credentialSectionMeta?: { title: string; description: string }
   userInputSectionMeta?: { title: string; description: string }
+  existingUserInputValues?: Record<string, unknown>
 }
 
 export const SchemaField = ({ fieldKey, fieldName, property, required }: SchemaFieldProps) => {

--- a/apps/console/src/lib/integrations/flow.ts
+++ b/apps/console/src/lib/integrations/flow.ts
@@ -122,7 +122,7 @@ function buildStartRequestBody(provider: IntegrationProvider, options?: StartInt
   }
 
   if (options?.installationId) {
-    body.installationId = options.installationId
+    body.integrationId = options.installationId
   }
 
   if (options?.userInput && Object.keys(options.userInput).length > 0) {

--- a/apps/console/src/lib/integrations/schema.ts
+++ b/apps/console/src/lib/integrations/schema.ts
@@ -74,7 +74,7 @@ export function buildInitialValues(sections: SchemaSection[]): FormValues {
         continue
       }
 
-      if (property.default !== undefined) {
+      if (property.default != null) {
         if (property.type === 'array' && Array.isArray(property.default)) {
           values[fieldName] = property.default.join('\n')
         } else if (property.type === 'boolean') {

--- a/apps/console/src/lib/integrations/utils.ts
+++ b/apps/console/src/lib/integrations/utils.ts
@@ -264,6 +264,21 @@ export function disabledOperationConfigKeys(provider?: IntegrationProvider): Set
   return new Set((provider?.operations ?? []).filter((op) => op.disabledForAll).map((op) => op.name.charAt(0).toLowerCase() + op.name.slice(1)))
 }
 
+export function resolveManageUrl(provider: IntegrationProvider | undefined, connectionEntry: ReturnType<typeof resolveConnectionEntry>, externalId: string, externalName: string): string | null {
+  if (!connectionEntry?.auth || !externalId) return null
+
+  const token = normalizeIntegrationToken(provider?.slug)
+
+  switch (token) {
+    case 'github':
+      return externalName ? `https://github.com/organizations/${externalName}/settings/installations/${externalId}` : `https://github.com/settings/installations/${externalId}`
+    case 'slack':
+      return `https://app.slack.com/apps-manage/${externalId}/integrations`
+    default:
+      return null
+  }
+}
+
 export async function parseIntegrationErrorMessage(response: Response): Promise<string> {
   const raw = await response.text().catch(() => '')
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "openlane-ui",

--- a/packages/codegen/query/integration.ts
+++ b/packages/codegen/query/integration.ts
@@ -21,6 +21,8 @@ export const GET_INTEGRATIONS = gql`
           createdBy
           environmentName
           scopeName
+          credentials
+          config
         }
       }
     }

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -24484,8 +24484,10 @@ export interface Integration extends Node {
   actionPlans: ActionPlanConnection
   assets: AssetConnection
   checkResults: CheckResultConnection
+  config?: Maybe<Scalars['Map']['output']>
   createdAt?: Maybe<Scalars['Time']['output']>
   createdBy?: Maybe<Scalars['String']['output']>
+  credentials?: Maybe<Scalars['Map']['output']>
   /** the canonical definition identifier for the installation */
   definitionID?: Maybe<Scalars['String']['output']>
   /** the human-readable definition slug recorded for this installation */
@@ -71302,6 +71304,8 @@ export type GetIntegrationsQuery = {
         createdBy?: string | null
         environmentName?: string | null
         scopeName?: string | null
+        credentials?: any | null
+        config?: any | null
       } | null
     } | null> | null
   }


### PR DESCRIPTION
- Pulls config + credentials from new backend graphql fields; these will return the full schema with the default values set as the previous values, allow users to see current config settings and update fields. This will *not* show secret values, those must be re-entered to update credentials. 
- Fixes the id being passed back to be the integration id so the integratoin is updated instead of a new integration being created in a pending state
- Adds a `manage` button to integrations that are apps/installed with no config settings such as github app, to allow for the user to manage the settings there 

<img width="704" height="441" alt="image" src="https://github.com/user-attachments/assets/8b5d3641-8b42-423c-ae56-6cd3fac6855e" />

~Depends on: https://github.com/theopenlane/core/pull/2346~ released