### PR TITLE
fix: enable scopes query

### DIFF
--- a/apps/console/src/lib/query-hooks/permissions.ts
+++ b/apps/console/src/lib/query-hooks/permissions.ts
@@ -80,12 +80,9 @@ export const useOrganizationRoles = () => {
 export const useScopes = () => {
   const { errorNotification } = useNotification()
   const fetchWithRetry = useFetchWithRetry()
-  const { data: session } = useSession()
-  const isImpersonation = !!session?.user?.isImpersonation
 
   const resp = useQuery<TScopesResponse>({
     queryKey: ['scopes'],
-    enabled: !isImpersonation,
     retry: shouldRetryPermission,
     queryFn: async () => {
       const res = await fetchWithRetry('/api/permissions/scopes', { method: 'GET' })


### PR DESCRIPTION
This just calls `v1/scopes` which pulls available scopes; shouldn't be a reason an impersonated user wouldn't be allow to do this