### PR TITLE
fix: Associated objects visibility in light mode (#2049)

### DIFF
--- a/apps/console/src/components/shared/object-association/association-section.tsx
+++ b/apps/console/src/components/shared/object-association/association-section.tsx
@@ -190,7 +190,7 @@ export const AssociationSection = <TConfig extends AssociationEntityConfig>({
         <PanelHeader heading="Associated Objects" noBorder />
         {isEditAllowed && entityId && <SetAssociationDialog config={config.dialogConfig} associationsData={associationsData} onUpdate={onUpdateEntity} />}
       </div>
-      <p className="text-sm text-muted">{`This shows objects directly associated with ${entityName}. This does not include objects linked by inheritance`}</p>
+      <p className="text-sm text-muted-foreground">{`This shows objects directly associated with ${entityName}. This does not include objects linked by inheritance`}</p>
       {hasSections && <AssociatedObjectsAccordion sections={sections} toggleAll={false} removable={isEditAllowed} onRemove={handleRemoveAssociation} />}
     </Panel>
   )


### PR DESCRIPTION
## Before

<img width="1556" height="280" alt="Screenshot 2026-08-08 at 09 18 22" src="https://github.com/user-attachments/assets/58607f72-fbaf-4f37-a96d-6c16c88e318d" />

## After

<img width="1390" height="376" alt="Screenshot 2026-08-08 at 09 47 14" src="https://github.com/user-attachments/assets/6a2e2291-5348-4968-816b-75720120a53e" />
<img width="1366" height="310" alt="Screenshot 2026-08-08 at 09 47 20" src="https://github.com/user-attachments/assets/1b1a1a89-8911-47f6-9581-2a466a2de205" />

## Verification

- Confirmed the helper text is readable in Storybook light mode.
- Confirmed the helper text remains readable in dark mode

Resolves: https://github.com/theopenlane/openlane-ui/issues/2049