### PR TITLE
feat: Collapse linked procedures on Policy page (#2048)

### DIFF
--- a/apps/console/src/components/pages/protected/policies/view/fields/linked-procedures.tsx
+++ b/apps/console/src/components/pages/protected/policies/view/fields/linked-procedures.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import React, { memo } from 'react'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@radix-ui/react-accordion'
 import usePlateEditor from '@/components/shared/plate/usePlateEditor.tsx'
-import { type GetInternalPolicyAssociationsByIdQuery } from '@repo/codegen/src/schema.ts'
-import { AlignLeft, Clock, User } from 'lucide-react'
+import { Avatar } from '@/components/shared/avatar/avatar'
+import { DocumentStatusBadge } from '@/components/shared/enum-mapper/policy-enum'
+import { type GetInternalPolicyAssociationsByIdQuery, type Group } from '@repo/codegen/src/schema.ts'
+import { AlignLeft, ChevronDown, Clock, User } from 'lucide-react'
 
 type ProcedureEdges = NonNullable<NonNullable<GetInternalPolicyAssociationsByIdQuery['internalPolicy']>['procedures']>['edges']
 
@@ -13,49 +16,95 @@ type LinkedProceduresProps = {
 
 type ProcedureNode = NonNullable<NonNullable<ProcedureEdges>[number]>['node']
 
-const ProcedureItem = memo(({ node }: { node: NonNullable<ProcedureNode> }) => {
-  const { convertToReadOnly } = usePlateEditor()
+const ProcedureItem = memo(
+  ({ node, showName = true, showApprover = false, showDivider = true }: { node: NonNullable<ProcedureNode>; showName?: boolean; showApprover?: boolean; showDivider?: boolean }) => {
+    const { convertToReadOnly } = usePlateEditor()
+    const metadataLabelClassName = `flex items-center gap-2 text-muted-foreground${showApprover ? ' text-sm' : ''}`
+    const metadataIconSize = showApprover ? 14 : 16
+    const fieldSpacingClassName = showApprover ? 'space-y-1' : 'space-y-3'
+    const contentSpacingClassName = 'space-y-3'
 
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-2 text-muted-foreground">
-        <User size={16} />
-        <span>Name</span>
+    return (
+      <div className={contentSpacingClassName}>
+        {showName && (
+          <div className={fieldSpacingClassName}>
+            <div className={metadataLabelClassName}>
+              <User size={metadataIconSize} />
+              <span>Name</span>
+            </div>
+            <p>{node.name}</p>
+          </div>
+        )}
+
+        {showApprover && node.approver && (
+          <div className={fieldSpacingClassName}>
+            <div className={metadataLabelClassName}>
+              <User size={metadataIconSize} />
+              <span>Approver</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Avatar entity={node.approver as Group} variant="small" className="h-4 w-4 text-xs" />
+              <span>{node.approver.displayName}</span>
+            </div>
+          </div>
+        )}
+
+        <div className={fieldSpacingClassName}>
+          <div className={metadataLabelClassName}>
+            <Clock size={metadataIconSize} />
+            <span>Type</span>
+          </div>
+          <p>{node.procedureKindName || 'Procedure'}</p>
+        </div>
+
+        <div className={fieldSpacingClassName}>
+          <div className={metadataLabelClassName}>
+            <AlignLeft size={metadataIconSize} />
+            <span>Description</span>
+          </div>
+          <div className="min-h-5">{convertToReadOnly(node.detailsJSON ? node.detailsJSON : (node.details ?? ''))}</div>
+        </div>
+
+        {showDivider && <hr className="border-border mt-4" />}
       </div>
-      <p>{node.name}</p>
-
-      <div className="flex items-center gap-2 text-muted-foreground">
-        <Clock size={16} />
-        <span>Type</span>
-      </div>
-      <p>{node.procedureKindName || 'Procedure'}</p>
-
-      <div className="flex items-center gap-2 text-muted-foreground">
-        <AlignLeft size={16} />
-        <span>Description</span>
-      </div>
-      <div className="min-h-5">{convertToReadOnly(node.detailsJSON ? node.detailsJSON : (node.details ?? ''))}</div>
-
-      <hr className="border-border mt-4" />
-    </div>
-  )
-})
+    )
+  },
+)
 
 ProcedureItem.displayName = 'ProcedureItem'
 
 const LinkedProcedures: React.FC<LinkedProceduresProps> = ({ procedures }) => {
-  if (!procedures || procedures.length === 0) {
+  const nodes = procedures?.flatMap((edge) => (edge?.node ? [edge.node] : [])) ?? []
+
+  if (nodes.length === 0) {
     return <p className="text-muted-foreground py-4">No procedures linked to this policy.</p>
   }
 
   return (
     <div className="space-y-6 py-4">
       <h2 className="text-xl font-semibold">Linked Procedures</h2>
-      {procedures.map((edge) => {
-        const node = edge?.node
-        if (!node) return null
-        return <ProcedureItem key={node.id} node={node} />
-      })}
+      {nodes.length === 1 ? (
+        <ProcedureItem node={nodes[0]} />
+      ) : (
+        <Accordion type="multiple" className="w-full space-y-2">
+          {nodes.map((node) => (
+            <AccordionItem key={node.id} value={node.id} className="rounded-lg border border-border px-4">
+              <AccordionTrigger asChild>
+                <button className="group flex w-full items-center justify-between gap-4 py-3 text-left">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <ChevronDown className="h-4 w-4 shrink-0 text-primary transition-transform group-data-[state=closed]:-rotate-90" />
+                    <span className="truncate font-medium">{node.name}</span>
+                  </div>
+                  {node.status && <DocumentStatusBadge status={node.status} />}
+                </button>
+              </AccordionTrigger>
+              <AccordionContent className="overflow-hidden pb-4 data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up">
+                <ProcedureItem node={node} showName={false} showApprover showDivider={false} />
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      )}
     </div>
   )
 }

--- a/packages/codegen/query/internal-policy.ts
+++ b/packages/codegen/query/internal-policy.ts
@@ -246,6 +246,16 @@ export const GET_INTERNAL_POLICY_ASSOCIATIONS_BY_ID = gql`
             displayID
             summary
             procedureKindName
+            status
+            approver {
+              id
+              displayName
+              gravatarLogoURL
+              logoURL
+              avatarFile {
+                base64
+              }
+            }
             details
             detailsJSON
           }

--- a/packages/codegen/src/historyschema.ts
+++ b/packages/codegen/src/historyschema.ts
@@ -113750,8 +113750,17 @@ export type GetInternalPolicyAssociationsByIdQuery = {
           displayID: string
           summary?: string | null
           procedureKindName?: string | null
+          status?: ProcedureDocumentStatus | null
           details?: string | null
           detailsJSON?: Array<any> | null
+          approver?: {
+            __typename?: 'Group'
+            id: string
+            displayName: string
+            gravatarLogoURL?: string | null
+            logoURL?: string | null
+            avatarFile?: { __typename?: 'File'; base64?: string | null } | null
+          } | null
         } | null
       } | null> | null
     }

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -77050,8 +77050,17 @@ export type GetInternalPolicyAssociationsByIdQuery = {
           displayID: string
           summary?: string | null
           procedureKindName?: string | null
+          status?: ProcedureDocumentStatus | null
           details?: string | null
           detailsJSON?: Array<any> | null
+          approver?: {
+            __typename?: 'Group'
+            id: string
+            displayName: string
+            gravatarLogoURL?: string | null
+            logoURL?: string | null
+            avatarFile?: { __typename?: 'File'; base64?: string | null } | null
+          } | null
         } | null
       } | null> | null
     }


### PR DESCRIPTION
## Summary

- Preserve the existing non-collapsible view when only one procedure is linked.
- Collapse linked procedures by default when a policy has multiple procedures.
- Show each procedure's name and status in the collapsed header.
- Show approver, type, and description when expanded.

## Screenshots

### Single Procedure
<img width="1732" height="1202" alt="Screenshot 2026-08-08 at 13 17 00" src="https://github.com/user-attachments/assets/867675bd-6dee-473b-92e5-c2693d3d9d72" />

### Multiple Procedures
<img width="1630" height="908" alt="Screenshot 2026-08-08 at 13 16 52" src="https://github.com/user-attachments/assets/7f711904-bfd7-4d57-8a83-bb332fa8f4b0" />
<img width="1752" height="1300" alt="Screenshot 2026-08-08 at 13 16 45" src="https://github.com/user-attachments/assets/55f4566e-d368-4387-a729-1da547e33252" />

### No Proc
<img width="1648" height="812" alt="Screenshot 2026-08-08 at 13 17 07" src="https://github.com/user-attachments/assets/61addb31-abed-4a0b-b9a8-1556395837d1" />
edure

Resolves: https://github.com/theopenlane/openlane-ui/issues/2048