### PR TITLE
fix: schedule released after first month

### DIFF
--- a/apps/console/src/app/api/stripe/schedules/update/route.ts
+++ b/apps/console/src/app/api/stripe/schedules/update/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'scheduleId, priceId and action are required' }, { status: 400 })
     }
 
-    const schedule = (await stripe.subscriptionSchedules.retrieve(scheduleId)) as Stripe.SubscriptionSchedule
+    let schedule = (await stripe.subscriptionSchedules.retrieve(scheduleId)) as Stripe.SubscriptionSchedule
 
     const newPrice = (await stripe.prices.retrieve(priceId)) as Stripe.Price
 
@@ -35,6 +35,13 @@ export async function POST(req: Request) {
         },
         { status: 400 },
       )
+    }
+
+    // Released schedules have no current_phase — recreate a schedule from the released subscription
+    if (schedule.status === 'released' && schedule.released_subscription) {
+      schedule = (await stripe.subscriptionSchedules.create({
+        from_subscription: schedule.released_subscription as string,
+      })) as Stripe.SubscriptionSchedule
     }
 
     const rawPhases = schedule.phases ?? []
@@ -110,7 +117,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Invalid action. Use "subscribe" or "unsubscribe".' }, { status: 400 })
     }
 
-    const updated = await stripe.subscriptionSchedules.update(scheduleId, {
+    const updated = await stripe.subscriptionSchedules.update(schedule.id, {
       phases,
     })
 

--- a/apps/console/src/components/pages/protected/organization-settings/billing/billing-summary.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/billing/billing-summary.tsx
@@ -14,9 +14,10 @@ type Props = {
   stripeCustomerId: string | null | undefined
   activePriceIds: Set<string | Price>
   nextPhaseStart: Date | null
+  currentInterval: 'month' | 'year' | null
 }
 
-const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart }: Props) => {
+const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart, currentInterval }: Props) => {
   const { currentOrgId } = useOrganization()
   const { data } = useGetOrganizationBilling(currentOrgId)
   const { data: schedules = [] } = useSchedulesQuery(stripeCustomerId)
@@ -32,21 +33,16 @@ const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart }: Pr
   const { mutateAsync: switchInterval, isPending: updating } = useSwitchIntervalMutation()
   const [confirmSwitchOpen, setConfirmSwitchOpen] = useState(false)
   const trialExpirationDate = trialExpiresAt ? parseISO(trialExpiresAt) : null
-  const trialEnded = trialExpirationDate ? isBefore(trialExpirationDate, new Date()) : false
+  const [now] = useState(() => new Date())
+  const trialEnded = trialExpirationDate ? isBefore(trialExpirationDate, now) : false
   const { errorNotification, successNotification } = useNotification()
   const { data: openlaneProducts } = useOpenlaneProductsQuery()
 
   const isSubscriptionCanceled = schedules[0]?.end_behavior === 'cancel'
 
