### PR TITLE
fix: nest IdIn query

### DIFF
--- a/apps/console/src/components/pages/protected/controls/table/controls-table.tsx
+++ b/apps/console/src/components/pages/protected/controls/table/controls-table.tsx
@@ -107,10 +107,6 @@ const ControlsTable: React.FC<TControlsTableProps> = ({ active, setActive }) => 
         }
       }
 
-      if (key === 'hasProgramsWith') {
-        return { hasProgramsWith: [{ idIn: value }] } as ControlWhereInput
-      }
-
       return { [key]: value } as ControlWhereInput
     })
 

--- a/apps/console/src/components/pages/protected/controls/tabs/documentation/policies-table.tsx
+++ b/apps/console/src/components/pages/protected/controls/tabs/documentation/policies-table.tsx
@@ -57,9 +57,6 @@ const PoliciesTable: React.FC<PoliciesTableProps> = ({ controlId, subcontrolIds,
       if (key === 'hasControlsWith' || key === 'hasSubcontrolsWith') {
         return {} as InternalPolicyWhereInput
       }
-      if (key === 'hasProgramsWith') {
-        return { hasProgramsWith: [{ idIn: value }] } as InternalPolicyWhereInput
-      }
       return { [key]: value }
     })
 

--- a/apps/console/src/components/pages/protected/controls/tabs/documentation/procedures-table.tsx
+++ b/apps/console/src/components/pages/protected/controls/tabs/documentation/procedures-table.tsx
@@ -57,9 +57,6 @@ const ProceduresTable: React.FC<ProceduresTableProps> = ({ controlId, subcontrol
       if (key === 'hasControlsWith') {
         return { hasControlsWith: [{ refCodeContainsFold: value as string }] } as ProcedureWhereInput
       }
-      if (key === 'hasProgramsWith') {
-        return { hasProgramsWith: [{ idIn: value }] } as ProcedureWhereInput
-      }
       if (key === 'hasSubcontrolsWith') {
         return { hasSubcontrolsWith: [{ refCodeContainsFold: value as string }] } as ProcedureWhereInput
       }

--- a/apps/console/src/components/pages/protected/policies/table/policies-table.tsx
+++ b/apps/console/src/components/pages/protected/policies/table/policies-table.tsx
@@ -57,10 +57,6 @@ export const PoliciesTable = () => {
         return { hasControlsWith: [{ refCodeContainsFold: value as string }] }
       }
 
-      if (key === 'hasProgramsWith') {
-        return { hasProgramsWith: [{ idIn: value }] } as InternalPolicyWhereInput
-      }
-
       if (key === 'hasSubcontrolsWith') {
         return { hasSubcontrolsWith: [{ refCodeContainsFold: value as string }] }
       }

--- a/apps/console/src/components/pages/protected/procedures/table/procedures-table.tsx
+++ b/apps/console/src/components/pages/protected/procedures/table/procedures-table.tsx
@@ -54,10 +54,6 @@ export const ProceduresTable = () => {
         return { hasControlsWith: [{ refCodeContainsFold: value as string }] } as ProcedureWhereInput
       }
 
-      if (key === 'hasProgramsWith') {
-        return { hasProgramsWith: [{ idIn: value }] } as ProcedureWhereInput
-      }
-
       if (key === 'hasSubcontrolsWith') {
         return { hasSubcontrolsWith: [{ refCodeContainsFold: value as string }] } as ProcedureWhereInput
       }

--- a/apps/console/src/components/pages/protected/risks/table/risk-table.tsx
+++ b/apps/console/src/components/pages/protected/risks/table/risk-table.tsx
@@ -68,10 +68,6 @@ const RiskTable: React.FC = () => {
 
   const where = useMemo(() => {
     const result = whereGenerator<RiskWhereInput>(filters, (key, value) => {
-      if (key === 'hasProgramsWith') {
-        return { hasProgramsWith: [{ idIn: value }] } as RiskWhereInput
-      }
-
       return { [key]: value } as RiskWhereInput
     })
 

--- a/apps/console/src/components/pages/protected/tasks/table/tasks-page.tsx
+++ b/apps/console/src/components/pages/protected/tasks/table/tasks-page.tsx
@@ -75,9 +75,6 @@ const TasksPage: React.FC = () => {
   const whereFilter = useMemo(() => {
     const result = filters
       ? whereGenerator<TaskWhereInput>(filters, (key, value) => {
-          if (key === 'hasProgramsWith') {
-            return { hasProgramsWith: [{ idIn: value }] } as TaskWhereInput
-          }
           return { [key]: value } as TaskWhereInput
         })
       : {}


### PR DESCRIPTION
The table helper has:
```
  if (key.endsWith('With')) {
          andConditions.push({ [key]: [{ idIn: valuesArray }] } as Condition)
        } 
 ```

Which is causing a nested `IdIn`:

```
 {
        "hasProgramsWith": [
          {
            "idIn": [
              {
                "idIn": [
                  "01KZEVA5PP6VD59BT9MMBKNEJ5"
                ]
              }
            ]
          }
        ]
      }
    ],
```

Removing the conditional allows it fallback and use the value directly