### PR TITLE
fix: enforce React and ReactDOM version parity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "openlane-ui",
@@ -206,7 +205,7 @@
         "@types/node": "latest",
         "dotenv": "latest",
         "eslint": "^10.0.0",
-        "react": "latest",
+        "react": "19.2.7",
         "swr": "latest",
         "tsup": "latest",
         "typescript": "^6.0.3",
@@ -393,6 +392,7 @@
     "postcss": "^8.5.16",
     "protobufjs": "^7.6.5",
     "react": "19.2.7",
+    "react-dom": "19.2.7",
     "shell-quote": "^1.9.0",
     "undici": "^6.27.0",
     "vite": "^8.1.4",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "build": "turbo build",
+    "build": "bun run check:react-versions && turbo build",
+    "check:react-versions": "node scripts/check-react-versions.mjs",
     "dev": "turbo dev --parallel",
     "debug": "turbo debug",
     "type-check": "turbo type-check",
     "clean": "rm -rf node_modules/** && rm -rf ./apps/console/.next && rm -rf ./apps/console/node_modules && rm -rf ./apps/storybook/.next && rm -rf ./apps/storybook/node_modules &&  rm -rf ./packages/*/node_modules",
     "turbo-clean": "turbo clean",
     "lint": "turbo run lint",
+    "test:react-versions": "node --test scripts/check-react-versions.test.mjs",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prepare": "husky"
   },
@@ -48,6 +50,7 @@
   ],
   "resolutions": {
     "react": "19.2.7",
+    "react-dom": "19.2.7",
     "node-fetch": "^3.3.2",
     "protobufjs": "^7.6.5",
     "shell-quote": "^1.9.0",

--- a/packages/dally/package.json
+++ b/packages/dally/package.json
@@ -27,7 +27,7 @@
     "@types/node": "latest",
     "@types/eslint": "latest",
     "eslint": "^10.0.0",
-    "react": "latest",
+    "react": "19.2.7",
     "tsup": "latest",
     "typescript": "^6.0.3"
   }

--- a/scripts/check-react-versions.mjs
+++ b/scripts/check-react-versions.mjs
@@ -1,0 +1,115 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const REACT_PACKAGES = ['react', 'react-dom']
+const INSTALLED_DEPENDENCY_SECTIONS = ['dependencies', 'devDependencies', 'optionalDependencies']
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+
+export const getReactVersionErrors = ({ rootManifest, workspaceManifests, installedVersions }) => {
+  const errors = []
+  const pinnedReact = rootManifest.resolutions?.react
+  const pinnedReactDOM = rootManifest.resolutions?.['react-dom']
+
+  if (!EXACT_VERSION.test(pinnedReact ?? '')) {
+    errors.push('package.json resolutions.react must be an exact version')
+  }
+
+  if (!EXACT_VERSION.test(pinnedReactDOM ?? '')) {
+    errors.push('package.json resolutions.react-dom must be an exact version')
+  }
+
+  if (pinnedReact && pinnedReactDOM && pinnedReact !== pinnedReactDOM) {
+    errors.push(`package.json resolutions mismatch: react=${pinnedReact}, react-dom=${pinnedReactDOM}`)
+  }
+
+  const manifests = [{ path: 'package.json', manifest: rootManifest }, ...workspaceManifests]
+
+  for (const { path, manifest } of manifests) {
+    for (const section of INSTALLED_DEPENDENCY_SECTIONS) {
+      for (const packageName of REACT_PACKAGES) {
+        const declaredVersion = manifest[section]?.[packageName]
+
+        if (declaredVersion && pinnedReact && declaredVersion !== pinnedReact) {
+          errors.push(`${path} ${section}.${packageName}=${declaredVersion}, expected ${pinnedReact}`)
+        }
+      }
+    }
+
+    for (const packageName of REACT_PACKAGES) {
+      const peerVersion = manifest.peerDependencies?.[packageName]
+
+      if (peerVersion && EXACT_VERSION.test(peerVersion) && pinnedReact && peerVersion !== pinnedReact) {
+        errors.push(`${path} peerDependencies.${packageName}=${peerVersion}, expected ${pinnedReact}`)
+      }
+    }
+  }
+
+  for (const packageName of REACT_PACKAGES) {
+    const installedVersion = installedVersions[packageName]
+
+    if (!installedVersion) {
+      errors.push(`node_modules/${packageName} is not installed at the workspace root`)
+    } else if (pinnedReact && installedVersion !== pinnedReact) {
+      errors.push(`installed ${packageName}=${installedVersion}, expected ${pinnedReact}`)
+    }
+  }
+
+  return errors
+}
+
+const readJson = async (path) => JSON.parse(await readFile(path, 'utf8'))
+
+const readWorkspaceManifests = async (rootDirectory, workspacePatterns) => {
+  const manifests = []
+
+  for (const pattern of workspacePatterns) {
+    if (!pattern.endsWith('/*')) throw new Error(`Unsupported workspace pattern: ${pattern}`)
+
+    const workspaceRoot = join(rootDirectory, pattern.slice(0, -2))
+    const entries = await readdir(workspaceRoot, { withFileTypes: true })
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+
+      const relativePath = join(pattern.slice(0, -2), entry.name, 'package.json')
+      manifests.push({ path: relativePath, manifest: await readJson(join(rootDirectory, relativePath)) })
+    }
+  }
+
+  return manifests
+}
+
+const readInstalledVersions = async (rootDirectory) => {
+  const versions = {}
+
+  for (const packageName of REACT_PACKAGES) {
+    try {
+      versions[packageName] = (await readJson(join(rootDirectory, 'node_modules', packageName, 'package.json'))).version
+    } catch {
+      versions[packageName] = null
+    }
+  }
+
+  return versions
+}
+
+const main = async () => {
+  const rootDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  const rootManifest = await readJson(join(rootDirectory, 'package.json'))
+  const workspaceManifests = await readWorkspaceManifests(rootDirectory, rootManifest.workspaces)
+  const installedVersions = await readInstalledVersions(rootDirectory)
+  const errors = getReactVersionErrors({ rootManifest, workspaceManifests, installedVersions })
+
+  if (errors.length) {
+    console.error(['React version validation failed:', ...errors.map((error) => `- ${error}`)].join('\n'))
+    process.exitCode = 1
+    return
+  }
+
+  console.log(`React and ReactDOM are aligned at ${rootManifest.resolutions.react}.`)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  await main()
+}

