### PR TITLE
Support more document upload types for trustcenter documents

### DIFF
--- a/apps/console/src/components/pages/protected/trust-center/reports-and-certifications/sheet/form-fields/file-field.tsx
+++ b/apps/console/src/components/pages/protected/trust-center/reports-and-certifications/sheet/form-fields/file-field.tsx
@@ -13,6 +13,9 @@ interface Props {
   uploadedFile?: File | null
 }
 
+const acceptedFileTypes = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document']
+const acceptedFileTypesShort = ['pdf', 'docx', 'jpeg', 'png', 'webp']
+
 export const FileField = ({ onFileUpload, uploadedFile }: Props) => {
   const {
     formState: { errors },
@@ -49,7 +52,7 @@ export const FileField = ({ onFileUpload, uploadedFile }: Props) => {
           </Card>
         </>
       ) : (
-        <FileUpload onFileUpload={onFileUpload} maxFileSizeInMb={10} acceptedFileTypes={['application/pdf']} acceptedFileTypesShort={['PDF']} multipleFiles={false} />
+        <FileUpload onFileUpload={onFileUpload} maxFileSizeInMb={10} acceptedFileTypes={acceptedFileTypes} acceptedFileTypesShort={acceptedFileTypesShort} multipleFiles={false} />
       )}
 
       {errors.file && <p className="text-red-500 text-sm mt-1">{String(errors.file.message)}</p>}


### PR DESCRIPTION
<img width="836" height="405" alt="CleanShot 2026-06-02 at 14 10 22" src="https://github.com/user-attachments/assets/1b15721c-0a35-4024-8d7b-fe25eb8c6e0f" />
