### PR TITLE
fix(auth): stop a single 401 from revoking a live session

### DIFF
--- a/apps/console/src/app/api/auth/sso/route.ts
+++ b/apps/console/src/app/api/auth/sso/route.ts
@@ -1,14 +1,12 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { secureFetch } from '@/lib/auth/utils/secure-fetch'
 import { parseAndSetResponseCookies } from '@/lib/auth/utils/parse-response-cookies'
-import { isSSOLoginPath } from '@/lib/auth/utils/sso-required'
 
-const DEFAULT_SSO_LOGIN_PATH = '/v1/sso/login'
+const SSO_LOGIN_PATH = '/v1/sso/login'
 
 interface SSOLoginRequest {
   organization_id: string
   is_test?: boolean
-  sso_login_path?: string
 }
 
 // is_test cookie is for sso being tested before enforcement
@@ -21,13 +19,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'organization_id is required' }, { status: 400 })
     }
 
-    const { sso_login_path: requestedLoginPath, ...ssoLoginPayload } = body
-    const loginPath = requestedLoginPath && isSSOLoginPath(requestedLoginPath) ? requestedLoginPath : DEFAULT_SSO_LOGIN_PATH
-
-    const ssoData = await secureFetch(`${process.env.API_REST_URL}${loginPath}`, {
+    const ssoData = await secureFetch(`${process.env.API_REST_URL}${SSO_LOGIN_PATH}`, {
       method: 'POST',
       body: JSON.stringify({
-        ...ssoLoginPayload,
+        organization_id: body.organization_id,
+        ...(body.is_test !== undefined && { is_test: body.is_test }),
       }),
     })
 

--- a/apps/console/src/app/api/auth/sso/route.ts
+++ b/apps/console/src/app/api/auth/sso/route.ts
@@ -1,10 +1,14 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { secureFetch } from '@/lib/auth/utils/secure-fetch'
 import { parseAndSetResponseCookies } from '@/lib/auth/utils/parse-response-cookies'
+import { isSSOLoginPath } from '@/lib/auth/utils/sso-required'
+
+const DEFAULT_SSO_LOGIN_PATH = '/v1/sso/login'
 
 interface SSOLoginRequest {
   organization_id: string
   is_test?: boolean
+  sso_login_path?: string
 }
 
 // is_test cookie is for sso being tested before enforcement
@@ -17,10 +21,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'organization_id is required' }, { status: 400 })
     }
 