--- a/scripts/check-react-versions.test.mjs
+++ b/scripts/check-react-versions.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getReactVersionErrors } from './check-react-versions.mjs'
+
+const validInput = () => ({
+  rootManifest: {
+    resolutions: { react: '19.2.7', 'react-dom': '19.2.7' },
+    peerDependencies: { react: '19.2.7', 'react-dom': '19.2.7' },
+  },
+  workspaceManifests: [
+    {
+      path: 'apps/console/package.json',
+      manifest: { dependencies: { react: '19.2.7', 'react-dom': '19.2.7' } },
+    },
+  ],
+  installedVersions: { react: '19.2.7', 'react-dom': '19.2.7' },
+})
+
+test('accepts aligned React and ReactDOM versions', () => {
+  assert.deepEqual(getReactVersionErrors(validInput()), [])
+})
+
+test('rejects mismatched root resolutions', () => {
+  const input = validInput()
+  input.rootManifest.resolutions['react-dom'] = '19.2.6'
+
+  assert.ok(getReactVersionErrors(input).some((error) => error.includes('resolutions mismatch')))
+})
+
+test('rejects a drifting workspace dependency', () => {
+  const input = validInput()
+  input.workspaceManifests[0].manifest.dependencies['react-dom'] = '19.2.6'
+
+  assert.ok(getReactVersionErrors(input).some((error) => error.includes('apps/console/package.json')))
+})
+
+test('rejects mismatched installed packages', () => {
+  const input = validInput()
+  input.installedVersions['react-dom'] = '19.2.6'
+
+  assert.ok(getReactVersionErrors(input).some((error) => error.includes('installed react-dom=19.2.6')))
+})


### PR DESCRIPTION
## Problem

The workspace pins React through the root Bun resolution but does not pin ReactDOM there. Bun can therefore hoist different React and ReactDOM patch versions at the workspace root, which causes ReactDOM to abort at runtime with an incompatible React versions error.

## Fix

- Pin both `react` and `react-dom` to `19.2.7` in root resolutions.
- Pin the Dally workspace's installed React development dependency to the same version.
- Validate root resolutions, workspace dependency declarations, and actually installed root package versions.
- Run that validation before every root build.
- Regenerate `bun.lock` with the repository-pinned Bun `1.2.16`.

## Validation

- `bun run check:react-versions`
- `bun run test:react-versions` (four positive and negative cases)
- `bunx prettier --check package.json packages/dally/package.json scripts/check-react-versions.mjs scripts/check-react-versions.test.mjs`
- `git diff --check`

Note: the repository's existing root `bun run type-check` currently fails before checking source because Turbo reports that no `type-check` task exists.