-  const currentInterval = useMemo(() => {
-    if (!schedules?.length) return null
-    const firstItem = schedules[0].subscription?.items?.data?.[0]
-    return firstItem?.price?.recurring?.interval ?? null
-  }, [schedules])
-
-  const modules = Object.values(openlaneProducts?.modules || {})
-  const addons = Object.values(openlaneProducts?.addons || {})
-  const modulesWithoutBase = modules.filter((m) => m.display_name !== 'Base Module')
+  const modules = useMemo(() => Object.values(openlaneProducts?.modules || {}), [openlaneProducts])
+  const addons = useMemo(() => Object.values(openlaneProducts?.addons || {}), [openlaneProducts])
+  const modulesWithoutBase = useMemo(() => modules.filter((m) => m.display_name !== 'Base Module'), [modules])
 
   const activeAddons = useMemo(() => {
     return addons.filter((a) => {
@@ -150,13 +146,13 @@ const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart }: Pr
       if (!expiresAt && trialEnded) return 'Expired'
 
       const expirationDate = parseISO(expiresAt)
-      if (isBefore(expirationDate, new Date())) return 'Expired'
+      if (isBefore(expirationDate, now)) return 'Expired'
 
       return `Expires in ${formatDistanceToNowStrict(expirationDate, { addSuffix: false })}`
     } catch {
       return 'N/A'
     }
-  }, [expiresAt, stripeSubscriptionStatus, trialExpiresAt, trialEnded])
+  }, [expiresAt, stripeSubscriptionStatus, trialExpiresAt, trialEnded, now])
 
   const handleSwitchInterval = async () => {
     try {

--- a/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
@@ -1,8 +1,9 @@
 'use client'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import { useOrganization } from '@/hooks/useOrganization'
-import { useOpenlaneProductsQuery, usePaymentMethodsQuery, useSchedulesQuery, useUpdateScheduleMutation, useUpcomingInvoiceQuery } from '@/lib/query-hooks/stripe'
+import { useOpenlaneProductsQuery, usePaymentMethodsQuery, useSchedulesQuery, useSubscriptionQuery, useUpdateScheduleMutation, useUpcomingInvoiceQuery } from '@/lib/query-hooks/stripe'
+import { type Price, type SubscriptionItem } from '@/types/stripe'
 import { ProductCard } from './product-card'
 import { useNotification } from '@/hooks/useNotification'
 import { useSearchParams } from 'next/navigation'
@@ -23,8 +24,15 @@ const PricingPlan = () => {
   const { data: schedules = [], isLoading: schedulesLoading } = useSchedulesQuery(stripeCustomerId)
   const { mutateAsync: updateSchedule, isPending: updating } = useUpdateScheduleMutation()
 
+  const scheduleSubscription = schedules[0]?.subscription ?? null
+
+  // For released schedules, subscription is null — fetch it directly by customer ID
+  const { data: directSubscription, isLoading: subscriptionLoading } = useSubscriptionQuery(!schedulesLoading && !scheduleSubscription ? stripeCustomerId : null)
+
+  const subscription = scheduleSubscription ?? directSubscription ?? null
+
   const scheduleId = schedules[0]?.id
-  const subscriptionId = schedules[0]?.subscription?.id
+  const subscriptionId = subscription?.id
   const { isLoading: invoiceLoading } = useUpcomingInvoiceQuery({
     customerId: stripeCustomerId,
     scheduleId,
@@ -33,52 +41,21 @@ const PricingPlan = () => {
 
   const { data: paymentData } = usePaymentMethodsQuery(stripeCustomerId)
 
-  const pageLoading = productsLoading || schedulesLoading || invoiceLoading
-
-  const allPhases = schedules?.[0]?.phases ?? []
-  const [now] = useState(() => Math.floor(Date.now() / 1000))
-
-  // Find the currently active phase index using Stripe's current_phase when available,
-  // otherwise match by timestamp (needed when status is "released" and current_phase is null)
-  const currentPhaseIndex = useMemo(() => {
-    const schedule = schedules?.[0]
-    if (!schedule) return -1
-    if (schedule.current_phase) {
-      const idx = (schedule.phases ?? []).findIndex((p) => p.start_date === schedule.current_phase?.start_date)
-      return idx >= 0 ? idx : -1
-    }
-    return (schedule.phases ?? []).findIndex((p) => p.start_date <= now && (p.end_date == null || p.end_date > now))
-  }, [schedules, now])
-
-  // For released schedules subscription is null — fall back to the current or last phase
-  const currentOrLastPhase = allPhases[currentPhaseIndex >= 0 ? currentPhaseIndex : allPhases.length - 1] ?? null
+  const pageLoading = productsLoading || schedulesLoading || subscriptionLoading || invoiceLoading
 
   const activePriceIds = useMemo(() => {
-    if (!schedules?.length) return new Set<string>()
-    const sub = schedules[0].subscription
-    if (sub?.items?.data?.length) {
-      return new Set(sub.items.data.map((item) => item.price?.id || item.price))
-    }
-    return new Set((currentOrLastPhase?.items ?? []).map((i) => i.price))
-  }, [schedules, currentOrLastPhase])
+    if (!subscription) return new Set<string | Price>()
+    const items: SubscriptionItem[] = subscription.items?.data || []
+    return new Set<string | Price>(items.map((item) => item.price?.id || item.price))
+  }, [subscription])
 
-  const currentInterval = useMemo(() => {
-    if (!schedules?.length) return null
-    const interval = schedules[0].subscription?.items?.data?.[0]?.price?.recurring?.interval
-    if (interval) return interval
-    // Derive interval from phase price IDs matched against the product catalog
-    const phasePriceIds = new Set((currentOrLastPhase?.items ?? []).map((i) => i.price))
-    const allProducts = [...Object.values(openlaneProducts?.modules ?? {}), ...Object.values(openlaneProducts?.addons ?? {})]
-    for (const product of allProducts) {
-      for (const price of product.billing.prices) {
-        if (phasePriceIds.has(price.price_id)) return price.interval
-      }
-    }
+  const currentInterval = useMemo((): 'month' | 'year' | null => {
+    const interval = subscription?.items?.data?.[0]?.price?.recurring?.interval
+    if (interval === 'month' || interval === 'year') return interval
     return null
-  }, [schedules, currentOrLastPhase, openlaneProducts])
+  }, [subscription])
 
-  const nextPhase = currentPhaseIndex >= 0 ? (allPhases[currentPhaseIndex + 1] ?? null) : null
-  const nextOrCurrentPhase = nextPhase ?? currentOrLastPhase
+  const nextOrCurrentPhase = schedules?.[0]?.phases?.[1] || schedules?.[0]?.phases?.[0] || null
 
   const nextPhaseActivePriceIds = useMemo(() => {
     if (!nextOrCurrentPhase) return new Set<string>()
@@ -86,18 +63,19 @@ const PricingPlan = () => {
   }, [nextOrCurrentPhase])
 
   const endingPriceIds = useMemo(() => {
-    if (!schedules?.length || currentPhaseIndex < 0) return new Set<string>()
+    if (!schedules?.length) return new Set<string>()
     const phases = schedules[0]?.phases || []
-    const nextIdx = currentPhaseIndex + 1
-    if (nextIdx >= phases.length) return new Set<string>()
-    const currentIds = new Set(phases[currentPhaseIndex].items.map((i) => i.price))
-    const nextIds = new Set(phases[nextIdx].items.map((i) => i.price))
+    if (phases.length < 2) return new Set<string>()
+    const currentIds = new Set(phases[0].items.map((i) => i.price))
+    const nextIds = new Set(phases[1].items.map((i) => i.price))
     return new Set(Array.from(currentIds).filter((id) => !nextIds.has(id)))
-  }, [schedules, currentPhaseIndex])
+  }, [schedules])
 
   const nextPhaseStart = useMemo(() => {
-    return nextPhase?.start_date != null ? new Date(nextPhase.start_date * 1000) : null
-  }, [nextPhase])
+    const startDate = schedules?.[0]?.phases?.[1]?.start_date
+    return startDate ? new Date(startDate * 1000) : null
+  }, [schedules])
+
   const isSubscriptionCanceled = schedules[0]?.end_behavior === 'cancel'
 
   const modules = Object.values(openlaneProducts?.modules || {})
@@ -183,7 +161,7 @@ const PricingPlan = () => {
       <SideNavigation />
 
       <div className="max-w-[1000px] ml-14">
-        <BillingSummary activePriceIds={activePriceIds} stripeCustomerId={stripeCustomerId} nextPhaseStart={nextPhaseStart} />
+        <BillingSummary activePriceIds={activePriceIds} stripeCustomerId={stripeCustomerId} nextPhaseStart={nextPhaseStart} currentInterval={currentInterval} />
         <>
           {!!schedules[0] && (
             <div>

--- a/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
@@ -72,9 +72,13 @@ const PricingPlan = () => {
   }, [schedules])
 
   const nextPhaseStart = useMemo(() => {
-    const startDate = schedules?.[0]?.phases?.[1]?.start_date
-    return startDate ? new Date(startDate * 1000) : null
-  }, [schedules])
+    // Prefer current period end from the subscription — it's always the actual next charge date
+    const periodEnd = subscription?.items?.data?.[0]?.current_period_end
+    if (periodEnd) return new Date(periodEnd * 1000)
+    // Fall back to next phase start for cases where subscription isn't loaded yet
+    const phaseStart = schedules?.[0]?.phases?.[1]?.start_date
+    return phaseStart ? new Date(phaseStart * 1000) : null
+  }, [subscription, schedules])
 
   const isSubscriptionCanceled = schedules[0]?.end_behavior === 'cancel'
 

--- a/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
@@ -35,19 +35,6 @@ const PricingPlan = () => {
 
   const pageLoading = productsLoading || schedulesLoading || invoiceLoading
 
-  const activePriceIds = useMemo(() => {
-    if (!schedules?.length) return new Set<string>()
-    const sub = schedules[0].subscription
-    const items = sub?.items?.data || []
-    return new Set(items.map((item) => item.price?.id || item.price))
-  }, [schedules])
-
-  const currentInterval = useMemo(() => {
-    if (!schedules?.length) return null
-    const firstItem = schedules[0].subscription?.items?.data?.[0]
-    return firstItem?.price?.recurring?.interval ?? null
-  }, [schedules])
-
   const allPhases = schedules?.[0]?.phases ?? []
   const [now] = useState(() => Math.floor(Date.now() / 1000))
 
@@ -63,8 +50,35 @@ const PricingPlan = () => {
     return (schedule.phases ?? []).findIndex((p) => p.start_date <= now && (p.end_date == null || p.end_date > now))
   }, [schedules, now])
 
+  // For released schedules subscription is null — fall back to the current or last phase
+  const currentOrLastPhase = allPhases[currentPhaseIndex >= 0 ? currentPhaseIndex : allPhases.length - 1] ?? null
+
+  const activePriceIds = useMemo(() => {
+    if (!schedules?.length) return new Set<string>()
+    const sub = schedules[0].subscription
+    if (sub?.items?.data?.length) {
+      return new Set(sub.items.data.map((item) => item.price?.id || item.price))
+    }
+    return new Set((currentOrLastPhase?.items ?? []).map((i) => i.price))
+  }, [schedules, currentOrLastPhase])
+
+  const currentInterval = useMemo(() => {
+    if (!schedules?.length) return null
+    const interval = schedules[0].subscription?.items?.data?.[0]?.price?.recurring?.interval
+    if (interval) return interval
+    // Derive interval from phase price IDs matched against the product catalog
+    const phasePriceIds = new Set((currentOrLastPhase?.items ?? []).map((i) => i.price))
+    const allProducts = [...Object.values(openlaneProducts?.modules ?? {}), ...Object.values(openlaneProducts?.addons ?? {})]
+    for (const product of allProducts) {
+      for (const price of product.billing.prices) {
+        if (phasePriceIds.has(price.price_id)) return price.interval
+      }
+    }
+    return null
+  }, [schedules, currentOrLastPhase, openlaneProducts])
+
   const nextPhase = currentPhaseIndex >= 0 ? (allPhases[currentPhaseIndex + 1] ?? null) : null
-  const nextOrCurrentPhase = nextPhase ?? allPhases[currentPhaseIndex] ?? allPhases[allPhases.length - 1] ?? null
+  const nextOrCurrentPhase = nextPhase ?? currentOrLastPhase
 
   const nextPhaseActivePriceIds = useMemo(() => {
     if (!nextOrCurrentPhase) return new Set<string>()

--- a/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import { useOrganization } from '@/hooks/useOrganization'
 import { useOpenlaneProductsQuery, usePaymentMethodsQuery, useSchedulesQuery, useUpdateScheduleMutation, useUpcomingInvoiceQuery } from '@/lib/query-hooks/stripe'
@@ -48,7 +48,23 @@ const PricingPlan = () => {
     return firstItem?.price?.recurring?.interval ?? null
   }, [schedules])
 
-  const nextOrCurrentPhase = schedules?.[0]?.phases?.[1] || schedules?.[0]?.phases?.[0] || null
+  const allPhases = schedules?.[0]?.phases ?? []
+  const [now] = useState(() => Math.floor(Date.now() / 1000))
+
+  // Find the currently active phase index using Stripe's current_phase when available,
+  // otherwise match by timestamp (needed when status is "released" and current_phase is null)
+  const currentPhaseIndex = useMemo(() => {
+    const schedule = schedules?.[0]
+    if (!schedule) return -1
+    if (schedule.current_phase) {
+      const idx = (schedule.phases ?? []).findIndex((p) => p.start_date === schedule.current_phase?.start_date)
+      return idx >= 0 ? idx : -1
+    }
+    return (schedule.phases ?? []).findIndex((p) => p.start_date <= now && (p.end_date == null || p.end_date > now))
+  }, [schedules, now])
+
+  const nextPhase = currentPhaseIndex >= 0 ? (allPhases[currentPhaseIndex + 1] ?? null) : null
+  const nextOrCurrentPhase = nextPhase ?? allPhases[currentPhaseIndex] ?? allPhases[allPhases.length - 1] ?? null
 
   const nextPhaseActivePriceIds = useMemo(() => {
     if (!nextOrCurrentPhase) return new Set<string>()
@@ -56,19 +72,18 @@ const PricingPlan = () => {
   }, [nextOrCurrentPhase])
 
   const endingPriceIds = useMemo(() => {
-    if (!schedules?.length) return new Set<string>()
-
+    if (!schedules?.length || currentPhaseIndex < 0) return new Set<string>()
     const phases = schedules[0]?.phases || []
-    if (phases.length < 2) return new Set<string>()
+    const nextIdx = currentPhaseIndex + 1
+    if (nextIdx >= phases.length) return new Set<string>()
+    const currentIds = new Set(phases[currentPhaseIndex].items.map((i) => i.price))
+    const nextIds = new Set(phases[nextIdx].items.map((i) => i.price))
+    return new Set(Array.from(currentIds).filter((id) => !nextIds.has(id)))
+  }, [schedules, currentPhaseIndex])
 
-    const currentIds = new Set(phases[0].items.map((i) => i.price))
-    const nextIds = new Set(phases[1].items.map((i) => i.price))
-
-    const ending = Array.from(currentIds).filter((id) => !nextIds.has(id))
-    return new Set(ending)
-  }, [schedules])
-
-  const nextPhaseStart = schedules?.[0]?.phases?.[1]?.start_date ? new Date(schedules[0].phases[1].start_date * 1000) : null
+  const nextPhaseStart = useMemo(() => {
+    return nextPhase?.start_date != null ? new Date(nextPhase.start_date * 1000) : null
+  }, [nextPhase])
   const isSubscriptionCanceled = schedules[0]?.end_behavior === 'cancel'
 
   const modules = Object.values(openlaneProducts?.modules || {})

--- a/apps/console/src/lib/query-hooks/stripe.ts
+++ b/apps/console/src/lib/query-hooks/stripe.ts
@@ -1,4 +1,4 @@
-import { type InvoicesResponse, type OpenlaneProductsResponse, type SubscriptionSchedulesResponse, type UpcomingInvoiceResponse } from '@/types/stripe'
+import { type InvoicesResponse, type OpenlaneProductsResponse, type Subscription, type SubscriptionSchedulesResponse, type UpcomingInvoiceResponse } from '@/types/stripe'
 import { openlaneAPIUrl } from '@repo/dally/auth'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
@@ -151,6 +151,19 @@ export function useOpenlaneProductsQuery(includeBeta: boolean = false) {
 
       return res.json() as Promise<OpenlaneProductsResponse>
     },
+  })
+}
+
+export function useSubscriptionQuery(customerId?: string | null) {
+  return useQuery<Subscription | null>({
+    queryKey: ['stripe-subscription', customerId],
+    queryFn: async () => {
+      if (!customerId) return null
+      const res = await fetch(`/api/stripe/subscription?customer=${customerId}`)
+      if (!res.ok) throw new Error('Failed to fetch subscription')
+      return res.json() as Promise<Subscription | null>
+    },
+    enabled: !!customerId,
   })
 }
 


### PR DESCRIPTION
the way all our subscriptions are setup today, after the trial ends the next phase is there for a month and then the scheduled is "released". This breaks a key assumption. This change will allow the correct data to show; looking to see if we need any other updates next. 