-    const ssoData = await secureFetch(`${process.env.API_REST_URL}/v1/sso/login`, {
+    const { sso_login_path: requestedLoginPath, ...ssoLoginPayload } = body
+    const loginPath = requestedLoginPath && isSSOLoginPath(requestedLoginPath) ? requestedLoginPath : DEFAULT_SSO_LOGIN_PATH
+
+    const ssoData = await secureFetch(`${process.env.API_REST_URL}${loginPath}`, {
       method: 'POST',
       body: JSON.stringify({
-        ...body,
+        ...ssoLoginPayload,
       }),
     })
 

--- a/apps/console/src/components/layouts/dashboard/dashboard.tsx
+++ b/apps/console/src/components/layouts/dashboard/dashboard.tsx
@@ -9,6 +9,8 @@ import { useElementHeight } from '@/hooks/useElementHeight'
 import SessionExpiredModal from '@/components/shared/session-expired-modal/session-expired-modal'
 import { useSession } from 'next-auth/react'
 import { useSessionExpiry } from '@/hooks/useSessionExpiry'
+import { useSSOReauth } from '@/hooks/useSSOReauth'
+import SSORequiredModal from '@/components/shared/sso-required-modal/sso-required-modal'
 import { bottomNavigationItems, personalNavigationItems, topNavigationItems } from '@/routes/dashboard'
 import Sidebar from '@/components/shared/sidebar/sidebar'
 import { type NavHeading, type NavItem, type Separator } from '@/types'
@@ -34,6 +36,7 @@ export interface DashboardLayoutProps {
 export function DashboardLayout({ children, error }: DashboardLayoutProps) {
   const { base, main } = dashboardStyles()
   const { showSessionExpiredModal } = useSessionExpiry()
+  const { ssoRequirement } = useSSOReauth()
   const { data: sessionData } = useSession()
   const { data: orgPermission } = useOrganizationRoles()
   const { role: currentUserRole } = useCurrentUserRole()
@@ -106,7 +109,8 @@ export function DashboardLayout({ children, error }: DashboardLayoutProps) {
               <ImpersonationBanner />
             </div>
 
-            <SessionExpiredModal open={showSessionExpiredModal} />
+            <SSORequiredModal requirement={ssoRequirement} />
+            <SessionExpiredModal open={showSessionExpiredModal && !ssoRequirement} />
             <Sidebar
               navItems={navItems}
               footerNavItems={footerNavItems}

--- a/apps/console/src/components/shared/session-expired-modal/session-expired-modal.tsx
+++ b/apps/console/src/components/shared/session-expired-modal/session-expired-modal.tsx
@@ -34,13 +34,9 @@ const SessionExpiredModal = ({ open }: SessionExpiredModalProps) => {
       return
     }
 
-    // The modal is a terminal state: reaching it means the console cannot
-    // establish a renewable session, so the session is torn down server-side
-    // (auth.ts events.signOut -> POST /v1/logout) rather than only cleared
-    // locally. That is only safe because the paths that raise it are now
-    // narrow — refresh-token.ts and session-health.ts classify infrastructure
-    // failures as `unavailable`, so a transient 401/403/5xx can no longer end
-    // up here. The ref keeps a rerender from revoking twice.
+    // Reaching this modal is terminal: the session is torn down server-side
+    // (auth.ts events.signOut -> POST /v1/logout), not just cleared locally.
+    // The ref keeps a rerender from revoking twice.
     if (!automaticSignOutStartedRef.current) {
       automaticSignOutStartedRef.current = true
       markSessionExpired()

--- a/apps/console/src/components/shared/session-expired-modal/session-expired-modal.tsx
+++ b/apps/console/src/components/shared/session-expired-modal/session-expired-modal.tsx
@@ -4,7 +4,7 @@ import { usePathname, useSearchParams } from 'next/navigation'
 import { Dialog, DialogContent } from '@repo/ui/dialog'
 import { Button } from '@repo/ui/button'
 import { Timer } from 'lucide-react'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { addHours, differenceInMilliseconds } from 'date-fns'
 import { signOut } from 'next-auth/react'
 import { markSessionExpired } from '@/lib/graphqlClient'
@@ -17,20 +17,36 @@ interface SessionExpiredModalProps {
 const SessionExpiredModal = ({ open }: SessionExpiredModalProps) => {
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const automaticSignOutStartedRef = useRef(false)
+
+  const signoutNoRedirect = async () => {
+    await signOut({ redirect: false })
+  }
 
   const handleSignOut = useCallback(async () => {
     const currentUrl = `${pathname}${searchParams.toString() ? `?${searchParams.toString()}` : ''}`
     await signOut({ redirect: true, redirectTo: buildLoginRedirect(currentUrl) })
   }, [pathname, searchParams])
 
-  const signoutNoRedirect = async () => {
-    await signOut({ redirect: false })
-  }
-
   useEffect(() => {
-    if (!open) return
-    markSessionExpired()
-    signoutNoRedirect()
+    if (!open) {
+      automaticSignOutStartedRef.current = false
+      return
+    }
+
+    // The modal is a terminal state: reaching it means the console cannot
+    // establish a renewable session, so the session is torn down server-side
+    // (auth.ts events.signOut -> POST /v1/logout) rather than only cleared
+    // locally. That is only safe because the paths that raise it are now
+    // narrow — refresh-token.ts and session-health.ts classify infrastructure
+    // failures as `unavailable`, so a transient 401/403/5xx can no longer end
+    // up here. The ref keeps a rerender from revoking twice.
+    if (!automaticSignOutStartedRef.current) {
+      automaticSignOutStartedRef.current = true
+      markSessionExpired()
+      void signoutNoRedirect()
+    }
+
     const now = new Date()
     const expireAt = addHours(now, 2)
     const timeoutDuration = differenceInMilliseconds(expireAt, now)

--- a/apps/console/src/components/shared/sso-required-modal/sso-required-modal.tsx
+++ b/apps/console/src/components/shared/sso-required-modal/sso-required-modal.tsx
@@ -23,7 +23,7 @@ const SSORequiredModal = ({ requirement }: SSORequiredModalProps) => {
     setLoading(true)
     setError(null)
 
-    const ssoConfig = await getSSORedirect(requirement.organizationId, requirement.ssoLoginPath)
+    const ssoConfig = await getSSORedirect(requirement.organizationId)
 
     if (!ssoConfig) {
       setError('We could not start single sign-on. Please try again.')

--- a/apps/console/src/components/shared/sso-required-modal/sso-required-modal.tsx
+++ b/apps/console/src/components/shared/sso-required-modal/sso-required-modal.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useState } from 'react'
+import { Dialog, DialogContent } from '@repo/ui/dialog'
+import { Button } from '@repo/ui/button'
+import { ArrowRightCircle, ShieldCheck } from 'lucide-react'
+import { getSSORedirect } from '@/lib/auth/utils/get-openlane-token'
+import { type SSORequirement } from '@/lib/auth/utils/sso-required'
+
+interface SSORequiredModalProps {
+  requirement: SSORequirement | null
+}
+
+const SSORequiredModal = ({ requirement }: SSORequiredModalProps) => {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleContinue = async () => {
+    if (!requirement) {
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    const ssoConfig = await getSSORedirect(requirement.organizationId, requirement.ssoLoginPath)
+
+    if (!ssoConfig) {
+      setError('We could not start single sign-on. Please try again.')
+      setLoading(false)
+      return
+    }
+
+    window.location.href = ssoConfig.redirect_uri
+  }
+
+  return (
+    <Dialog open={!!requirement}>
+      <DialogContent className="flex flex-col items-center justify-center gap-6 py-7 size-fit" showCloseButton={false}>
+        <ShieldCheck className="w-12 h-12" strokeWidth={1} />
+        <div className="text-center">
+          <h2 className="text-2xl font-semibold mb-2">Single sign-on required</h2>
+          <p className="text-sm max-w-xs mx-auto">Your organization requires single sign-on. Sign in again with your identity provider to continue.</p>
+          {error && <p className="text-sm text-red-600 mt-2">{error}</p>}
+        </div>
+        <Button variant="primary" onClick={handleContinue} disabled={loading}>
+          {loading ? (
+            'Redirecting...'
+          ) : (
+            <div className="flex items-center justify-center">
+              Continue with SSO
+              <ArrowRightCircle size={16} className="ml-2" />
+            </div>
+          )}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default SSORequiredModal

--- a/apps/console/src/hooks/useOnboardingQuestions.ts
+++ b/apps/console/src/hooks/useOnboardingQuestions.ts
@@ -1,11 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { type OnboardingQuestionsResponse, type OnboardingStep } from '@/lib/onboarding-questions/types'
+import { reportSSORequirementFromResponse } from '@/lib/auth/utils/session-status'
 
 const fetchOnboardingQuestions = async (): Promise<OnboardingQuestionsResponse> => {
   const response = await fetch('/api/onboarding/questions')
 
   if (!response.ok) {
+    await reportSSORequirementFromResponse(response)
     throw new Error('Failed to load onboarding questions')
   }
 

--- a/apps/console/src/hooks/useSSOReauth.ts
+++ b/apps/console/src/hooks/useSSOReauth.ts
@@ -1,0 +1,18 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { getSSORequirement, SSO_REAUTH_REQUIRED_EVENT } from '@/lib/auth/utils/session-status'
+import { type SSORequirement } from '@/lib/auth/utils/sso-required'
+
+export const useSSOReauth = () => {
+  const [ssoRequirement, setSSORequirement] = useState<SSORequirement | null>(getSSORequirement)
+
+  useEffect(() => {
+    const handler = () => setSSORequirement(getSSORequirement())
+
+    window.addEventListener(SSO_REAUTH_REQUIRED_EVENT, handler)
+    return () => window.removeEventListener(SSO_REAUTH_REQUIRED_EVENT, handler)
+  }, [])
+
+  return { ssoRequirement }
+}

--- a/apps/console/src/hooks/useSessionExpiry.ts
+++ b/apps/console/src/hooks/useSessionExpiry.ts
@@ -4,9 +4,11 @@ import { useEffect, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { jwtDecode } from 'jwt-decode'
 import { refreshTokens } from '@/lib/auth/utils/session-refresh'
+import { SessionUnavailableError } from '@/lib/auth/utils/session-health'
 import { getIsSessionInvalid } from '@/lib/auth/utils/session-status'
 
 const ACTIVITY_EVENTS: Array<keyof WindowEventMap> = ['keydown', 'mousemove', 'click', 'scroll', 'touchstart']
+const ACTIVITY_RETRY_BACKOFF_MS = 30_000
 
 interface RefreshTokenClaims {
   nbf?: number
@@ -63,13 +65,15 @@ export function useSessionExpiry() {
 
     let armed = false
     let inFlight = false
+    let nextAttemptAt = 0
 
     const onActivity = async () => {
-      if (!armed || inFlight) return
+      if (!armed || inFlight || Date.now() < nextAttemptAt) return
       inFlight = true
       try {
         await refreshTokens(token)
-      } catch {
+      } catch (error) {
+        nextAttemptAt = Date.now() + (error instanceof SessionUnavailableError ? error.retryAfterMs : ACTIVITY_RETRY_BACKOFF_MS)
         inFlight = false
       }
     }

--- a/apps/console/src/lib/auth/utils/core-api-request.ts
+++ b/apps/console/src/lib/auth/utils/core-api-request.ts
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers'
 import { csrfCookieName, openlaneAPIUrl } from '@repo/dally/auth'
 import { auth } from '../auth'
 import { secureFetch } from './secure-fetch'
+import { parseSSORequirement, type SSOUnauthorizedBody } from './sso-required'
 
 export const HTTP_METHODS = {
   GET: 'GET',
@@ -15,12 +16,22 @@ type HttpMethod = (typeof HTTP_METHODS)[keyof typeof HTTP_METHODS]
 
 const MAX_LOGGED_BODY_CHARS = 500
 
-const readBodyForLog = async (response: Response): Promise<string> => {
+const readBody = async (response: Response): Promise<string> => {
   try {
-    const text = await response.text()
-    return text.length > MAX_LOGGED_BODY_CHARS ? `${text.slice(0, MAX_LOGGED_BODY_CHARS)}…` : text
+    return await response.text()
   } catch {
     return '<unreadable>'
+  }
+}
+
+const truncateForLog = (body: string): string => (body.length > MAX_LOGGED_BODY_CHARS ? `${body.slice(0, MAX_LOGGED_BODY_CHARS)}…` : body)
+
+const parseUnauthorizedBody = (body: string): SSOUnauthorizedBody | null => {
+  try {
+    const parsed: SSOUnauthorizedBody = JSON.parse(body)
+    return parsed
+  } catch {
+    return null
   }
 }
 
@@ -62,6 +73,7 @@ export async function coreAPIRequest(route: string, method: HttpMethod, req?: Ne
       upstreamUrl,
       {
         method,
+        redirect: 'manual',
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
@@ -85,7 +97,27 @@ export async function coreAPIRequest(route: string, method: HttpMethod, req?: Ne
     throw error
   }
 
+  if (response.status >= 300 && response.status < 400) {
+    console.error(
+      '[coreAPIRequest] upstream redirect not followed',
+      JSON.stringify({
+        upstreamUrl,
+        method,
+        status: response.status,
+        location: response.headers.get('location'),
+        upstreamRequestId: response.headers.get('x-request-id'),
+        cfRay: response.headers.get('cf-ray'),
+        userId: session.user.userId,
+        durationMs: Date.now() - startedAt,
+      }),
+    )
+
+    return NextResponse.json({ error: errorMsg ?? 'Failed to fetch' }, { status: 502 })
+  }
+
   if (!response.ok) {
+    const upstreamBody = await readBody(response)
+
     console.error(
       '[coreAPIRequest] upstream error response',
       JSON.stringify({
@@ -99,9 +131,15 @@ export async function coreAPIRequest(route: string, method: HttpMethod, req?: Ne
         userId: session.user.userId,
         durationMs: Date.now() - startedAt,
         hasCsrfToken: !!csrfToken,
-        body: await readBodyForLog(response),
+        body: truncateForLog(upstreamBody),
       }),
     )
+
+    const unauthorizedBody = response.status === 401 ? parseUnauthorizedBody(upstreamBody) : null
+
+    if (unauthorizedBody && parseSSORequirement(unauthorizedBody)) {
+      return NextResponse.json(unauthorizedBody, { status: 401 })
+    }
 
     return NextResponse.json({ error: errorMsg ?? 'Failed to fetch' }, { status: response.status })
   }

--- a/apps/console/src/lib/auth/utils/get-openlane-token.ts
+++ b/apps/console/src/lib/auth/utils/get-openlane-token.ts
@@ -32,12 +32,13 @@ export const checkWebfinger = async (email: string): Promise<WebfingerConfig | n
   return null
 }
 
-export const getSSORedirect = async (organizationId: string): Promise<{ redirect_uri: string; organization_id: string } | null> => {
+export const getSSORedirect = async (organizationId: string, ssoLoginPath?: string): Promise<{ redirect_uri: string; organization_id: string } | null> => {
   try {
     const ssoResponse = await secureFetch(`/api/auth/sso`, {
       method: 'POST',
       body: JSON.stringify({
         organization_id: organizationId,
+        ...(ssoLoginPath && { sso_login_path: ssoLoginPath }),
       }),
     })
 

--- a/apps/console/src/lib/auth/utils/get-openlane-token.ts
+++ b/apps/console/src/lib/auth/utils/get-openlane-token.ts
@@ -32,13 +32,12 @@ export const checkWebfinger = async (email: string): Promise<WebfingerConfig | n
   return null
 }
 
-export const getSSORedirect = async (organizationId: string, ssoLoginPath?: string): Promise<{ redirect_uri: string; organization_id: string } | null> => {
+export const getSSORedirect = async (organizationId: string): Promise<{ redirect_uri: string; organization_id: string } | null> => {
   try {
     const ssoResponse = await secureFetch(`/api/auth/sso`, {
       method: 'POST',
       body: JSON.stringify({
         organization_id: organizationId,
-        ...(ssoLoginPath && { sso_login_path: ssoLoginPath }),
       }),
     })
 

--- a/apps/console/src/lib/auth/utils/redirect.test.ts
+++ b/apps/console/src/lib/auth/utils/redirect.test.ts
@@ -1,14 +1,10 @@
 import { buildLoginRedirect, sanitizeLoginRedirect } from './redirect'
 
 /**
- * #2193 — the login URL stopped carrying `?redirect=/` when the target is just
- * the root, since that param does nothing.
- *
- * The rest of this module is open-redirect protection, which had no coverage at
- * all. A post-login redirect is attacker-influenceable, so the refusals are the
+ * A post-login redirect is attacker-influenceable, so the refusals are the
  * security boundary: anything that is not a same-site absolute path must fall
- * back rather than be followed. `//evil.com` is the classic bypass — it is a
- * protocol-relative URL, not a path, despite starting with a slash.
+ * back rather than be followed. `//evil.com` is the classic bypass — a
+ * protocol-relative URL, not a path, despite the leading slash.
  */
 describe('sanitizeLoginRedirect — accepted targets', () => {
   test('keeps a same-site absolute path', () => {
@@ -66,7 +62,7 @@ describe('buildLoginRedirect', () => {
   })
 
   test('omits the param when the target is the root', () => {
-    // The point of this commit: ?redirect=/ carries no information.
+    // ?redirect=/ carries no information.
     expect(buildLoginRedirect('/')).toBe('/login')
   })
 

--- a/apps/console/src/lib/auth/utils/redirect.test.ts
+++ b/apps/console/src/lib/auth/utils/redirect.test.ts
@@ -1,0 +1,94 @@
+import { buildLoginRedirect, sanitizeLoginRedirect } from './redirect'
+
+/**
+ * #2193 — the login URL stopped carrying `?redirect=/` when the target is just
+ * the root, since that param does nothing.
+ *
+ * The rest of this module is open-redirect protection, which had no coverage at
+ * all. A post-login redirect is attacker-influenceable, so the refusals are the
+ * security boundary: anything that is not a same-site absolute path must fall
+ * back rather than be followed. `//evil.com` is the classic bypass — it is a
+ * protocol-relative URL, not a path, despite starting with a slash.
+ */
+describe('sanitizeLoginRedirect — accepted targets', () => {
+  test('keeps a same-site absolute path', () => {
+    expect(sanitizeLoginRedirect('/controls')).toBe('/controls')
+  })
+
+  test('preserves query and hash', () => {
+    expect(sanitizeLoginRedirect('/controls?tab=evidence#top')).toBe('/controls?tab=evidence#top')
+  })
+
+  test('trims surrounding whitespace', () => {
+    expect(sanitizeLoginRedirect('  /controls  ')).toBe('/controls')
+  })
+
+  test('normalises a traversal that stays on-site', () => {
+    expect(sanitizeLoginRedirect('/controls/../policies')).toBe('/policies')
+  })
+})
+
+describe('sanitizeLoginRedirect — refusals', () => {
+  test.each([
+    ['an absolute http url', 'http://evil.com/steal'],
+    ['an absolute https url', 'https://evil.com/steal'],
+    ['a protocol-relative url', '//evil.com'],
+    ['a protocol-relative url with a path', '//evil.com/steal'],
+    ['a javascript: url', 'javascript:alert(1)'],
+    ['a relative path with no leading slash', 'controls'],
+    ['an empty string', ''],
+    ['whitespace only', '   '],
+  ])('falls back for %s', (_label, redirect) => {
+    expect(sanitizeLoginRedirect(redirect)).toBe('/')
+  })
+
+  test('falls back for null and undefined', () => {
+    expect(sanitizeLoginRedirect(null)).toBe('/')
+    expect(sanitizeLoginRedirect(undefined)).toBe('/')
+  })
+
+  test('refuses to bounce back to the login page itself', () => {
+    // Otherwise a successful login lands straight back on the form.
+    expect(sanitizeLoginRedirect('/login')).toBe('/')
+    expect(sanitizeLoginRedirect('/login/support')).toBe('/')
+  })
+
+  test('honours a custom fallback', () => {
+    expect(sanitizeLoginRedirect('https://evil.com', '/dashboard')).toBe('/dashboard')
+  })
+})
+
+describe('buildLoginRedirect', () => {
+  test('returns a bare login path when there is no target', () => {
+    expect(buildLoginRedirect(null)).toBe('/login')
+    expect(buildLoginRedirect(undefined)).toBe('/login')
+    expect(buildLoginRedirect('')).toBe('/login')
+  })
+
+  test('omits the param when the target is the root', () => {
+    // The point of this commit: ?redirect=/ carries no information.
+    expect(buildLoginRedirect('/')).toBe('/login')
+  })
+
+  test('omits the param when the target sanitises to the fallback', () => {
+    expect(buildLoginRedirect('https://evil.com')).toBe('/login')
+    expect(buildLoginRedirect('/login')).toBe('/login')
+  })
+
+  test('carries a real target as an encoded param', () => {
+    expect(buildLoginRedirect('/controls')).toBe(`/login?redirect=${encodeURIComponent('/controls')}`)
+  })
+
+  test('encodes query and hash in the param', () => {
+    const built = buildLoginRedirect('/controls?tab=evidence#top')
+
+    expect(built).toBe(`/login?redirect=${encodeURIComponent('/controls?tab=evidence#top')}`)
+    expect(built).not.toContain('?tab=')
+  })
+
+  test('never emits an off-site target in the param', () => {
+    for (const hostile of ['//evil.com', 'https://evil.com/steal', 'javascript:alert(1)']) {
+      expect(buildLoginRedirect(hostile)).not.toContain('evil.com')
+    }
+  })
+})

--- a/apps/console/src/lib/auth/utils/refresh-classification.test.ts
+++ b/apps/console/src/lib/auth/utils/refresh-classification.test.ts
@@ -3,13 +3,9 @@ import { probeSession, resetSessionProbe } from './session-health'
 
 /**
  * `rejected` and `signed-out` are destructive verdicts: they end at the
- * session-expired modal, which signs out and revokes the tokens and the server
- * session. Anything that is merely an infrastructure answer — a 403 from a CSRF
- * or policy failure, a 404/405 from a bad deploy, a proxy 5xx, a truncated body
- * — must stay `unavailable` so a live user is not logged out by a blip.
- *
- * So both classifiers are allowlists for the destructive outcome, and these
- * tests pin the allowlist rather than the (open-ended) recoverable set.
+ * session-expired modal, which revokes the tokens and the server session. Both
+ * classifiers are therefore allowlists, and these tests pin the allowlist
+ * rather than the open-ended recoverable set.
  */
 
 const globals = globalThis as unknown as { fetch: typeof fetch }

--- a/apps/console/src/lib/auth/utils/refresh-classification.test.ts
+++ b/apps/console/src/lib/auth/utils/refresh-classification.test.ts
@@ -1,0 +1,79 @@
+import { fetchNewAccessToken } from './refresh-token'
+import { probeSession, resetSessionProbe } from './session-health'
+
+/**
+ * `rejected` and `signed-out` are destructive verdicts: they end at the
+ * session-expired modal, which signs out and revokes the tokens and the server
+ * session. Anything that is merely an infrastructure answer — a 403 from a CSRF
+ * or policy failure, a 404/405 from a bad deploy, a proxy 5xx, a truncated body
+ * — must stay `unavailable` so a live user is not logged out by a blip.
+ *
+ * So both classifiers are allowlists for the destructive outcome, and these
+ * tests pin the allowlist rather than the (open-ended) recoverable set.
+ */
+
+const globals = globalThis as unknown as { fetch: typeof fetch }
+const originalFetch = globals.fetch
+
+let respond: (url: string) => Response
+
+globals.fetch = (async (input: RequestInfo | URL) => respond(String(input))) as typeof fetch
+
+const json = (body: unknown, status = 200): Response => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+const csrfOr = (fallback: (url: string) => Response) => (url: string) => (url.includes('/csrf') ? json({ csrf: 'test-csrf' }) : fallback(url))
+
+afterAll(() => {
+  globals.fetch = originalFetch
+})
+
+beforeEach(() => {
+  resetSessionProbe()
+})
+
+describe('refresh response classification', () => {
+  test.each([400, 401])('%i means the credential is dead', async (status) => {
+    respond = csrfOr(() => new Response('nope', { status }))
+    expect((await fetchNewAccessToken('r')).status).toBe('rejected')
+  })
+
+  test.each([403, 404, 405, 408, 425, 429, 500, 502, 503])('%i stays recoverable', async (status) => {
+    respond = csrfOr(() => new Response('nope', { status }))
+    expect((await fetchNewAccessToken('r')).status).toBe('unavailable')
+  })
+
+  test('a 2xx without an access token is recoverable, not a rejection', async () => {
+    respond = csrfOr(() => json({}))
+    expect((await fetchNewAccessToken('r')).status).toBe('unavailable')
+  })
+
+  test('an unparseable 2xx body is recoverable, not a rejection', async () => {
+    respond = csrfOr(() => new Response('<html>gateway</html>', { status: 200, headers: { 'content-type': 'application/json' } }))
+    expect((await fetchNewAccessToken('r')).status).toBe('unavailable')
+  })
+
+  test('keeps the submitted refresh token when the response does not rotate it', async () => {
+    respond = csrfOr(() => json({ access_token: 'new-access' }))
+    const result = await fetchNewAccessToken('original-refresh')
+
+    expect(result.status).toBe('ok')
+    if (result.status === 'ok') expect(result.tokens.refreshToken).toBe('original-refresh')
+  })
+})
+
+describe('session probe classification', () => {
+  test('a 200 carrying no access token is a real signed-out session', async () => {
+    respond = () => json(null)
+    expect((await probeSession({ maxAgeMs: 0 })).status).toBe('signed-out')
+  })
+
+  test.each([401, 403, 404, 500, 502])('%i is an infrastructure answer, not a sign-out', async (status) => {
+    respond = () => new Response('nope', { status })
+    expect((await probeSession({ maxAgeMs: 0 })).status).toBe('unavailable')
+  })
+
+  test('a 200 with an access token is available', async () => {
+    respond = () => json({ user: { accessToken: 'a', refreshToken: 'r' } })
+    expect((await probeSession({ maxAgeMs: 0 })).status).toBe('available')
+  })
+})

--- a/apps/console/src/lib/auth/utils/refresh-token.ts
+++ b/apps/console/src/lib/auth/utils/refresh-token.ts
@@ -10,13 +10,9 @@ export interface Tokens {
 export type RefreshResult = { status: 'ok'; tokens: Tokens } | { status: 'rejected' } | { status: 'unavailable'; retryAfterMs: number }
 
 /**
- * Only these mean "this refresh credential is dead".
- *
- * `rejected` is destructive: it ends in the session-expired modal, which signs
- * out and revokes the tokens and server session. So it is an ALLOWLIST, not a
- * list of retryable statuses — anything unrecognised (403 from a CSRF or policy
- * failure, a 404/405 from a bad deploy, a proxy error) must stay recoverable
- * rather than log a live user out.
+ * `rejected` is destructive: it ends in the session-expired modal, which
+ * revokes the tokens and server session. So this is an allowlist — anything
+ * unrecognised stays recoverable rather than logging a live user out.
  */
 const REJECTED_REFRESH_STATUSES = new Set([400, 401])
 

--- a/apps/console/src/lib/auth/utils/refresh-token.ts
+++ b/apps/console/src/lib/auth/utils/refresh-token.ts
@@ -1,13 +1,14 @@
 import { openlaneAPIUrl } from '@repo/dally/auth'
 import { secureFetch } from './secure-fetch'
 import { parseRetryAfter } from './retry-after'
+import { readSSORequirement, type SSORequirement } from './sso-required'
 
 export interface Tokens {
   accessToken: string
   refreshToken: string
 }
 
-export type RefreshResult = { status: 'ok'; tokens: Tokens } | { status: 'rejected' } | { status: 'unavailable'; retryAfterMs: number }
+export type RefreshResult = { status: 'ok'; tokens: Tokens } | { status: 'rejected' } | { status: 'sso-required'; requirement: SSORequirement } | { status: 'unavailable'; retryAfterMs: number }
 
 /**
  * `rejected` is destructive: it ends in the session-expired modal, which
@@ -31,6 +32,12 @@ export const fetchNewAccessToken = async (refreshToken: string): Promise<Refresh
 
   if (!response.ok) {
     console.error(`Failed to refresh access token. Status: ${response.status}`)
+
+    const ssoRequirement = await readSSORequirement(response)
+
+    if (ssoRequirement) {
+      return { status: 'sso-required', requirement: ssoRequirement }
+    }
 
     return REJECTED_REFRESH_STATUSES.has(response.status) ? { status: 'rejected' } : { status: 'unavailable', retryAfterMs: parseRetryAfter(response.headers.get('retry-after')) }
   }

--- a/apps/console/src/lib/auth/utils/refresh-token.ts
+++ b/apps/console/src/lib/auth/utils/refresh-token.ts
@@ -9,6 +9,17 @@ export interface Tokens {
 
 export type RefreshResult = { status: 'ok'; tokens: Tokens } | { status: 'rejected' } | { status: 'unavailable'; retryAfterMs: number }
 
+/**
+ * Only these mean "this refresh credential is dead".
+ *
+ * `rejected` is destructive: it ends in the session-expired modal, which signs
+ * out and revokes the tokens and server session. So it is an ALLOWLIST, not a
+ * list of retryable statuses — anything unrecognised (403 from a CSRF or policy
+ * failure, a 404/405 from a bad deploy, a proxy error) must stay recoverable
+ * rather than log a live user out.
+ */
+const REJECTED_REFRESH_STATUSES = new Set([400, 401])
+
 export const fetchNewAccessToken = async (refreshToken: string): Promise<RefreshResult> => {
   let response: Response
 
@@ -22,24 +33,24 @@ export const fetchNewAccessToken = async (refreshToken: string): Promise<Refresh
     return { status: 'unavailable', retryAfterMs: parseRetryAfter(null) }
   }
 
-  if (response.status === 429 || response.status >= 500) {
-    console.error(`Refresh endpoint unavailable. Status: ${response.status}`)
-    return { status: 'unavailable', retryAfterMs: parseRetryAfter(response.headers.get('retry-after')) }
-  }
-
   if (!response.ok) {
     console.error(`Failed to refresh access token. Status: ${response.status}`)
-    return { status: 'rejected' }
+
+    return REJECTED_REFRESH_STATUSES.has(response.status) ? { status: 'rejected' } : { status: 'unavailable', retryAfterMs: parseRetryAfter(response.headers.get('retry-after')) }
   }
 
   try {
-    const data = await response.json()
+    const data: { access_token?: string; refresh_token?: string } = await response.json()
 
-    if (!data?.access_token) {
-      return { status: 'rejected' }
+    // A 2xx with no access token is a malformed response, not proof the
+    // credential is dead — stay recoverable.
+    if (!data.access_token) {
+      return { status: 'unavailable', retryAfterMs: parseRetryAfter(response.headers.get('retry-after')) }
     }
 
-    return { status: 'ok', tokens: { accessToken: data.access_token, refreshToken: data.refresh_token } }
+    // Core does not necessarily rotate the refresh token; keep the one we sent
+    // rather than storing undefined.
+    return { status: 'ok', tokens: { accessToken: data.access_token, refreshToken: data.refresh_token || refreshToken } }
   } catch (error) {
     console.error('Refresh token response was not valid JSON:', error)
     return { status: 'unavailable', retryAfterMs: parseRetryAfter(null) }

--- a/apps/console/src/lib/auth/utils/secure-fetch.test.ts
+++ b/apps/console/src/lib/auth/utils/secure-fetch.test.ts
@@ -1,0 +1,99 @@
+import { fetchCSRFToken } from './secure-fetch'
+
+/**
+ * The CSRF token cache and in-flight dedupe (fetchCSRFToken) exist because
+ * /csrf is rate-limited and was previously hit once per outbound request.
+ *
+ * The cache is module-level state, so these tests are ordered to walk a single
+ * lifecycle rather than resetting it: the rejection case runs first (a failure
+ * caches nothing), then the concurrent dedupe populates it, then the warm-cache
+ * reuse reads it, and finally the server-side case asserts the cache is bypassed
+ * entirely when there is no `window`.
+ */
+
+const globals = globalThis as unknown as { window?: unknown; fetch: typeof fetch }
+const originalWindow = globals.window
+const originalFetch = globals.fetch
+
+let fetchCalls = 0
+let respond: () => Promise<Response>
+
+const jsonResponse = (csrf: string): Response =>
+  new Response(JSON.stringify({ csrf }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+
+globals.window = globalThis
+globals.fetch = (() => {
+  fetchCalls++
+  return respond()
+}) as unknown as typeof fetch
+
+afterAll(() => {
+  globals.window = originalWindow
+  globals.fetch = originalFetch
+})
+
+describe('fetchCSRFToken', () => {
+  test('propagates a failed response and caches nothing', async () => {
+    fetchCalls = 0
+    respond = async () => new Response('nope', { status: 500, statusText: 'Server Error', headers: { 'content-type': 'application/json' } })
+
+    await expect(fetchCSRFToken()).rejects.toThrow(/Failed to fetch CSRF token: 500/)
+    expect(fetchCalls).toBe(1)
+
+    // A rejection must clear the in-flight slot, otherwise every later caller
+    // would await the same dead promise.
+    await expect(fetchCSRFToken()).rejects.toThrow(/Failed to fetch CSRF token: 500/)
+    expect(fetchCalls).toBe(2)
+  })
+
+  test('rejects an HTML response instead of parsing it as JSON', async () => {
+    fetchCalls = 0
+    respond = async () => new Response('<!doctype html><html></html>', { status: 200, headers: { 'content-type': 'text/html' } })
+
+    await expect(fetchCSRFToken()).rejects.toThrow(/received HTML/i)
+    expect(fetchCalls).toBe(1)
+  })
+
+  test('dedupes concurrent callers onto a single request', async () => {
+    fetchCalls = 0
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    respond = async () => {
+      await gate
+      return jsonResponse('token-a')
+    }
+
+    const inFlight = [fetchCSRFToken(), fetchCSRFToken(), fetchCSRFToken(), fetchCSRFToken(), fetchCSRFToken()]
+    release?.()
+    const tokens = await Promise.all(inFlight)
+
+    expect(fetchCalls).toBe(1)
+    expect(tokens).toEqual(['token-a', 'token-a', 'token-a', 'token-a', 'token-a'])
+  })
+
+  test('serves later callers from the cache without a new request', async () => {
+    fetchCalls = 0
+    respond = async () => jsonResponse('token-b')
+
+    expect(await fetchCSRFToken()).toBe('token-a')
+    expect(await fetchCSRFToken()).toBe('token-a')
+    expect(fetchCalls).toBe(0)
+  })
+
+  test('never caches when there is no window (server-side)', async () => {
+    fetchCalls = 0
+    respond = async () => jsonResponse('token-server')
+    globals.window = undefined
+
+    expect(await fetchCSRFToken()).toBe('token-server')
+    expect(await fetchCSRFToken()).toBe('token-server')
+    expect(fetchCalls).toBe(2)
+
+    globals.window = globalThis
+  })
+})

--- a/apps/console/src/lib/auth/utils/secure-fetch.ts
+++ b/apps/console/src/lib/auth/utils/secure-fetch.ts
@@ -8,24 +8,34 @@ export interface SecureFetchCSRFOptions {
   token?: string
 }
 
+const CSRF_EXEMPT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'TRACE'])
+
+const resolveMethod = (url: string | URL | globalThis.Request, options: RequestInit): string => (options.method ?? (url instanceof Request ? url.method : 'GET')).toUpperCase()
+
+export const isCSRFRejection = async (response: Response): Promise<boolean> => {
+  if (response.status !== 403) {
+    return false
+  }
+
+  try {
+    return (await response.clone().text()).toLowerCase().includes('csrf')
+  } catch {
+    return false
+  }
+}
+
 export const secureFetch = async (url: string | URL | globalThis.Request, options: RequestInit = {}, csrfOptions: SecureFetchCSRFOptions = {}) => {
-  const headers: Record<string, string> = {
+  const baseHeaders: Record<string, string> = {
     ...((options.headers as Record<string, string>) || {}),
     'Content-Type': jsonContentType,
   }
 
-  let csrfToken = csrfOptions.token ?? getCookie(csrfCookieName)
-  if (!csrfToken) {
-    csrfToken = await fetchCSRFToken()
-  }
+  const send = async (csrfToken: string) => {
+    const headers = appendCookie({ ...baseHeaders, [csrfHeader]: csrfToken }, csrfCookieName, csrfToken)
 
-  headers[csrfHeader] = csrfToken
-  const newHeaders = appendCookie(headers, csrfCookieName, csrfToken)
-
-  try {
     const res = await fetch(url, {
       ...options,
-      headers: newHeaders,
+      headers,
       credentials: 'include',
     })
 
@@ -39,6 +49,24 @@ export const secureFetch = async (url: string | URL | globalThis.Request, option
     }
 
     return res
+  }
+
+  let csrfToken = csrfOptions.token ?? getCookie(csrfCookieName)
+  if (!csrfToken) {
+    csrfToken = await fetchCSRFToken()
+  }
+
+  try {
+    const response = await send(csrfToken)
+
+    if (!csrfOptions.token && !CSRF_EXEMPT_METHODS.has(resolveMethod(url, options)) && (await isCSRFRejection(response))) {
+      console.warn('[secureFetch] ⚠️ CSRF token rejected — refetching and retrying once')
+      invalidateCSRFToken()
+
+      return await send(await fetchCSRFToken())
+    }
+
+    return response
   } catch (err) {
     console.error('[secureFetch] ⚠️ Fetch error:', err)
     throw err
@@ -57,6 +85,11 @@ const CSRF_TTL_MS = 55 * 60 * 1000
 let cachedCSRFToken: string | null = null
 let cachedCSRFTokenExpiresAt = 0
 let inFlightCSRFRequest: Promise<string> | null = null
+
+export const invalidateCSRFToken = () => {
+  cachedCSRFToken = null
+  cachedCSRFTokenExpiresAt = 0
+}
 
 export const fetchCSRFToken = async (): Promise<string> => {
   const canCache = typeof window !== 'undefined'

--- a/apps/console/src/lib/auth/utils/session-health.ts
+++ b/apps/console/src/lib/auth/utils/session-health.ts
@@ -38,12 +38,11 @@ const runProbe = async (): Promise<SessionProbeResult> => {
     return { status: 'unavailable', retryAfterMs: DEFAULT_RETRY_MS }
   }
 
-  if (response.status === 429 || response.status >= 500) {
-    return { status: 'unavailable', retryAfterMs: parseRetryAfter(response.headers.get('retry-after')) }
-  }
-
+  // Any non-OK response is an infrastructure answer, not evidence about the
+  // session — treating it as signed-out fed the destructive expiry path. A real
+  // signed-out session is a 200 whose body carries no access token (below).
   if (!response.ok) {
-    return { status: 'signed-out' }
+    return { status: 'unavailable', retryAfterMs: parseRetryAfter(response.headers.get('retry-after')) }
   }
 
   try {

--- a/apps/console/src/lib/auth/utils/session-refresh.test.ts
+++ b/apps/console/src/lib/auth/utils/session-refresh.test.ts
@@ -3,18 +3,10 @@ import { resetSessionProbe } from './session-health'
 import { clearTokens, setAuthoritativeTokens } from './session-tokens'
 
 /**
- * A 401 must never trigger a refresh that the backend is guaranteed to reject.
- *
  * Core issues refresh tokens with `nbf = accessTokenExp - 15m`, so for most of a
- * session's life /v1/refresh cannot succeed. The reactive 401 path used to call
- * it anyway; refresh-token.ts reads that predictable failure as `rejected`,
- * which raises session-expired, whose modal calls signOut(), whose NextAuth
- * event POSTs /v1/logout and REVOKES the tokens and session server-side. One
- * unrelated 401 could therefore destroy a valid session — and, when a session is
- * shared (as in the e2e suite), everyone else's too.
- *
- * recoverTokensAfterUnauthorized keeps the useful half of that path — adopting a
- * token another tab or request already obtained — and gates only the network
+ * session's life /v1/refresh cannot succeed and the old reactive 401 path read
+ * that predictable failure as a dead credential. recoverTokensAfterUnauthorized
+ * still adopts a token another tab already obtained, but gates the network
  * refresh on the token actually being due.
  */
 

--- a/apps/console/src/lib/auth/utils/session-refresh.test.ts
+++ b/apps/console/src/lib/auth/utils/session-refresh.test.ts
@@ -1,0 +1,154 @@
+import { recoverTokensAfterUnauthorized } from './session-refresh'
+import { resetSessionProbe } from './session-health'
+import { clearTokens, setAuthoritativeTokens } from './session-tokens'
+
+/**
+ * A 401 must never trigger a refresh that the backend is guaranteed to reject.
+ *
+ * Core issues refresh tokens with `nbf = accessTokenExp - 15m`, so for most of a
+ * session's life /v1/refresh cannot succeed. The reactive 401 path used to call
+ * it anyway; refresh-token.ts reads that predictable failure as `rejected`,
+ * which raises session-expired, whose modal calls signOut(), whose NextAuth
+ * event POSTs /v1/logout and REVOKES the tokens and session server-side. One
+ * unrelated 401 could therefore destroy a valid session — and, when a session is
+ * shared (as in the e2e suite), everyone else's too.
+ *
+ * recoverTokensAfterUnauthorized keeps the useful half of that path — adopting a
+ * token another tab or request already obtained — and gates only the network
+ * refresh on the token actually being due.
+ */
+
+const HOUR_S = 60 * 60
+
+// Unsigned JWT-shaped string; jwtDecode only base64-decodes the payload.
+const makeToken = (id: string, expiresInSeconds: number): string => {
+  const now = Math.floor(Date.now() / 1000)
+  const payload = { id, iat: now - (HOUR_S - expiresInSeconds), exp: now + expiresInSeconds }
+  const b64 = (value: object) => Buffer.from(JSON.stringify(value)).toString('base64url')
+  return `${b64({ alg: 'none' })}.${b64(payload)}.`
+}
+
+// refreshAt is exp - min(60s, ttl*5%); a 1h token is due inside its last minute.
+const freshToken = (id: string) => makeToken(id, HOUR_S)
+const dueToken = (id: string) => makeToken(id, 30)
+
+// Deliberately does NOT define `window`: fetchCSRFToken only populates its
+// module-level cache when one exists, and secure-fetch.test.ts asserts on that
+// cache's lifecycle. Leaving window undefined keeps these files independent.
+const globals = globalThis as unknown as { navigator?: unknown; fetch: typeof fetch }
+const originalNavigator = globals.navigator
+const originalFetch = globals.fetch
+
+// withRefreshLock dedupes concurrent refreshes through the Web Locks API, which
+// bun does not implement — without a stand-in it silently degrades to an
+// unsynchronized run and the dedupe cannot be observed. Serialize by name.
+const lockQueues = new Map<string, Promise<unknown>>()
+const locksStub = {
+  request: <T>(name: string, _options: unknown, run: () => Promise<T>): Promise<T> => {
+    const previous = lockQueues.get(name) ?? Promise.resolve()
+    const next = previous.then(run, run)
+    lockQueues.set(
+      name,
+      next.catch(() => undefined),
+    )
+    return next
+  },
+}
+
+let sessionTokens: { accessToken: string; refreshToken: string } | null = null
+let calls: string[] = []
+let refreshResponse: () => Response
+
+globals.navigator = { locks: locksStub }
+globals.fetch = (async (input: RequestInfo | URL) => {
+  const url = String(input)
+  calls.push(url)
+
+  if (url.includes('/api/auth/session')) {
+    return new Response(JSON.stringify(sessionTokens ? { user: sessionTokens } : {}), { status: 200, headers: { 'content-type': 'application/json' } })
+  }
+
+  // secureFetch mints a CSRF token before any authenticated POST.
+  if (url.includes('/csrf')) {
+    return new Response(JSON.stringify({ csrf: 'test-csrf' }), { status: 200, headers: { 'content-type': 'application/json' } })
+  }
+
+  if (url.includes('/v1/refresh')) return refreshResponse()
+
+  throw new Error(`unexpected fetch: ${url}`)
+}) as typeof fetch
+
+afterAll(() => {
+  globals.navigator = originalNavigator
+  globals.fetch = originalFetch
+})
+
+beforeEach(() => {
+  calls = []
+  lockQueues.clear()
+  clearTokens()
+  resetSessionProbe()
+  refreshResponse = () => new Response(JSON.stringify({ access_token: freshToken('refreshed'), refresh_token: 'r-refreshed' }), { status: 200, headers: { 'content-type': 'application/json' } })
+})
+
+const refreshCalls = () => calls.filter((c) => c.includes('/v1/refresh')).length
+const probeCalls = () => calls.filter((c) => c.includes('/api/auth/session')).length
+
+describe('recoverTokensAfterUnauthorized', () => {
+  test('a 401 on a token that is not due does NOT call /v1/refresh', async () => {
+    const access = freshToken('a')
+    const failed = setAuthoritativeTokens(access, 'r-a')
+    sessionTokens = { accessToken: access, refreshToken: 'r-a' }
+
+    const recovered = await recoverTokensAfterUnauthorized(failed)
+
+    expect(recovered).toBeNull()
+    expect(probeCalls()).toBe(1)
+    expect(refreshCalls()).toBe(0)
+  })
+
+  test('adopts a newer token from the session cookie without refreshing', async () => {
+    const failed = setAuthoritativeTokens(freshToken('old'), 'r-old')
+    const newer = freshToken('newer')
+    sessionTokens = { accessToken: newer, refreshToken: 'r-newer' }
+
+    const recovered = await recoverTokensAfterUnauthorized(failed)
+
+    expect(recovered?.accessToken).toBe(newer)
+    expect(refreshCalls()).toBe(0)
+  })
+
+  test('adopts a newer in-memory token without probing or refreshing', async () => {
+    const failed = { accessToken: freshToken('stale'), refreshToken: 'r-stale', issuedAt: 0, refreshAt: 0 }
+    const newer = freshToken('installed')
+    setAuthoritativeTokens(newer, 'r-installed')
+
+    const recovered = await recoverTokensAfterUnauthorized(failed)
+
+    expect(recovered?.accessToken).toBe(newer)
+    expect(probeCalls()).toBe(0)
+    expect(refreshCalls()).toBe(0)
+  })
+
+  test('a 401 on a token that IS due refreshes over the network', async () => {
+    const access = dueToken('due')
+    const failed = setAuthoritativeTokens(access, 'r-due')
+    sessionTokens = { accessToken: access, refreshToken: 'r-due' }
+
+    const recovered = await recoverTokensAfterUnauthorized(failed)
+
+    expect(refreshCalls()).toBe(1)
+    expect(recovered?.accessToken).not.toBe(access)
+  })
+
+  test('concurrent recoveries of a due token issue a single /v1/refresh', async () => {
+    const access = dueToken('shared')
+    const failed = setAuthoritativeTokens(access, 'r-shared')
+    sessionTokens = { accessToken: access, refreshToken: 'r-shared' }
+
+    const results = await Promise.all([recoverTokensAfterUnauthorized(failed), recoverTokensAfterUnauthorized(failed), recoverTokensAfterUnauthorized(failed)])
+
+    expect(refreshCalls()).toBe(1)
+    for (const result of results) expect(result?.accessToken).not.toBe(access)
+  })
+})

--- a/apps/console/src/lib/auth/utils/session-refresh.ts
+++ b/apps/console/src/lib/auth/utils/session-refresh.ts
@@ -3,13 +3,39 @@
 import { fetchNewAccessToken } from './refresh-token'
 import { probeSession, SessionUnavailableError } from './session-health'
 import { notifySessionExpired } from './session-status'
-import { getKnownTokens, getTokenGeneration, setAuthoritativeTokens, type TokenState } from './session-tokens'
+import { getKnownTokens, getTokenGeneration, getUsableTokens, setAuthoritativeTokens, type TokenState } from './session-tokens'
 
 // Web Locks key, not a duration: the namespace is browser-global (hence the prefix) and shared
 // across tabs, so an exclusive hold means five open tabs produce one /v1/refresh. The generation
 // check inside the lock makes queued waiters adopt the winner's tokens instead of minting their
 // own; it degrades to an unsynchronized run() where locks are unavailable.
 const SESSION_REFRESH_LOCK = 'openlane-session-refresh'
+
+const MAX_CONSECUTIVE_REFRESH_FAILURES = 5
+
+let consecutiveRefreshFailures = 0
+let refreshCooldownUntil = 0
+let lastRefreshFailure: Error | null = null
+
+const recordRefreshSuccess = () => {
+  consecutiveRefreshFailures = 0
+  refreshCooldownUntil = 0
+  lastRefreshFailure = null
+}
+
+const recordRefreshFailure = (error: Error, retryAfterMs: number): Error => {
+  consecutiveRefreshFailures += 1
+  refreshCooldownUntil = Date.now() + retryAfterMs
+  lastRefreshFailure = error
+
+  if (consecutiveRefreshFailures >= MAX_CONSECUTIVE_REFRESH_FAILURES) {
+    console.error(`Giving up on session refresh after ${consecutiveRefreshFailures} consecutive failures`)
+    notifySessionExpired()
+    lastRefreshFailure = new Error('Session expired')
+  }
+
+  return lastRefreshFailure
+}
 
 interface RefreshOptions {
   /**
@@ -47,10 +73,20 @@ export const refreshTokens = async (refreshToken: string, { networkOnlyIfDue = f
       return superseded
     }
 
+    if (lastRefreshFailure && Date.now() < refreshCooldownUntil) {
+      const stillUsable = getUsableTokens()
+
+      if (stillUsable) {
+        return stillUsable
+      }
+
+      throw lastRefreshFailure
+    }
+
     const probe = await probeSession({ maxAgeMs: 0 })
 
     if (probe.status === 'unavailable') {
-      throw new SessionUnavailableError(probe.retryAfterMs)
+      throw recordRefreshFailure(new SessionUnavailableError(probe.retryAfterMs), probe.retryAfterMs)
     }
 
     if (probe.status === 'signed-out') {
@@ -65,6 +101,7 @@ export const refreshTokens = async (refreshToken: string, { networkOnlyIfDue = f
     // Compare BOTH tokens: keying off the refresh token alone assumes every
     // rotation replaces it, which is not guaranteed.
     if (cookieAccessToken && cookieRefreshToken && (cookieAccessToken !== known?.accessToken || cookieRefreshToken !== known?.refreshToken)) {
+      recordRefreshSuccess()
       return setAuthoritativeTokens(cookieAccessToken, cookieRefreshToken)
     }
 
@@ -80,13 +117,15 @@ export const refreshTokens = async (refreshToken: string, { networkOnlyIfDue = f
     const result = await fetchNewAccessToken(cookieRefreshToken ?? refreshToken)
 
     if (result.status === 'unavailable') {
-      throw new SessionUnavailableError(result.retryAfterMs)
+      throw recordRefreshFailure(new SessionUnavailableError(result.retryAfterMs), result.retryAfterMs)
     }
 
     if (result.status === 'rejected') {
       notifySessionExpired()
       throw new Error('Session expired')
     }
+
+    recordRefreshSuccess()
 
     const adopted = setAuthoritativeTokens(result.tokens.accessToken, result.tokens.refreshToken)
 

--- a/apps/console/src/lib/auth/utils/session-refresh.ts
+++ b/apps/console/src/lib/auth/utils/session-refresh.ts
@@ -12,6 +12,22 @@ import { getKnownTokens, getTokenGeneration, setAuthoritativeTokens, type TokenS
 // instead of minting their own. Degrades to an unsynchronized run() where locks are unavailable.
 const SESSION_REFRESH_LOCK = 'openlane-session-refresh'
 
+interface RefreshOptions {
+  /**
+   * Only hit /v1/refresh when the current token has actually reached refreshAt.
+   *
+   * Core issues refresh tokens with `nbf = accessTokenExp + refreshoverlap`
+   * (-15m), so a refresh attempted earlier is rejected BY DESIGN. That is fine
+   * for the proactive path, which only fires at refreshAt. The reactive 401
+   * path has no such guarantee: a 401 raised for any non-token reason would
+   * trigger a doomed refresh, and refresh-token.ts classifies that rejection as
+   * `rejected` -> notifySessionExpired() -> the modal's signOut() -> POST
+   * /v1/logout, which revokes the tokens and deletes the session server-side.
+   * A single unrelated 401 could therefore destroy a perfectly good session.
+   */
+  networkOnlyIfDue?: boolean
+}
+
 type TokenPersister = (tokens: { accessToken: string; refreshToken: string }) => Promise<unknown>
 
 let persistTokens: TokenPersister | null = null
@@ -28,7 +44,7 @@ const withRefreshLock = async <T>(run: () => Promise<T>): Promise<T> => {
   return run()
 }
 
-export const refreshTokens = async (refreshToken: string): Promise<TokenState> => {
+export const refreshTokens = async (refreshToken: string, { networkOnlyIfDue = false }: RefreshOptions = {}): Promise<TokenState> => {
   const observedGeneration = getTokenGeneration()
 
   return withRefreshLock(async () => {
@@ -51,9 +67,21 @@ export const refreshTokens = async (refreshToken: string): Promise<TokenState> =
 
     const cookieAccessToken = probe.session.user?.accessToken
     const cookieRefreshToken = probe.session.user?.refreshToken
+    const known = getKnownTokens()
 
-    if (cookieAccessToken && cookieRefreshToken && cookieRefreshToken !== refreshToken) {
+    // Compare BOTH tokens: keying off the refresh token alone assumes every
+    // rotation replaces it, which is not guaranteed.
+    if (cookieAccessToken && cookieRefreshToken && (cookieAccessToken !== known?.accessToken || cookieRefreshToken !== known?.refreshToken)) {
       return setAuthoritativeTokens(cookieAccessToken, cookieRefreshToken)
+    }
+
+    // Re-read after reconciliation: a concurrent request may have installed a
+    // newer token while this one was in flight, and it is THAT token's timing
+    // that decides whether a refresh is legal.
+    const refreshCandidate = getKnownTokens()
+
+    if (networkOnlyIfDue && refreshCandidate && Date.now() < refreshCandidate.refreshAt) {
+      return refreshCandidate
     }
 
     const result = await fetchNewAccessToken(cookieRefreshToken ?? refreshToken)
@@ -79,4 +107,30 @@ export const refreshTokens = async (refreshToken: string): Promise<TokenState> =
 
     return adopted
   })
+}
+
+/**
+ * Recover from a 401 without ever refreshing before the token is due.
+ *
+ * Returns the token state to retry with, or null when nothing changed and the
+ * caller should surface the 401 as-is. Reconciliation (adopting a newer token
+ * another tab or request already obtained) always runs; only the network
+ * refresh is gated.
+ */
+export const recoverTokensAfterUnauthorized = async (failedTokens: TokenState): Promise<TokenState | null> => {
+  const known = getKnownTokens()
+
+  if (known && known.accessToken !== failedTokens.accessToken) {
+    return known
+  }
+
+  const refreshToken = known?.refreshToken || failedTokens.refreshToken
+
+  if (!refreshToken) {
+    return null
+  }
+
+  const recovered = await refreshTokens(refreshToken, { networkOnlyIfDue: true })
+
+  return recovered.accessToken === failedTokens.accessToken ? null : recovered
 }

--- a/apps/console/src/lib/auth/utils/session-refresh.ts
+++ b/apps/console/src/lib/auth/utils/session-refresh.ts
@@ -2,7 +2,7 @@
 
 import { fetchNewAccessToken } from './refresh-token'
 import { probeSession, SessionUnavailableError } from './session-health'
-import { notifySessionExpired } from './session-status'
+import { notifySSOReauthRequired, notifySessionExpired } from './session-status'
 import { getKnownTokens, getTokenGeneration, getUsableTokens, setAuthoritativeTokens, type TokenState } from './session-tokens'
 
 // Web Locks key, not a duration: the namespace is browser-global (hence the prefix) and shared
@@ -118,6 +118,11 @@ export const refreshTokens = async (refreshToken: string, { networkOnlyIfDue = f
 
     if (result.status === 'unavailable') {
       throw recordRefreshFailure(new SessionUnavailableError(result.retryAfterMs), result.retryAfterMs)
+    }
+
+    if (result.status === 'sso-required') {
+      notifySSOReauthRequired(result.requirement)
+      throw new Error('SSO re-authentication required')
     }
 
     if (result.status === 'rejected') {

--- a/apps/console/src/lib/auth/utils/session-refresh.ts
+++ b/apps/console/src/lib/auth/utils/session-refresh.ts
@@ -5,25 +5,18 @@ import { probeSession, SessionUnavailableError } from './session-health'
 import { notifySessionExpired } from './session-status'
 import { getKnownTokens, getTokenGeneration, setAuthoritativeTokens, type TokenState } from './session-tokens'
 
-// Web Locks key, not a duration. The lock namespace is per-origin and shared across tabs, so an
-// exclusive hold means five open tabs produce one /v1/refresh instead of five. The name is a
-// browser-global string, hence the openlane- prefix. Serializing is only half the job: the
-// generation check inside the lock is what makes queued waiters adopt the winner's tokens
-// instead of minting their own. Degrades to an unsynchronized run() where locks are unavailable.
+// Web Locks key, not a duration: the namespace is browser-global (hence the prefix) and shared
+// across tabs, so an exclusive hold means five open tabs produce one /v1/refresh. The generation
+// check inside the lock makes queued waiters adopt the winner's tokens instead of minting their
+// own; it degrades to an unsynchronized run() where locks are unavailable.
 const SESSION_REFRESH_LOCK = 'openlane-session-refresh'
 
 interface RefreshOptions {
   /**
-   * Only hit /v1/refresh when the current token has actually reached refreshAt.
-   *
-   * Core issues refresh tokens with `nbf = accessTokenExp + refreshoverlap`
-   * (-15m), so a refresh attempted earlier is rejected BY DESIGN. That is fine
-   * for the proactive path, which only fires at refreshAt. The reactive 401
-   * path has no such guarantee: a 401 raised for any non-token reason would
-   * trigger a doomed refresh, and refresh-token.ts classifies that rejection as
-   * `rejected` -> notifySessionExpired() -> the modal's signOut() -> POST
-   * /v1/logout, which revokes the tokens and deletes the session server-side.
-   * A single unrelated 401 could therefore destroy a perfectly good session.
+   * Core issues refresh tokens with `nbf = accessTokenExp - 15m`, so a refresh
+   * attempted earlier is rejected by design. The proactive path only fires at
+   * refreshAt; the reactive 401 path needs this gate, or an unrelated 401
+   * escalates into a logout that revokes the session server-side.
    */
   networkOnlyIfDue?: boolean
 }
@@ -113,9 +106,7 @@ export const refreshTokens = async (refreshToken: string, { networkOnlyIfDue = f
  * Recover from a 401 without ever refreshing before the token is due.
  *
  * Returns the token state to retry with, or null when nothing changed and the
- * caller should surface the 401 as-is. Reconciliation (adopting a newer token
- * another tab or request already obtained) always runs; only the network
- * refresh is gated.
+ * caller should surface the 401 as-is.
  */
 export const recoverTokensAfterUnauthorized = async (failedTokens: TokenState): Promise<TokenState | null> => {
   const known = getKnownTokens()

--- a/apps/console/src/lib/auth/utils/session-status.ts
+++ b/apps/console/src/lib/auth/utils/session-status.ts
@@ -2,15 +2,19 @@
 
 import { clearTokens } from './session-tokens'
 import { resetSessionProbe } from './session-health'
+import { readSSORequirement, type SSORequirement } from './sso-required'
 
 export const SESSION_EXPIRED_EVENT = 'session-expired'
+export const SSO_REAUTH_REQUIRED_EVENT = 'sso-reauth-required'
 
 let isSessionInvalid = false
+let ssoRequirement: SSORequirement | null = null
 
 export const getIsSessionInvalid = () => isSessionInvalid
 
 export const markSessionExpired = () => {
   isSessionInvalid = true
+  ssoRequirement = null
   clearTokens()
   resetSessionProbe()
 }
@@ -19,4 +23,30 @@ export const notifySessionExpired = () => {
   if (isSessionInvalid) return
   markSessionExpired()
   window.dispatchEvent(new Event(SESSION_EXPIRED_EVENT))
+}
+
+export const getSSORequirement = () => ssoRequirement
+
+export const notifySSOReauthRequired = (requirement: SSORequirement) => {
+  if (ssoRequirement) return
+  ssoRequirement = requirement
+  window.dispatchEvent(new Event(SSO_REAUTH_REQUIRED_EVENT))
+}
+
+export const clearSSOReauthRequired = () => {
+  if (!ssoRequirement) return
+  ssoRequirement = null
+  window.dispatchEvent(new Event(SSO_REAUTH_REQUIRED_EVENT))
+}
+
+export const reportSSORequirementFromResponse = async (response: Response): Promise<boolean> => {
+  const requirement = await readSSORequirement(response)
+
+  if (!requirement) {
+    return false
+  }
+
+  notifySSOReauthRequired(requirement)
+
+  return true
 }

--- a/apps/console/src/lib/auth/utils/set-csrf-cookie.ts
+++ b/apps/console/src/lib/auth/utils/set-csrf-cookie.ts
@@ -1,12 +1,12 @@
 'use server'
 
-import { cookieDomain, csrfCookieName, isDevelopment } from '@repo/dally/auth'
+import { cookieDomain, csrfCookieName, useInsecureCookies } from '@repo/dally/auth'
 import { cookies } from 'next/headers'
 
 export const setCSRFCookie = async (csrfToken: string) => {
   const cookieStore = await cookies()
 
-  if (isDevelopment) {
+  if (useInsecureCookies) {
     cookieStore.set(`${csrfCookieName}`, csrfToken, {
       sameSite: 'lax',
       secure: false,

--- a/apps/console/src/lib/auth/utils/set-session-cookie.ts
+++ b/apps/console/src/lib/auth/utils/set-session-cookie.ts
@@ -1,5 +1,5 @@
 'use server'
-import { sessionCookieName, sessionCookieExpiration, isDevelopment, cookieDomain } from '@repo/dally/auth'
+import { sessionCookieName, sessionCookieExpiration, useInsecureCookies, cookieDomain } from '@repo/dally/auth'
 import { cookies } from 'next/headers'
 
 export const setSessionCookie = async (session: string) => {
@@ -9,9 +9,11 @@ export const setSessionCookie = async (session: string) => {
   const expires = new Date()
   expires.setTime(expires.getTime() + 1000 * 60 * expirationTime)
 
-  // if in development, don't set domain
-  if (isDevelopment) {
+  if (useInsecureCookies) {
     cookieStore.set(`${sessionCookieName}`, session, {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
       expires,
     })
   } else {

--- a/apps/console/src/lib/auth/utils/sso-required.ts
+++ b/apps/console/src/lib/auth/utils/sso-required.ts
@@ -1,6 +1,5 @@
 export interface SSORequirement {
   organizationId: string
-  ssoLoginPath?: string
 }
 
 export interface SSOUnauthorizedBody {
@@ -9,18 +8,12 @@ export interface SSOUnauthorizedBody {
   sso_login_path?: string
 }
 
-const SSO_LOGIN_PATH_PATTERN = /^\/v1\/sso\/[a-zA-Z0-9\-_/]+$/
-
-export const isSSOLoginPath = (value: string): boolean => SSO_LOGIN_PATH_PATTERN.test(value)
-
 export const parseSSORequirement = (body: SSOUnauthorizedBody | null): SSORequirement | null => {
   if (body?.sso_required !== true || typeof body.organization_id !== 'string' || body.organization_id === '') {
     return null
   }
 
-  const ssoLoginPath = body.sso_login_path && isSSOLoginPath(body.sso_login_path) ? body.sso_login_path : undefined
-
-  return { organizationId: body.organization_id, ssoLoginPath }
+  return { organizationId: body.organization_id }
 }
 
 export const readSSORequirement = async (response: Response): Promise<SSORequirement | null> => {

--- a/apps/console/src/lib/auth/utils/sso-required.ts
+++ b/apps/console/src/lib/auth/utils/sso-required.ts
@@ -1,0 +1,37 @@
+export interface SSORequirement {
+  organizationId: string
+  ssoLoginPath?: string
+}
+
+export interface SSOUnauthorizedBody {
+  sso_required?: boolean
+  organization_id?: string
+  sso_login_path?: string
+}
+
+const SSO_LOGIN_PATH_PATTERN = /^\/v1\/sso\/[a-zA-Z0-9\-_/]+$/
+
+export const isSSOLoginPath = (value: string): boolean => SSO_LOGIN_PATH_PATTERN.test(value)
+
+export const parseSSORequirement = (body: SSOUnauthorizedBody | null): SSORequirement | null => {
+  if (body?.sso_required !== true || typeof body.organization_id !== 'string' || body.organization_id === '') {
+    return null
+  }
+
+  const ssoLoginPath = body.sso_login_path && isSSOLoginPath(body.sso_login_path) ? body.sso_login_path : undefined
+
+  return { organizationId: body.organization_id, ssoLoginPath }
+}
+
+export const readSSORequirement = async (response: Response): Promise<SSORequirement | null> => {
+  if (response.status !== 401) {
+    return null
+  }
+
+  try {
+    const body: SSOUnauthorizedBody = await response.clone().json()
+    return parseSSORequirement(body)
+  } catch {
+    return null
+  }
+}

--- a/apps/console/src/lib/auth/utils/sso-token-storage.test.ts
+++ b/apps/console/src/lib/auth/utils/sso-token-storage.test.ts
@@ -1,0 +1,120 @@
+import { clearSsoTokenAuthorization, readSsoTokenAuthorization, setSsoTokenAuthorization } from './sso-token-storage'
+
+/**
+ * ISS-2680 — authorizing an API token for SSO always redirected back to the
+ * personal-access-tokens page, because the token TYPE was not round-tripped
+ * across the SSO hop. It is now stashed in localStorage and read back on return.
+ *
+ * This is parsed from storage that survives a redirect, so it has to be
+ * defensive: unparseable JSON, a missing or unrecognised tokenType, and a
+ * throwing localStorage (private mode) all yield null rather than sending the
+ * user to the wrong page or crashing the callback.
+ */
+
+const store = new Map<string, string>()
+
+const globals = globalThis as unknown as { window?: unknown; localStorage?: unknown }
+const originalWindow = globals.window
+const originalLocalStorage = globals.localStorage
+
+const workingStorage = {
+  getItem: (key: string) => store.get(key) ?? null,
+  setItem: (key: string, value: string) => store.set(key, String(value)),
+  removeItem: (key: string) => store.delete(key),
+}
+
+globals.window = globalThis
+globals.localStorage = workingStorage
+
+afterAll(() => {
+  globals.window = originalWindow
+  globals.localStorage = originalLocalStorage
+})
+
+beforeEach(() => {
+  store.clear()
+  globals.localStorage = workingStorage
+})
+
+describe('sso token authorization round-trip', () => {
+  test('reads back an api token type', () => {
+    setSsoTokenAuthorization('api')
+
+    expect(readSsoTokenAuthorization()).toBe('api')
+  })
+
+  test('reads back a personal token type', () => {
+    setSsoTokenAuthorization('personal')
+
+    expect(readSsoTokenAuthorization()).toBe('personal')
+  })
+
+  test('returns null when nothing was stored', () => {
+    expect(readSsoTokenAuthorization()).toBeNull()
+  })
+
+  test('clear removes the stored authorization', () => {
+    setSsoTokenAuthorization('api')
+    clearSsoTokenAuthorization()
+
+    expect(readSsoTokenAuthorization()).toBeNull()
+  })
+})
+
+describe('defensive parsing', () => {
+  const writeRaw = (value: string) => store.set('api_token', value)
+
+  test('returns null for unparseable JSON', () => {
+    writeRaw('{not json')
+
+    expect(readSsoTokenAuthorization()).toBeNull()
+  })
+
+  test('returns null when tokenType is missing', () => {
+    writeRaw(JSON.stringify({ somethingElse: true }))
+
+    expect(readSsoTokenAuthorization()).toBeNull()
+  })
+
+  test('returns null for an unrecognised tokenType', () => {
+    // Guards against an old stored shape sending the user to the wrong page.
+    writeRaw(JSON.stringify({ tokenType: 'service' }))
+
+    expect(readSsoTokenAuthorization()).toBeNull()
+  })
+
+  test('returns null for an empty stored value', () => {
+    writeRaw('')
+
+    expect(readSsoTokenAuthorization()).toBeNull()
+  })
+})
+
+describe('when localStorage is unavailable', () => {
+  beforeEach(() => {
+    globals.localStorage = {
+      get length(): number {
+        throw new Error('SecurityError')
+      },
+      getItem: () => {
+        throw new Error('SecurityError')
+      },
+      setItem: () => {
+        throw new Error('SecurityError')
+      },
+      removeItem: () => {
+        throw new Error('SecurityError')
+      },
+    }
+  })
+
+  test('read returns null instead of throwing', () => {
+    expect(() => readSsoTokenAuthorization()).not.toThrow()
+    expect(readSsoTokenAuthorization()).toBeNull()
+  })
+
+  test('set and clear swallow the failure', () => {
+    expect(() => setSsoTokenAuthorization('api')).not.toThrow()
+    expect(() => clearSsoTokenAuthorization()).not.toThrow()
+  })
+})

--- a/apps/console/src/lib/auth/utils/sso-token-storage.test.ts
+++ b/apps/console/src/lib/auth/utils/sso-token-storage.test.ts
@@ -1,14 +1,10 @@
 import { clearSsoTokenAuthorization, readSsoTokenAuthorization, setSsoTokenAuthorization } from './sso-token-storage'
 
 /**
- * ISS-2680 — authorizing an API token for SSO always redirected back to the
- * personal-access-tokens page, because the token TYPE was not round-tripped
- * across the SSO hop. It is now stashed in localStorage and read back on return.
- *
- * This is parsed from storage that survives a redirect, so it has to be
- * defensive: unparseable JSON, a missing or unrecognised tokenType, and a
- * throwing localStorage (private mode) all yield null rather than sending the
- * user to the wrong page or crashing the callback.
+ * The token type is not round-tripped across the SSO hop, so it is stashed in
+ * localStorage and read back on return. That storage survives a redirect and is
+ * not trustworthy, so unparseable JSON, a missing or unrecognised tokenType and
+ * a throwing localStorage all yield null.
  */
 
 const store = new Map<string, string>()

--- a/apps/console/src/lib/auth/utils/sso-token-storage.ts
+++ b/apps/console/src/lib/auth/utils/sso-token-storage.ts
@@ -20,9 +20,9 @@ export const setSsoTokenAuthorization = (tokenType: SsoTokenType) => {
 }
 
 export const readSsoTokenAuthorization = (): SsoTokenType | null => {
-  const raw = getStorage()?.getItem(SSO_TOKEN_STORAGE_KEY)
-  if (!raw) return null
   try {
+    const raw = getStorage()?.getItem(SSO_TOKEN_STORAGE_KEY)
+    if (!raw) return null
     const parsed: { tokenType?: SsoTokenType } = JSON.parse(raw)
     return parsed.tokenType === 'api' || parsed.tokenType === 'personal' ? parsed.tokenType : null
   } catch {
@@ -31,5 +31,9 @@ export const readSsoTokenAuthorization = (): SsoTokenType | null => {
 }
 
 export const clearSsoTokenAuthorization = () => {
-  getStorage()?.removeItem(SSO_TOKEN_STORAGE_KEY)
+  try {
+    getStorage()?.removeItem(SSO_TOKEN_STORAGE_KEY)
+  } catch {
+    return
+  }
 }

--- a/apps/console/src/lib/fetchGraphql.ts
+++ b/apps/console/src/lib/fetchGraphql.ts
@@ -3,7 +3,7 @@ import { csrfCookieName, csrfHeader } from '@repo/dally/auth'
 import { getCookie } from './auth/utils/getCookie'
 import { probeSession, SessionUnavailableError } from './auth/utils/session-health'
 import { refreshTokens } from './auth/utils/session-refresh'
-import { getIsSessionInvalid, notifySessionExpired, reportSSORequirementFromResponse } from './auth/utils/session-status'
+import { clearSSOReauthRequired, getIsSessionInvalid, notifySessionExpired, reportSSORequirementFromResponse } from './auth/utils/session-status'
 import { getKnownTokens, getUsableTokens, setAuthoritativeTokens } from './auth/utils/session-tokens'
 
 const resolveAccessToken = async (): Promise<string> => {
@@ -133,7 +133,9 @@ export const fetchGraphQLWithUpload = async <TVariables extends object>({ query,
     response = await post()
   }
 
-  if (await reportSSORequirementFromResponse(response)) {
+  if (response.ok) {
+    clearSSOReauthRequired()
+  } else if (await reportSSORequirementFromResponse(response)) {
     throw new Error('SSO re-authentication required')
   }
 

--- a/apps/console/src/lib/fetchGraphql.ts
+++ b/apps/console/src/lib/fetchGraphql.ts
@@ -1,4 +1,4 @@
-import { fetchCSRFToken } from './auth/utils/secure-fetch'
+import { fetchCSRFToken, invalidateCSRFToken, isCSRFRejection } from './auth/utils/secure-fetch'
 import { csrfCookieName, csrfHeader } from '@repo/dally/auth'
 import { getCookie } from './auth/utils/getCookie'
 import { probeSession, SessionUnavailableError } from './auth/utils/session-health'
@@ -114,12 +114,24 @@ export const fetchGraphQLWithUpload = async <TVariables extends object>({ query,
     body = JSON.stringify({ query, variables: normalizedVariables })
   }
 
-  const response = await fetch(process.env.NEXT_PUBLIC_API_GQL_URL ?? '', {
-    method: 'POST',
-    headers,
-    body,
-    credentials: 'include',
-  })
+  const endpoint = process.env.NEXT_PUBLIC_API_GQL_URL ?? ''
+  const post = async () =>
+    await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body,
+      credentials: 'include',
+    })
+
+  let response = await post()
+
+  if (await isCSRFRejection(response)) {
+    invalidateCSRFToken()
+    const freshCSRFToken = await fetchCSRFToken()
+    headers[csrfHeader] = freshCSRFToken
+    headers['cookie'] = `${csrfCookieName}=${freshCSRFToken}`
+    response = await post()
+  }
 
   const result = await response.json()
   if (result.errors) throw result.errors

--- a/apps/console/src/lib/fetchGraphql.ts
+++ b/apps/console/src/lib/fetchGraphql.ts
@@ -3,7 +3,7 @@ import { csrfCookieName, csrfHeader } from '@repo/dally/auth'
 import { getCookie } from './auth/utils/getCookie'
 import { probeSession, SessionUnavailableError } from './auth/utils/session-health'
 import { refreshTokens } from './auth/utils/session-refresh'
-import { getIsSessionInvalid, notifySessionExpired } from './auth/utils/session-status'
+import { getIsSessionInvalid, notifySessionExpired, reportSSORequirementFromResponse } from './auth/utils/session-status'
 import { getKnownTokens, getUsableTokens, setAuthoritativeTokens } from './auth/utils/session-tokens'
 
 const resolveAccessToken = async (): Promise<string> => {
@@ -131,6 +131,10 @@ export const fetchGraphQLWithUpload = async <TVariables extends object>({ query,
     headers[csrfHeader] = freshCSRFToken
     headers['cookie'] = `${csrfCookieName}=${freshCSRFToken}`
     response = await post()
+  }
+
+  if (await reportSSORequirementFromResponse(response)) {
+    throw new Error('SSO re-authentication required')
   }
 
   const result = await response.json()

--- a/apps/console/src/lib/graphqlClient.ts
+++ b/apps/console/src/lib/graphqlClient.ts
@@ -152,10 +152,9 @@ export const useFetchWithRetry = () => {
 
     let response = await makeRequest()
 
-    // Retry a 401 only when recovery actually produced a different access token.
-    // recoverTokensAfterUnauthorized reconciles newer tokens first and refuses to
-    // call /v1/refresh before the token is due, so an unrelated 401 no longer
-    // escalates into a session-destroying logout.
+    // Retry a 401 only when recovery produced a different access token.
+    // recoverTokensAfterUnauthorized refuses to call /v1/refresh before the
+    // token is due, so an unrelated 401 no longer escalates into a logout.
     if (response.status === 401 && !getIsSessionInvalid()) {
       const recovered = await recoverTokensAfterUnauthorized(current)
 

--- a/apps/console/src/lib/graphqlClient.ts
+++ b/apps/console/src/lib/graphqlClient.ts
@@ -8,9 +8,9 @@ import { useSession } from 'next-auth/react'
 import { useCallback, useEffect, useRef } from 'react'
 import { fetchCSRFToken } from './auth/utils/secure-fetch'
 import { probeSession, SessionUnavailableError } from './auth/utils/session-health'
-import { refreshTokens, setTokenPersister } from './auth/utils/session-refresh'
+import { recoverTokensAfterUnauthorized, refreshTokens, setTokenPersister } from './auth/utils/session-refresh'
 import { getIsSessionInvalid, notifySessionExpired } from './auth/utils/session-status'
-import { getKnownTokens, getUsableTokens, observeSessionTokens, setAuthoritativeTokens, type TokenState } from './auth/utils/session-tokens'
+import { getUsableTokens, observeSessionTokens, setAuthoritativeTokens, type TokenState } from './auth/utils/session-tokens'
 
 export { getIsSessionInvalid, markSessionExpired } from './auth/utils/session-status'
 
@@ -152,12 +152,19 @@ export const useFetchWithRetry = () => {
 
     let response = await makeRequest()
 
-    const retryRefreshToken = getKnownTokens()?.refreshToken || refreshToken
+    // Retry a 401 only when recovery actually produced a different access token.
+    // recoverTokensAfterUnauthorized reconciles newer tokens first and refuses to
+    // call /v1/refresh before the token is due, so an unrelated 401 no longer
+    // escalates into a session-destroying logout.
+    if (response.status === 401 && !getIsSessionInvalid()) {
+      const recovered = await recoverTokensAfterUnauthorized(current)
 
-    if (response.status === 401 && retryRefreshToken && !getIsSessionInvalid()) {
-      const refreshed = await refreshTokens(retryRefreshToken)
-      headers.set('Authorization', `Bearer ${refreshed.accessToken}`)
-      response = await makeRequest()
+      // Re-check the latch: a concurrent expiry may have landed while recovery
+      // was in flight, and retrying then would be pointless.
+      if (recovered && !getIsSessionInvalid()) {
+        headers.set('Authorization', `Bearer ${recovered.accessToken}`)
+        response = await makeRequest()
+      }
     }
 
     return response

--- a/apps/console/src/lib/graphqlClient.ts
+++ b/apps/console/src/lib/graphqlClient.ts
@@ -9,8 +9,8 @@ import { useCallback, useEffect, useRef } from 'react'
 import { fetchCSRFToken, invalidateCSRFToken, isCSRFRejection } from './auth/utils/secure-fetch'
 import { probeSession, SessionUnavailableError } from './auth/utils/session-health'
 import { recoverTokensAfterUnauthorized, refreshTokens, setTokenPersister } from './auth/utils/session-refresh'
-import { getIsSessionInvalid, notifySessionExpired } from './auth/utils/session-status'
-import { getUsableTokens, observeSessionTokens, setAuthoritativeTokens, type TokenState } from './auth/utils/session-tokens'
+import { clearSSOReauthRequired, getIsSessionInvalid, notifySessionExpired, reportSSORequirementFromResponse } from './auth/utils/session-status'
+import { getKnownTokens, getUsableTokens, observeSessionTokens, setAuthoritativeTokens, type TokenState } from './auth/utils/session-tokens'
 
 export { getIsSessionInvalid, markSessionExpired } from './auth/utils/session-status'
 
@@ -169,14 +169,26 @@ export const useFetchWithRetry = () => {
     // recoverTokensAfterUnauthorized refuses to call /v1/refresh before the
     // token is due, so an unrelated 401 no longer escalates into a logout.
     if (response.status === 401 && !getIsSessionInvalid()) {
-      const recovered = await recoverTokensAfterUnauthorized(current)
+      const knownTokens = getKnownTokens()
+      const hasNewerToken = !!knownTokens && knownTokens.accessToken !== current.accessToken
+      const ssoRequired = !hasNewerToken && (await reportSSORequirementFromResponse(response))
 
-      // Re-check the latch: a concurrent expiry may have landed while recovery
-      // was in flight, and retrying then would be pointless.
-      if (recovered && !getIsSessionInvalid()) {
-        headers.set('Authorization', `Bearer ${recovered.accessToken}`)
-        response = await makeRequest()
+      if (!ssoRequired) {
+        const recovered = await recoverTokensAfterUnauthorized(current)
+
+        // Re-check the latch: a concurrent expiry may have landed while recovery
+        // was in flight, and retrying then would be pointless.
+        if (recovered && !getIsSessionInvalid()) {
+          headers.set('Authorization', `Bearer ${recovered.accessToken}`)
+          response = await makeRequest()
+        }
       }
+    }
+
+    if (response.ok) {
+      clearSSOReauthRequired()
+    } else if (response.status === 401) {
+      await reportSSORequirementFromResponse(response)
     }
 
     return response

--- a/apps/console/src/lib/graphqlClient.ts
+++ b/apps/console/src/lib/graphqlClient.ts
@@ -6,7 +6,7 @@ import { getCookie } from './auth/utils/getCookie'
 import type { Session } from 'next-auth'
 import { useSession } from 'next-auth/react'
 import { useCallback, useEffect, useRef } from 'react'
-import { fetchCSRFToken } from './auth/utils/secure-fetch'
+import { fetchCSRFToken, invalidateCSRFToken, isCSRFRejection } from './auth/utils/secure-fetch'
 import { probeSession, SessionUnavailableError } from './auth/utils/session-health'
 import { recoverTokensAfterUnauthorized, refreshTokens, setTokenPersister } from './auth/utils/session-refresh'
 import { getIsSessionInvalid, notifySessionExpired } from './auth/utils/session-status'
@@ -151,6 +151,19 @@ export const useFetchWithRetry = () => {
       })
 
     let response = await makeRequest()
+
+    if (await isCSRFRejection(response)) {
+      invalidateCSRFToken()
+
+      try {
+        const freshCSRFToken = await fetchCSRFToken()
+        headers.set(csrfHeader, freshCSRFToken)
+        headers.set('cookie', `${csrfCookieName}=${freshCSRFToken}`)
+        response = await makeRequest()
+      } catch (error) {
+        console.error('❌ CSRF refetch after a rejected token failed:', error)
+      }
+    }
 
     // Retry a 401 only when recovery produced a different access token.
     // recoverTokensAfterUnauthorized refuses to call /v1/refresh before the

--- a/apps/console/src/lib/query-hooks/integrations.ts
+++ b/apps/console/src/lib/query-hooks/integrations.ts
@@ -3,6 +3,7 @@ import { normalizeDefinition, parseIntegrationErrorMessage, HEALTH_CHECK_STALE_T
 import { type IntegrationProvidersResponse, type RawProvidersResponse } from '@/lib/integrations/types'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
+import { reportSSORequirementFromResponse } from '@/lib/auth/utils/session-status'
 
 type HealthResponse = {
   status?: string
@@ -27,6 +28,8 @@ export const useIntegrationProviders = () => {
       })
 
       if (!res.ok) {
+        await reportSSORequirementFromResponse(res)
+
         const err = await res.json().catch(() => ({}))
         throw new Error(err.error ?? 'Failed to fetch integration providers')
       }

--- a/config/.env.example
+++ b/config/.env.example
@@ -24,6 +24,10 @@ SESSION_COOKIE_EXPIRATION_MINUTES=10
 SESSION_NEXAUTH_MAX_AGE=7200
 # leave empty for local development
 COOKIE_DOMAIN=
+# Test-only: emits dev-style cookies (no Secure attribute, no cookie domain) so a PRODUCTION
+# build can authenticate over plain HTTP on localhost for the Playwright suite. NEVER set this
+# in a deployed environment — the E2E runner sets it inline for the one process that needs it.
+# COOKIE_PLAYWRIGHT_INSECURE=true
 # leave empty for all domains
 NEXT_PUBLIC_ALLOWED_LOGIN_DOMAINS=
 

--- a/packages/dally/src/index.ts
+++ b/packages/dally/src/index.ts
@@ -17,6 +17,7 @@ export const surveyLicenseKey = process.env.NEXT_PUBLIC_SURVEYJS_KEY
 
 export const pirschAnalyticsKey = process.env.NEXT_PUBLIC_PIRSCH_KEY
 export const isDevelopment = process.env.NODE_ENV === 'development'
+export const useInsecureCookies = process.env.COOKIE_PLAYWRIGHT_INSECURE === 'true' || isDevelopment
 export const isVercelDev = process.env.VERCEL_ENV === 'development' || process.env.VERCEL_ENV === 'preview'
 
 export const recaptchaSiteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY


### PR DESCRIPTION
if we got 401 error for some reason but our session was fine, we could have logged out user / kill their session. this now only happens if session is no longer valid. tested locally