### PR TITLE
trust center nda needs to filter on kind

### DIFF
--- a/apps/console/next-env.d.ts
+++ b/apps/console/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/console/src/lib/graphql-hooks/trust-center-nda-request.ts
+++ b/apps/console/src/lib/graphql-hooks/trust-center-nda-request.ts
@@ -29,6 +29,7 @@ import {
   type UpdateTrustCenterNdaRequestMutationVariables,
   type DeleteBulkTrustCenterNdaRequestMutation,
   type DeleteBulkTrustCenterNdaRequestMutationVariables,
+  TemplateTemplateKind,
 } from '@repo/codegen/src/schema'
 import { fetchGraphQLWithUpload } from '../fetchGraphql'
 import { type TPagination } from '@repo/ui/pagination-types'
@@ -36,11 +37,15 @@ import { type TPagination } from '@repo/ui/pagination-types'
 export const useGetTrustCenterNDAFiles = (enabled = true) => {
   const { client } = useGraphQLClient()
 
+  const templateWhere = {
+    kind: TemplateTemplateKind.TRUSTCENTER_NDA,
+  }
+
   const queryResult = useQuery<GetTrustCenterNdaFilesQuery>({
     queryKey: ['trustCenterNdaFiles'],
     queryFn: () =>
       client.request<GetTrustCenterNdaFilesQuery>(GET_ALL_TRUST_CENTER_NDA_FILES, {
-        where: {},
+        templateWhere,
       }),
     enabled,
   })
@@ -106,16 +111,18 @@ export const useUpdateTrustCenterNdaRequest = () => {
 export const useGetNDAStats = ({ ndaApprovalRequired, enabled = true }: { ndaApprovalRequired: boolean; enabled: boolean }) => {
   const { client } = useGraphQLClient()
 
-  const thirtyDaysAgo = new Date()
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
-
-  const variables: GetNdaRequestCountQueryVariables = {
-    where: ndaApprovalRequired ? { status: TrustCenterNdaRequestTrustCenterNdaRequestStatus.NEEDS_APPROVAL } : { createdAtGTE: thirtyDaysAgo.toISOString() },
-  }
-
   const queryResult = useQuery<GetNdaRequestCountQuery>({
     queryKey: ['ndaRequestsCount', ndaApprovalRequired],
-    queryFn: () => client.request<GetNdaRequestCountQuery>(GET_NDA_REQUESTS_COUNT, variables),
+    queryFn: () => {
+      const thirtyDaysAgo = new Date()
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+
+      const variables: GetNdaRequestCountQueryVariables = {
+        where: ndaApprovalRequired ? { status: TrustCenterNdaRequestTrustCenterNdaRequestStatus.NEEDS_APPROVAL } : { createdAtGTE: thirtyDaysAgo.toISOString() },
+      }
+
+      return client.request<GetNdaRequestCountQuery>(GET_NDA_REQUESTS_COUNT, variables)
+    },
     enabled,
   })
 

--- a/apps/console/src/lib/graphql-hooks/trust-center-nda-request.ts
+++ b/apps/console/src/lib/graphql-hooks/trust-center-nda-request.ts
@@ -45,7 +45,7 @@ export const useGetTrustCenterNDAFiles = (enabled = true) => {
     queryKey: ['trustCenterNdaFiles'],
     queryFn: () =>
       client.request<GetTrustCenterNdaFilesQuery>(GET_ALL_TRUST_CENTER_NDA_FILES, {
-        templateWhere,
+        where: templateWhere,
       }),
     enabled,
   })

--- a/apps/storybook/src/__mocks__/next-auth-react.ts
+++ b/apps/storybook/src/__mocks__/next-auth-react.ts
@@ -8,6 +8,10 @@ export function useSession() {
   }
 }
 
+export async function getSession() {
+  return null
+}
+
 export function SessionProvider({ children }: { children: React.ReactNode }): React.ReactNode {
   return children
 }


### PR DESCRIPTION
Query was not filtering on the kind, and so if an org had any newer non-trust center templates the nda would no longer show, and adding a new one would get a constraint error. 
<img width="1260" height="359" alt="image" src="https://github.com/user-attachments/assets/816e746d-7e92-490e-84e8-21bb3a49f65a" />
