### PR TITLE
fix: prevent duplicate OIDC callback submission

### DIFF
--- a/apps/console/src/app/(auth)/login/sso/page.tsx
+++ b/apps/console/src/app/(auth)/login/sso/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { signIn } from 'next-auth/react'
 import { getCookie } from '@/lib/auth/utils/getCookie'
 import { sanitizeLoginRedirect } from '@/lib/auth/utils/redirect'
+import { runSSOCallbackOnce } from './run-sso-callback-once'
 
 const ORG_SETTINGS_URL = '/organization-settings/authentication'
 const LOGIN_URL = '/login'
@@ -12,6 +13,7 @@ const LOGIN_URL = '/login'
 const SSOCallbackPage: React.FC = () => {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const callbackStartedRef = useRef(false)
 
   const getRedirectUrl = (error?: string, isSuccess = false) => {
     const isTesting = localStorage.getItem('testing_sso')
@@ -98,7 +100,7 @@ const SSOCallbackPage: React.FC = () => {
       }
     }
 
-    handleSSOCallback()
+    runSSOCallbackOnce(callbackStartedRef, handleSSOCallback)
   }, [router, searchParams])
 
   return (

--- a/apps/console/src/app/(auth)/login/sso/run-sso-callback-once.test.ts
+++ b/apps/console/src/app/(auth)/login/sso/run-sso-callback-once.test.ts
@@ -1,0 +1,13 @@
+import { runSSOCallbackOnce } from './run-sso-callback-once'
+
+describe('runSSOCallbackOnce', () => {
+  it('submits the SSO callback only once when the effect runs more than once', () => {
+    const guard = { current: false }
+    const submitCallback = jest.fn()
+
+    expect(runSSOCallbackOnce(guard, submitCallback)).toBe(true)
+    expect(runSSOCallbackOnce(guard, submitCallback)).toBe(false)
+
+    expect(submitCallback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/console/src/app/(auth)/login/sso/run-sso-callback-once.ts
+++ b/apps/console/src/app/(auth)/login/sso/run-sso-callback-once.ts
@@ -1,0 +1,9 @@
+type CallbackGuard = { current: boolean }
+
+export const runSSOCallbackOnce = (guard: CallbackGuard, callback: () => void | Promise<void>) => {
+  if (guard.current) return false
+
+  guard.current = true
+  void callback()
+  return true
+}


### PR DESCRIPTION
## Problem

The OIDC callback page runs its submission inside a React effect while React Strict Mode is enabled. If the effect runs more than once, the same single-use authorization code can be POSTed twice. The second request can fail with `sso_callback_failed` even when the first callback is already succeeding.

## Fix

- Claim a per-mount callback guard synchronously before starting the async callback.
- Ignore later effect executions for the same mounted callback page.
- Add regression coverage proving repeated invocations submit only once.

## Validation

- `npx -y bun@1.2.16 test 'apps/console/src/app/(auth)/login/sso/run-sso-callback-once.test.ts'`
- `bunx eslint --max-warnings=0` on the changed TypeScript files
- `bunx prettier --check` on the changed TypeScript files
- `git diff --check`