### PR TITLE
test(console): unit coverage for filters, storage, formatting and pla…

### DIFF
--- a/apps/console/src/components/pages/protected/auditor-dashboard/utils/control-status.test.ts
+++ b/apps/console/src/components/pages/protected/auditor-dashboard/utils/control-status.test.ts
@@ -2,8 +2,8 @@ import { EvidenceEvidenceStatus, ReviewReviewStatus } from '@repo/codegen/src/sc
 import { getControlEvidenceStatus, getControlLastReviewed, getControlReview, type ControlReviewSummary } from './control-status'
 
 /**
- * ISS-2433 — both roll-ups are priority-ordered, and the ordering is the point: the row must
- * surface the most blocking evidence state and the most active review.
+ * Both roll-ups are priority-ordered, and the ordering is the point: the row must surface the most blocking
+ * evidence state and the most active review.
  */
 
 const review = (over: Partial<ControlReviewSummary>): ControlReviewSummary => ({ id: 'r-1', ...over })

--- a/apps/console/src/components/pages/protected/auditor-dashboard/utils/control-status.test.ts
+++ b/apps/console/src/components/pages/protected/auditor-dashboard/utils/control-status.test.ts
@@ -2,11 +2,8 @@ import { EvidenceEvidenceStatus, ReviewReviewStatus } from '@repo/codegen/src/sc
 import { getControlEvidenceStatus, getControlLastReviewed, getControlReview, type ControlReviewSummary } from './control-status'
 
 /**
- * ISS-2433 — the auditor dashboard rolls a control's many evidence records and
- * reviews up into one status per row. Both roll-ups are priority-ordered, and
- * the ordering is the point: the row must surface the MOST BLOCKING evidence
- * state (so an approved artifact never hides a rejected one) and the MOST ACTIVE
- * review (so a completed review never hides one still in progress).
+ * ISS-2433 — both roll-ups are priority-ordered, and the ordering is the point: the row must
+ * surface the most blocking evidence state and the most active review.
  */
 
 const review = (over: Partial<ControlReviewSummary>): ControlReviewSummary => ({ id: 'r-1', ...over })

--- a/apps/console/src/components/pages/protected/auditor-dashboard/utils/control-status.test.ts
+++ b/apps/console/src/components/pages/protected/auditor-dashboard/utils/control-status.test.ts
@@ -1,0 +1,104 @@
+import { EvidenceEvidenceStatus, ReviewReviewStatus } from '@repo/codegen/src/schema'
+import { getControlEvidenceStatus, getControlLastReviewed, getControlReview, type ControlReviewSummary } from './control-status'
+
+/**
+ * ISS-2433 — the auditor dashboard rolls a control's many evidence records and
+ * reviews up into one status per row. Both roll-ups are priority-ordered, and
+ * the ordering is the point: the row must surface the MOST BLOCKING evidence
+ * state (so an approved artifact never hides a rejected one) and the MOST ACTIVE
+ * review (so a completed review never hides one still in progress).
+ */
+
+const review = (over: Partial<ControlReviewSummary>): ControlReviewSummary => ({ id: 'r-1', ...over })
+
+describe('getControlEvidenceStatus', () => {
+  test('returns null when a control has no evidence', () => {
+    expect(getControlEvidenceStatus([])).toBeNull()
+  })
+
+  test('returns null when every entry is null or undefined', () => {
+    expect(getControlEvidenceStatus([null, undefined])).toBeNull()
+  })
+
+  test('surfaces the most blocking status, not the first one present', () => {
+    const status = getControlEvidenceStatus([EvidenceEvidenceStatus.AUDITOR_APPROVED, EvidenceEvidenceStatus.REJECTED])
+
+    expect(status).toBe(EvidenceEvidenceStatus.REJECTED)
+  })
+
+  test('ranks MISSING_ARTIFACT above every other state', () => {
+    const status = getControlEvidenceStatus([EvidenceEvidenceStatus.REJECTED, EvidenceEvidenceStatus.MISSING_ARTIFACT, EvidenceEvidenceStatus.NEEDS_RENEWAL])
+
+    expect(status).toBe(EvidenceEvidenceStatus.MISSING_ARTIFACT)
+  })
+
+  test('ranks REJECTED above NEEDS_RENEWAL', () => {
+    expect(getControlEvidenceStatus([EvidenceEvidenceStatus.NEEDS_RENEWAL, EvidenceEvidenceStatus.REJECTED])).toBe(EvidenceEvidenceStatus.REJECTED)
+  })
+
+  test('only reports AUDITOR_APPROVED when nothing more blocking exists', () => {
+    expect(getControlEvidenceStatus([EvidenceEvidenceStatus.AUDITOR_APPROVED])).toBe(EvidenceEvidenceStatus.AUDITOR_APPROVED)
+  })
+
+  test('ignores nulls mixed in with real statuses', () => {
+    expect(getControlEvidenceStatus([null, EvidenceEvidenceStatus.REQUESTED, undefined])).toBe(EvidenceEvidenceStatus.REQUESTED)
+  })
+})
+
+describe('getControlReview', () => {
+  test('returns null when a control has no reviews', () => {
+    expect(getControlReview([])).toBeNull()
+  })
+
+  test('prefers an in-progress review over a completed one', () => {
+    const picked = getControlReview([review({ id: 'done', status: ReviewReviewStatus.COMPLETED }), review({ id: 'active', status: ReviewReviewStatus.IN_PROGRESS })])
+
+    expect(picked?.id).toBe('active')
+  })
+
+  test('prefers IN_PROGRESS over IN_REVIEW over OPEN', () => {
+    const reviews = [
+      review({ id: 'open', status: ReviewReviewStatus.OPEN }),
+      review({ id: 'inreview', status: ReviewReviewStatus.IN_REVIEW }),
+      review({ id: 'inprogress', status: ReviewReviewStatus.IN_PROGRESS }),
+    ]
+
+    expect(getControlReview(reviews)?.id).toBe('inprogress')
+    expect(getControlReview(reviews.slice(0, 2))?.id).toBe('inreview')
+  })
+
+  test('ranks WONT_DO last', () => {
+    const picked = getControlReview([review({ id: 'wontdo', status: ReviewReviewStatus.WONT_DO }), review({ id: 'done', status: ReviewReviewStatus.COMPLETED })])
+
+    expect(picked?.id).toBe('done')
+  })
+
+  test('falls back to the first review when none carry a known status', () => {
+    const picked = getControlReview([review({ id: 'first', status: null }), review({ id: 'second' })])
+
+    expect(picked?.id).toBe('first')
+  })
+})
+
+describe('getControlLastReviewed', () => {
+  test('returns null when no review has been reviewed', () => {
+    expect(getControlLastReviewed([])).toBeNull()
+    expect(getControlLastReviewed([review({ reviewedAt: null })])).toBeNull()
+  })
+
+  test('returns the most recent reviewedAt regardless of input order', () => {
+    const reviews = [
+      review({ id: 'a', reviewedAt: '2026-01-01T00:00:00.000Z' }),
+      review({ id: 'b', reviewedAt: '2026-07-01T00:00:00.000Z' }),
+      review({ id: 'c', reviewedAt: '2026-03-01T00:00:00.000Z' }),
+    ]
+
+    expect(getControlLastReviewed(reviews)).toBe('2026-07-01T00:00:00.000Z')
+  })
+
+  test('ignores reviews with no reviewedAt', () => {
+    const reviews = [review({ id: 'a', reviewedAt: null }), review({ id: 'b', reviewedAt: '2026-02-01T00:00:00.000Z' })]
+
+    expect(getControlLastReviewed(reviews)).toBe('2026-02-01T00:00:00.000Z')
+  })
+})

--- a/apps/console/src/components/pages/protected/campaigns/create/steps/targets/target-entry.test.ts
+++ b/apps/console/src/components/pages/protected/campaigns/create/steps/targets/target-entry.test.ts
@@ -1,9 +1,9 @@
 import { type CampaignTargetEntry, getRecipientDisplayName, hasTarget, mergeTargets, removeTarget, toCampaignTargetInputs, toEmailKeys, toggleTarget } from './target-entry'
 
 /**
- * ISS-2560 / #2073 — recipients arrive from personnel, contacts, CSV and manual entry, so the
- * same person routinely arrives twice. Email is the identity key, and merging enriches rather
- * than replaces: a manual entry later matched to a contact keeps the contactID.
+ * Recipients arrive from personnel, contacts, CSV and manual entry, so the same person routinely arrives
+ * twice. Email is the identity key, and merging enriches rather than replaces: a manual entry later matched
+ * to a contact keeps the contactID.
  */
 
 const target = (over: Partial<CampaignTargetEntry> = {}): CampaignTargetEntry => ({

--- a/apps/console/src/components/pages/protected/campaigns/create/steps/targets/target-entry.test.ts
+++ b/apps/console/src/components/pages/protected/campaigns/create/steps/targets/target-entry.test.ts
@@ -1,0 +1,139 @@
+import { type CampaignTargetEntry, getRecipientDisplayName, hasTarget, mergeTargets, removeTarget, toCampaignTargetInputs, toEmailKeys, toggleTarget } from './target-entry'
+
+/**
+ * ISS-2560 / #2073 — campaign recipients can be assembled from personnel,
+ * contacts, a CSV and manual entry, so the same person routinely arrives twice.
+ * Email is the identity key throughout, compared case- and whitespace-insensitively.
+ *
+ * The rules that fail silently if broken:
+ *  - merging ENRICHES rather than replaces: a manual entry that later matches a
+ *    contact keeps the contactID, and a blank name is filled from the duplicate
+ *  - a recipient whose "name" is just their email address is sent with no name,
+ *    so the email is not printed twice in the greeting
+ *  - invalid and excluded emails are dropped at conversion, not earlier, so the
+ *    picker can still show them
+ */
+
+const target = (over: Partial<CampaignTargetEntry> = {}): CampaignTargetEntry => ({
+  email: 'user@acme.com',
+  fullName: 'Ada Lovelace',
+  source: 'manual',
+  ...over,
+})
+
+describe('hasTarget', () => {
+  test('matches ignoring case and whitespace', () => {
+    const targets = [target({ email: 'user@acme.com' })]
+
+    expect(hasTarget(targets, '  USER@ACME.COM ')).toBe(true)
+    expect(hasTarget(targets, 'other@acme.com')).toBe(false)
+  })
+})
+
+describe('mergeTargets', () => {
+  test('keeps one entry per email regardless of case', () => {
+    const merged = mergeTargets([target({ email: 'user@acme.com' })], [target({ email: 'USER@acme.com' })])
+
+    expect(merged).toHaveLength(1)
+  })
+
+  test('fills a blank name from the incoming duplicate', () => {
+    const merged = mergeTargets([target({ fullName: '' })], [target({ fullName: 'Ada Lovelace' })])
+
+    expect(merged[0].fullName).toBe('Ada Lovelace')
+  })
+
+  test('keeps the existing name when both have one', () => {
+    const merged = mergeTargets([target({ fullName: 'Existing' })], [target({ fullName: 'Incoming' })])
+
+    expect(merged[0].fullName).toBe('Existing')
+  })
+
+  test('adopts a contactID from the duplicate when the existing entry has none', () => {
+    // A manually-typed address later matched to a contact must gain its id.
+    const merged = mergeTargets([target({ source: 'manual' })], [target({ source: 'contact', contactID: 'c-1' })])
+
+    expect(merged[0].contactID).toBe('c-1')
+  })
+
+  test('does not overwrite an existing contactID', () => {
+    const merged = mergeTargets([target({ contactID: 'c-1' })], [target({ contactID: 'c-2' })])
+
+    expect(merged[0].contactID).toBe('c-1')
+  })
+
+  test('drops entries with a blank email', () => {
+    expect(mergeTargets([], [target({ email: '   ' })])).toEqual([])
+  })
+
+  test('preserves distinct recipients', () => {
+    const merged = mergeTargets([target({ email: 'a@acme.com' })], [target({ email: 'b@acme.com' })])
+
+    expect(merged).toHaveLength(2)
+  })
+})
+
+describe('removeTarget and toggleTarget', () => {
+  test('removes ignoring case', () => {
+    expect(removeTarget([target({ email: 'user@acme.com' })], 'USER@ACME.COM')).toEqual([])
+  })
+
+  test('toggle adds then removes the same recipient', () => {
+    const entry = target({ email: 'user@acme.com' })
+    const added = toggleTarget([], entry)
+    expect(added).toHaveLength(1)
+
+    expect(toggleTarget(added, entry)).toEqual([])
+  })
+})
+
+describe('getRecipientDisplayName', () => {
+  test('blanks a name that is just the email address', () => {
+    expect(getRecipientDisplayName('user@acme.com', 'user@acme.com')).toBe('')
+    expect(getRecipientDisplayName('  USER@ACME.COM ', 'user@acme.com')).toBe('')
+  })
+
+  test('keeps a real name, trimmed', () => {
+    expect(getRecipientDisplayName('  Ada Lovelace ', 'user@acme.com')).toBe('Ada Lovelace')
+  })
+})
+
+describe('toCampaignTargetInputs', () => {
+  test('converts a valid recipient', () => {
+    expect(toCampaignTargetInputs([target({ email: 'user@acme.com', fullName: 'Ada', contactID: 'c-1' })])).toEqual([{ email: 'user@acme.com', fullName: 'Ada', contactID: 'c-1' }])
+  })
+
+  test('drops invalid email addresses', () => {
+    expect(toCampaignTargetInputs([target({ email: 'not-an-email' })])).toEqual([])
+  })
+
+  test('drops excluded emails, matched case-insensitively', () => {
+    const excluded = toEmailKeys(['USER@ACME.COM'])
+
+    expect(toCampaignTargetInputs([target({ email: 'user@acme.com' })], excluded)).toEqual([])
+  })
+
+  test('omits fullName when it is only the email address', () => {
+    const [input] = toCampaignTargetInputs([target({ email: 'user@acme.com', fullName: 'user@acme.com' })])
+
+    expect(input.fullName).toBeUndefined()
+  })
+
+  test('omits an empty contactID rather than sending a blank string', () => {
+    const [input] = toCampaignTargetInputs([target({ contactID: '' })])
+
+    expect(input.contactID).toBeUndefined()
+  })
+
+  test('trims the email it sends', () => {
+    const [input] = toCampaignTargetInputs([target({ email: '  user@acme.com  ' })])
+
+    expect(input.email).toBe('user@acme.com')
+  })
+})
+
+describe('toEmailKeys', () => {
+  test('normalises and drops blanks', () => {
+    expect(toEmailKeys(['  USER@ACME.COM ', '', 'other@acme.com'])).toEqual(new Set(['user@acme.com', 'other@acme.com']))
+  })
+})

--- a/apps/console/src/components/pages/protected/campaigns/create/steps/targets/target-entry.test.ts
+++ b/apps/console/src/components/pages/protected/campaigns/create/steps/targets/target-entry.test.ts
@@ -1,17 +1,9 @@
 import { type CampaignTargetEntry, getRecipientDisplayName, hasTarget, mergeTargets, removeTarget, toCampaignTargetInputs, toEmailKeys, toggleTarget } from './target-entry'
 
 /**
- * ISS-2560 / #2073 — campaign recipients can be assembled from personnel,
- * contacts, a CSV and manual entry, so the same person routinely arrives twice.
- * Email is the identity key throughout, compared case- and whitespace-insensitively.
- *
- * The rules that fail silently if broken:
- *  - merging ENRICHES rather than replaces: a manual entry that later matches a
- *    contact keeps the contactID, and a blank name is filled from the duplicate
- *  - a recipient whose "name" is just their email address is sent with no name,
- *    so the email is not printed twice in the greeting
- *  - invalid and excluded emails are dropped at conversion, not earlier, so the
- *    picker can still show them
+ * ISS-2560 / #2073 — recipients arrive from personnel, contacts, CSV and manual entry, so the
+ * same person routinely arrives twice. Email is the identity key, and merging enriches rather
+ * than replaces: a manual entry later matched to a contact keeps the contactID.
  */
 
 const target = (over: Partial<CampaignTargetEntry> = {}): CampaignTargetEntry => ({

--- a/apps/console/src/components/pages/protected/campaigns/recurrence/campaign-recurrence.test.ts
+++ b/apps/console/src/components/pages/protected/campaigns/recurrence/campaign-recurrence.test.ts
@@ -1,0 +1,132 @@
+import { CampaignFrequency } from '@repo/codegen/src/schema'
+import { buildRecurrenceUpdateInput, describeCampaignRecurrence, describeRecurrence, toRecurrenceValues, type CampaignRecurrenceSource, type CampaignRecurrenceValues } from './campaign-recurrence'
+
+/**
+ * #2110 — recurring campaigns. Three pieces of pure logic here:
+ *
+ *  - toRecurrenceValues turns a possibly-null campaign into safe form defaults,
+ *    coercing NONE / zero / negative values rather than showing them
+ *  - buildRecurrenceUpdateInput must emit clearRecurrenceEndAt when the end date
+ *    is removed; omitting the key would silently keep the old end date
+ *  - describeRecurrence collapses frequency × interval into a human phrase, and
+ *    has to fold whole years ("Every 2 years", not "Every 24 months")
+ */
+
+const source = (over: Partial<CampaignRecurrenceSource> = {}): CampaignRecurrenceSource =>
+  ({
+    isRecurring: false,
+    recurrenceFrequency: null,
+    recurrenceInterval: null,
+    recurrenceTimezone: null,
+    recurrenceEndAt: null,
+    ...over,
+  }) as CampaignRecurrenceSource
+
+const values = (over: Partial<CampaignRecurrenceValues> = {}): CampaignRecurrenceValues => ({
+  isRecurring: true,
+  frequency: CampaignFrequency.MONTHLY,
+  interval: 1,
+  timezone: 'UTC',
+  endAt: null,
+  ...over,
+})
+
+describe('toRecurrenceValues', () => {
+  test('produces safe defaults for a null campaign', () => {
+    const result = toRecurrenceValues(null)
+
+    expect(result.isRecurring).toBe(false)
+    expect(result.frequency).toBe(CampaignFrequency.MONTHLY)
+    expect(result.interval).toBe(1)
+    expect(result.endAt).toBeNull()
+    expect(result.timezone).toMatch(/\S/)
+  })
+
+  test('coerces a NONE frequency to the first supported one', () => {
+    expect(toRecurrenceValues(source({ recurrenceFrequency: CampaignFrequency.NONE })).frequency).toBe(CampaignFrequency.MONTHLY)
+  })
+
+  test('coerces a zero or negative interval to 1', () => {
+    expect(toRecurrenceValues(source({ recurrenceInterval: 0 })).interval).toBe(1)
+    expect(toRecurrenceValues(source({ recurrenceInterval: -2 })).interval).toBe(1)
+  })
+
+  test('preserves a real frequency, interval and timezone', () => {
+    const result = toRecurrenceValues(source({ isRecurring: true, recurrenceFrequency: CampaignFrequency.QUARTERLY, recurrenceInterval: 2, recurrenceTimezone: 'America/New_York' }))
+
+    expect(result).toMatchObject({ isRecurring: true, frequency: CampaignFrequency.QUARTERLY, interval: 2, timezone: 'America/New_York' })
+  })
+
+  test('parses an end date into a Date', () => {
+    const result = toRecurrenceValues(source({ recurrenceEndAt: '2026-12-31T00:00:00.000Z' }))
+
+    expect(result.endAt).toBeInstanceOf(Date)
+  })
+})
+
+describe('buildRecurrenceUpdateInput', () => {
+  test('sends only isRecurring:false when recurrence is off', () => {
+    expect(buildRecurrenceUpdateInput(values({ isRecurring: false }))).toEqual({ isRecurring: false })
+  })
+
+  test('sends the full recurrence shape when on', () => {
+    const input = buildRecurrenceUpdateInput(values({ frequency: CampaignFrequency.QUARTERLY, interval: 2, timezone: 'UTC', endAt: new Date('2026-12-31T00:00:00.000Z') }))
+
+    expect(input).toMatchObject({
+      isRecurring: true,
+      recurrenceFrequency: CampaignFrequency.QUARTERLY,
+      recurrenceInterval: 2,
+      recurrenceTimezone: 'UTC',
+      recurrenceEndAt: '2026-12-31T00:00:00.000Z',
+    })
+  })
+
+  test('explicitly clears the end date when it is removed', () => {
+    // Omitting the key would leave the previous end date in place.
+    const input = buildRecurrenceUpdateInput(values({ endAt: null }))
+
+    expect(input).toMatchObject({ clearRecurrenceEndAt: true })
+    expect(input).not.toHaveProperty('recurrenceEndAt')
+  })
+})
+
+describe('describeRecurrence', () => {
+  test('reports a non-recurring campaign', () => {
+    expect(describeRecurrence({ isRecurring: false, frequency: CampaignFrequency.MONTHLY, interval: 1 })).toBe('Does not repeat')
+  })
+
+  test('reports a NONE frequency as non-recurring even when the flag is on', () => {
+    expect(describeRecurrence({ isRecurring: true, frequency: CampaignFrequency.NONE, interval: 1 })).toBe('Does not repeat')
+  })
+
+  test('describes single-cycle frequencies', () => {
+    expect(describeRecurrence({ isRecurring: true, frequency: CampaignFrequency.MONTHLY, interval: 1 })).toBe('Every month')
+    expect(describeRecurrence({ isRecurring: true, frequency: CampaignFrequency.QUARTERLY, interval: 1 })).toBe('Every 3 months')
+    expect(describeRecurrence({ isRecurring: true, frequency: CampaignFrequency.YEARLY, interval: 1 })).toBe('Every year')
+  })
+
+  test('folds whole years rather than reporting months', () => {
+    // 12 monthly cycles is "Every year", not "Every 12 months".
+    expect(describeRecurrence({ isRecurring: true, frequency: CampaignFrequency.MONTHLY, interval: 12 })).toBe('Every year')
+    expect(describeRecurrence({ isRecurring: true, frequency: CampaignFrequency.QUARTERLY, interval: 8 })).toBe('Every 2 years')
+  })
+
+  test('multiplies frequency by interval', () => {
+    expect(describeRecurrence({ isRecurring: true, frequency: CampaignFrequency.MONTHLY, interval: 2 })).toBe('Every 2 months')
+    expect(describeRecurrence({ isRecurring: true, frequency: CampaignFrequency.BIANNUALLY, interval: 1 })).toBe('Every 6 months')
+  })
+
+  test('treats a zero or negative interval as 1', () => {
+    expect(describeRecurrence({ isRecurring: true, frequency: CampaignFrequency.MONTHLY, interval: 0 })).toBe('Every month')
+  })
+})
+
+describe('describeCampaignRecurrence', () => {
+  test('reads recurrence straight off a campaign record', () => {
+    expect(describeCampaignRecurrence(source({ isRecurring: true, recurrenceFrequency: CampaignFrequency.QUARTERLY, recurrenceInterval: 1 }))).toBe('Every 3 months')
+  })
+
+  test('reports a campaign with no recurrence set', () => {
+    expect(describeCampaignRecurrence(source())).toBe('Does not repeat')
+  })
+})

--- a/apps/console/src/components/pages/protected/campaigns/recurrence/campaign-recurrence.test.ts
+++ b/apps/console/src/components/pages/protected/campaigns/recurrence/campaign-recurrence.test.ts
@@ -2,14 +2,8 @@ import { CampaignFrequency } from '@repo/codegen/src/schema'
 import { buildRecurrenceUpdateInput, describeCampaignRecurrence, describeRecurrence, toRecurrenceValues, type CampaignRecurrenceSource, type CampaignRecurrenceValues } from './campaign-recurrence'
 
 /**
- * #2110 — recurring campaigns. Three pieces of pure logic here:
- *
- *  - toRecurrenceValues turns a possibly-null campaign into safe form defaults,
- *    coercing NONE / zero / negative values rather than showing them
- *  - buildRecurrenceUpdateInput must emit clearRecurrenceEndAt when the end date
- *    is removed; omitting the key would silently keep the old end date
- *  - describeRecurrence collapses frequency × interval into a human phrase, and
- *    has to fold whole years ("Every 2 years", not "Every 24 months")
+ * #2110 — recurring campaigns. buildRecurrenceUpdateInput must emit clearRecurrenceEndAt when
+ * the end date is removed; omitting the key silently keeps the old one.
  */
 
 const source = (over: Partial<CampaignRecurrenceSource> = {}): CampaignRecurrenceSource =>

--- a/apps/console/src/components/pages/protected/campaigns/recurrence/campaign-recurrence.test.ts
+++ b/apps/console/src/components/pages/protected/campaigns/recurrence/campaign-recurrence.test.ts
@@ -2,8 +2,8 @@ import { CampaignFrequency } from '@repo/codegen/src/schema'
 import { buildRecurrenceUpdateInput, describeCampaignRecurrence, describeRecurrence, toRecurrenceValues, type CampaignRecurrenceSource, type CampaignRecurrenceValues } from './campaign-recurrence'
 
 /**
- * #2110 — recurring campaigns. buildRecurrenceUpdateInput must emit clearRecurrenceEndAt when
- * the end date is removed; omitting the key silently keeps the old one.
+ * Recurring campaigns. buildRecurrenceUpdateInput must emit clearRecurrenceEndAt when the end date is
+ * removed; omitting the key silently keeps the old one.
  */
 
 const source = (over: Partial<CampaignRecurrenceSource> = {}): CampaignRecurrenceSource =>

--- a/apps/console/src/components/pages/protected/control-report/report-coverage.test.ts
+++ b/apps/console/src/components/pages/protected/control-report/report-coverage.test.ts
@@ -3,17 +3,9 @@ import { type ControlReportItem } from '@/lib/graphql-hooks/control'
 import { deriveOrgCoverage, getFrameworkRelatedControls, getOrgRelatedControls, hasOrgCoverageGap, hasPolicyGap, type RelatedControlItem } from './report-coverage'
 
 /**
- * The control report's org-coverage column and its "gap" filters are driven by
- * these pure helpers. The rules that are easy to regress:
- *
- *  - a related control counts as ORG-owned when it has no referenceFramework or
- *    that framework is literally 'CUSTOM'
- *  - ARCHIVED / NOT_APPLICABLE refs are excluded from the active tally but stay
- *    in orgControlRefs (the chip list still shows them)
- *  - worstStatus is the earliest entry in ORG_COVERAGE_SEVERITY_ORDER, which is
- *    ordered worst → best, so APPROVED only wins when nothing else is present
- *  - both gap predicates apply to FRAMEWORK controls only; a custom control can
- *    never be "missing org coverage"
+ * Drives the control report's org-coverage column and its gap filters. A related control counts
+ * as org-owned when it has no referenceFramework or that framework is 'CUSTOM', and worstStatus
+ * takes the earliest entry in ORG_COVERAGE_SEVERITY_ORDER.
  */
 
 const related = (over: Partial<RelatedControlItem> = {}): RelatedControlItem =>

--- a/apps/console/src/components/pages/protected/control-report/report-coverage.test.ts
+++ b/apps/console/src/components/pages/protected/control-report/report-coverage.test.ts
@@ -1,0 +1,128 @@
+import { ControlControlStatus } from '@repo/codegen/src/schema'
+import { type ControlReportItem } from '@/lib/graphql-hooks/control'
+import { deriveOrgCoverage, getFrameworkRelatedControls, getOrgRelatedControls, hasOrgCoverageGap, hasPolicyGap, type RelatedControlItem } from './report-coverage'
+
+/**
+ * The control report's org-coverage column and its "gap" filters are driven by
+ * these pure helpers. The rules that are easy to regress:
+ *
+ *  - a related control counts as ORG-owned when it has no referenceFramework or
+ *    that framework is literally 'CUSTOM'
+ *  - ARCHIVED / NOT_APPLICABLE refs are excluded from the active tally but stay
+ *    in orgControlRefs (the chip list still shows them)
+ *  - worstStatus is the earliest entry in ORG_COVERAGE_SEVERITY_ORDER, which is
+ *    ordered worst → best, so APPROVED only wins when nothing else is present
+ *  - both gap predicates apply to FRAMEWORK controls only; a custom control can
+ *    never be "missing org coverage"
+ */
+
+const related = (over: Partial<RelatedControlItem> = {}): RelatedControlItem =>
+  ({
+    id: over.id ?? 'rc-1',
+    refCode: over.refCode ?? 'ORG-1',
+    status: over.status ?? ControlControlStatus.APPROVED,
+    referenceFramework: 'referenceFramework' in over ? over.referenceFramework : null,
+  }) as RelatedControlItem
+
+const control = (over: Partial<ControlReportItem> = {}): ControlReportItem =>
+  ({
+    id: 'c-1',
+    refCode: 'CC1.1',
+    referenceFramework: 'SOC2',
+    relatedControls: [],
+    linkedPolicies: { totalCount: 0, internalPolicies: [] },
+    ...over,
+  }) as unknown as ControlReportItem
+
+describe('org vs framework partitioning', () => {
+  test('treats a missing referenceFramework as org-owned', () => {
+    expect(getOrgRelatedControls([related({ referenceFramework: null })])).toHaveLength(1)
+    expect(getFrameworkRelatedControls([related({ referenceFramework: null })])).toHaveLength(0)
+  })
+
+  test("treats the literal 'CUSTOM' framework as org-owned", () => {
+    expect(getOrgRelatedControls([related({ referenceFramework: 'CUSTOM' })])).toHaveLength(1)
+  })
+
+  test('treats a named framework as framework-owned', () => {
+    expect(getOrgRelatedControls([related({ referenceFramework: 'SOC2' })])).toHaveLength(0)
+    expect(getFrameworkRelatedControls([related({ referenceFramework: 'SOC2' })])).toHaveLength(1)
+  })
+
+  test('tolerates null/undefined input', () => {
+    expect(getOrgRelatedControls(null)).toEqual([])
+    expect(getFrameworkRelatedControls(undefined)).toEqual([])
+  })
+})
+
+describe('deriveOrgCoverage', () => {
+  test('returns null when there is no org-owned related control', () => {
+    expect(deriveOrgCoverage([])).toBeNull()
+    expect(deriveOrgCoverage([related({ referenceFramework: 'SOC2' })])).toBeNull()
+  })
+
+  test('counts approved refs and reports APPROVED as the worst when all are approved', () => {
+    const coverage = deriveOrgCoverage([related({ id: 'a', status: ControlControlStatus.APPROVED }), related({ id: 'b', status: ControlControlStatus.APPROVED })])
+
+    expect(coverage).toMatchObject({ approvedCount: 2, activeCount: 2, worstStatus: ControlControlStatus.APPROVED })
+  })
+
+  test('picks the worst status by severity order, not by input order', () => {
+    const coverage = deriveOrgCoverage([
+      related({ id: 'a', status: ControlControlStatus.APPROVED }),
+      related({ id: 'b', status: ControlControlStatus.NOT_IMPLEMENTED }),
+      related({ id: 'c', status: ControlControlStatus.CHANGES_REQUESTED }),
+    ])
+
+    expect(coverage?.worstStatus).toBe(ControlControlStatus.CHANGES_REQUESTED)
+    expect(coverage?.approvedCount).toBe(1)
+    expect(coverage?.activeCount).toBe(3)
+  })
+
+  test('excludes ARCHIVED and NOT_APPLICABLE from the active tally but keeps them in the ref list', () => {
+    const coverage = deriveOrgCoverage([
+      related({ id: 'a', status: ControlControlStatus.APPROVED }),
+      related({ id: 'b', status: ControlControlStatus.ARCHIVED }),
+      related({ id: 'c', status: ControlControlStatus.NOT_APPLICABLE }),
+    ])
+
+    expect(coverage?.activeCount).toBe(1)
+    expect(coverage?.approvedCount).toBe(1)
+    expect(coverage?.orgControlRefs).toHaveLength(3)
+  })
+
+  test('reports zero active coverage when every org ref is inactive', () => {
+    const coverage = deriveOrgCoverage([related({ id: 'a', status: ControlControlStatus.ARCHIVED })])
+
+    expect(coverage).not.toBeNull()
+    expect(coverage?.activeCount).toBe(0)
+    expect(coverage?.worstStatus).toBeNull()
+  })
+})
+
+describe('gap predicates', () => {
+  test('a custom control never counts as having a coverage or policy gap', () => {
+    const custom = control({ referenceFramework: 'CUSTOM', relatedControls: [], linkedPolicies: { totalCount: 0, internalPolicies: [] } })
+
+    expect(hasOrgCoverageGap(custom)).toBe(false)
+    expect(hasPolicyGap(custom)).toBe(false)
+  })
+
+  test('a framework control with no org-owned related control has a coverage gap', () => {
+    expect(hasOrgCoverageGap(control({ relatedControls: [] }))).toBe(true)
+    expect(hasOrgCoverageGap(control({ relatedControls: [related({ referenceFramework: 'SOC2' })] }))).toBe(true)
+  })
+
+  test('a framework control whose only org coverage is archived still has a gap', () => {
+    expect(hasOrgCoverageGap(control({ relatedControls: [related({ status: ControlControlStatus.ARCHIVED })] }))).toBe(true)
+  })
+
+  test('a framework control with active org coverage has no gap', () => {
+    expect(hasOrgCoverageGap(control({ relatedControls: [related({ status: ControlControlStatus.NOT_IMPLEMENTED })] }))).toBe(false)
+  })
+
+  test('policy gap tracks the linked internal policies list', () => {
+    expect(hasPolicyGap(control({ linkedPolicies: { totalCount: 0, internalPolicies: [] } }))).toBe(true)
+    expect(hasPolicyGap(control({ linkedPolicies: { totalCount: 1, internalPolicies: [{ id: 'p-1' }] } } as unknown as Partial<ControlReportItem>))).toBe(false)
+  })
+})

--- a/apps/console/src/components/pages/protected/control-report/report-coverage.test.ts
+++ b/apps/console/src/components/pages/protected/control-report/report-coverage.test.ts
@@ -3,9 +3,9 @@ import { type ControlReportItem } from '@/lib/graphql-hooks/control'
 import { deriveOrgCoverage, getFrameworkRelatedControls, getOrgRelatedControls, hasOrgCoverageGap, hasPolicyGap, type RelatedControlItem } from './report-coverage'
 
 /**
- * Drives the control report's org-coverage column and its gap filters. A related control counts
- * as org-owned when it has no referenceFramework or that framework is 'CUSTOM', and worstStatus
- * takes the earliest entry in ORG_COVERAGE_SEVERITY_ORDER.
+ * Drives the control report's org-coverage column and its gap filters. A related control counts as org-owned
+ * when it has no referenceFramework or that framework is 'CUSTOM', and worstStatus takes the earliest entry
+ * in ORG_COVERAGE_SEVERITY_ORDER.
  */
 
 const related = (over: Partial<RelatedControlItem> = {}): RelatedControlItem =>

--- a/apps/console/src/components/pages/protected/policies/view/tabs/history/utils.test.ts
+++ b/apps/console/src/components/pages/protected/policies/view/tabs/history/utils.test.ts
@@ -1,13 +1,9 @@
 import { getRevisionKind, makeGroupResolver, parseRevision, toPlateValue } from './utils'
 
 /**
- * ISS-2256 — the policy history diff printed raw group ULIDs for Approver and
- * Delegate. makeGroupResolver maps an id to its group name, falling back to the
- * id when the name is not loaded yet, and passing null/undefined straight
- * through so an unset field still diffs as empty rather than as the string
- * "undefined".
- *
- * parseRevision / getRevisionKind back the major-vs-minor badge on the same tab.
+ * ISS-2256 — the policy history diff printed raw group ULIDs for Approver and Delegate.
+ * makeGroupResolver maps id to name, passing null through so an unset field diffs as empty
+ * rather than as the string "undefined".
  */
 describe('makeGroupResolver', () => {
   const map = new Map([['01HXGROUP0000000000000000A', 'Security Team']])

--- a/apps/console/src/components/pages/protected/policies/view/tabs/history/utils.test.ts
+++ b/apps/console/src/components/pages/protected/policies/view/tabs/history/utils.test.ts
@@ -1,0 +1,85 @@
+import { getRevisionKind, makeGroupResolver, parseRevision, toPlateValue } from './utils'
+
+/**
+ * ISS-2256 — the policy history diff printed raw group ULIDs for Approver and
+ * Delegate. makeGroupResolver maps an id to its group name, falling back to the
+ * id when the name is not loaded yet, and passing null/undefined straight
+ * through so an unset field still diffs as empty rather than as the string
+ * "undefined".
+ *
+ * parseRevision / getRevisionKind back the major-vs-minor badge on the same tab.
+ */
+describe('makeGroupResolver', () => {
+  const map = new Map([['01HXGROUP0000000000000000A', 'Security Team']])
+
+  test('resolves a known id to its group name', () => {
+    expect(makeGroupResolver(map)('01HXGROUP0000000000000000A')).toBe('Security Team')
+  })
+
+  test('falls back to the raw id when the name is not in the map', () => {
+    expect(makeGroupResolver(map)('01HXUNKNOWN00000000000000B')).toBe('01HXUNKNOWN00000000000000B')
+  })
+
+  test('falls back to the raw id when there is no map at all', () => {
+    expect(makeGroupResolver(undefined)('01HXGROUP0000000000000000A')).toBe('01HXGROUP0000000000000000A')
+  })
+
+  test('passes null and undefined through unchanged', () => {
+    // A cleared approver must stay empty in the diff, not become "undefined".
+    expect(makeGroupResolver(map)(null)).toBeNull()
+    expect(makeGroupResolver(map)(undefined)).toBeUndefined()
+  })
+
+  test('passes an empty string through unchanged', () => {
+    expect(makeGroupResolver(map)('')).toBe('')
+  })
+})
+
+describe('parseRevision', () => {
+  test('parses a plain semver triple', () => {
+    expect(parseRevision('1.2.3')).toEqual({ major: 1, minor: 2, patch: 3 })
+  })
+
+  test('tolerates a leading v in either case', () => {
+    expect(parseRevision('v1.2.3')).toEqual({ major: 1, minor: 2, patch: 3 })
+    expect(parseRevision('V1.2.3')).toEqual({ major: 1, minor: 2, patch: 3 })
+  })
+
+  test('returns null for empty, short or non-numeric revisions', () => {
+    expect(parseRevision(null)).toBeNull()
+    expect(parseRevision(undefined)).toBeNull()
+    expect(parseRevision('')).toBeNull()
+    expect(parseRevision('1.2')).toBeNull()
+    expect(parseRevision('v1.x.3')).toBeNull()
+  })
+})
+
+describe('getRevisionKind', () => {
+  test('is major only when both minor and patch are zero', () => {
+    expect(getRevisionKind('v2.0.0')).toBe('major')
+  })
+
+  test('is minor when either minor or patch is non-zero', () => {
+    expect(getRevisionKind('v2.1.0')).toBe('minor')
+    expect(getRevisionKind('v2.0.1')).toBe('minor')
+  })
+
+  test('defaults to minor for an unparseable revision', () => {
+    expect(getRevisionKind(null)).toBe('minor')
+    expect(getRevisionKind('draft')).toBe('minor')
+  })
+})
+
+describe('toPlateValue', () => {
+  test('passes an array through', () => {
+    const value = [{ type: 'p', children: [{ text: 'hi' }] }]
+    expect(toPlateValue(value)).toBe(value)
+  })
+
+  test('returns null for anything that is not an array', () => {
+    expect(toPlateValue(null)).toBeNull()
+    expect(toPlateValue(undefined)).toBeNull()
+    expect(toPlateValue('<p>hi</p>')).toBeNull()
+    expect(toPlateValue({ type: 'p' })).toBeNull()
+  })
+})

--- a/apps/console/src/components/pages/protected/policies/view/tabs/history/utils.test.ts
+++ b/apps/console/src/components/pages/protected/policies/view/tabs/history/utils.test.ts
@@ -1,9 +1,8 @@
 import { getRevisionKind, makeGroupResolver, parseRevision, toPlateValue } from './utils'
 
 /**
- * ISS-2256 — the policy history diff printed raw group ULIDs for Approver and Delegate.
- * makeGroupResolver maps id to name, passing null through so an unset field diffs as empty
- * rather than as the string "undefined".
+ * The policy history diff printed raw group ULIDs for Approver and Delegate. makeGroupResolver maps id to
+ * name, passing null through so an unset field diffs as empty rather than as the string "undefined".
  */
 describe('makeGroupResolver', () => {
   const map = new Map([['01HXGROUP0000000000000000A', 'Security Team']])

--- a/apps/console/src/components/pages/protected/programs/[id]/hooks/use-timeline-readiness-form-schema.test.ts
+++ b/apps/console/src/components/pages/protected/programs/[id]/hooks/use-timeline-readiness-form-schema.test.ts
@@ -1,0 +1,75 @@
+import { ProgramProgramStatus } from '@repo/codegen/src/schema'
+import { changedTimelineFields, type TimelineReadinessFormValues } from './use-timeline-readiness-form-schema'
+
+/**
+ * ISS-2707 — an old program could not be marked complete. The timeline form
+ * validated "end date must be in the future" unconditionally, so any program
+ * whose audit period had already ended failed validation the moment you touched
+ * its status — even though the end date was untouched.
+ *
+ * The fix makes the date rules conditional on the field actually having CHANGED,
+ * which makes changedTimelineFields the load-bearing piece. It compares by DAY,
+ * not by timestamp: the form hands back a Date built from a date-picker, so two
+ * values for the same calendar day must not read as a change and re-trigger the
+ * validation this bug was about.
+ */
+
+const values = (over: Partial<TimelineReadinessFormValues> = {}): TimelineReadinessFormValues => ({
+  startDate: null,
+  endDate: null,
+  status: ProgramProgramStatus.NOT_STARTED,
+  ...over,
+})
+
+describe('changedTimelineFields', () => {
+  test('reports nothing changed for identical values', () => {
+    const initial = values({ startDate: new Date('2026-01-01'), endDate: new Date('2026-12-31') })
+
+    expect(changedTimelineFields(initial, initial)).toEqual({ startDate: false, endDate: false, status: false })
+  })
+
+  test('ignores a time-of-day difference on the same calendar day', () => {
+    // The whole point of comparing by day: a re-created Date for the same day
+    // must not look like an edit, or an untouched past end date would fail
+    // validation again.
+    const initial = values({ endDate: new Date('2026-12-31T00:00:00.000Z') })
+    const current = values({ endDate: new Date('2026-12-31T18:45:00.000Z') })
+
+    expect(changedTimelineFields(current, initial).endDate).toBe(false)
+  })
+
+  test('detects a different calendar day', () => {
+    const initial = values({ endDate: new Date('2026-12-31') })
+    const current = values({ endDate: new Date('2027-01-01') })
+
+    expect(changedTimelineFields(current, initial).endDate).toBe(true)
+  })
+
+  test('detects clearing a date', () => {
+    expect(changedTimelineFields(values({ endDate: null }), values({ endDate: new Date('2026-12-31') })).endDate).toBe(true)
+  })
+
+  test('detects setting a previously empty date', () => {
+    expect(changedTimelineFields(values({ startDate: new Date('2026-01-01') }), values({ startDate: null })).startDate).toBe(true)
+  })
+
+  test('treats null and undefined dates as equivalent', () => {
+    expect(changedTimelineFields(values({ endDate: null }), values({ endDate: undefined })).endDate).toBe(false)
+  })
+
+  test('detects a status change on its own', () => {
+    const initial = values({ endDate: new Date('2020-01-01'), status: ProgramProgramStatus.IN_PROGRESS })
+    const current = values({ endDate: new Date('2020-01-01'), status: ProgramProgramStatus.COMPLETED })
+
+    // The exact bug scenario: a long-past end date, only the status touched.
+    // Dates must read as unchanged so the future-date rule stays out of the way.
+    expect(changedTimelineFields(current, initial)).toEqual({ startDate: false, endDate: false, status: true })
+  })
+
+  test('reports each field independently', () => {
+    const initial = values({ startDate: new Date('2026-01-01'), endDate: new Date('2026-12-31') })
+    const current = values({ startDate: new Date('2026-02-01'), endDate: new Date('2026-12-31') })
+
+    expect(changedTimelineFields(current, initial)).toEqual({ startDate: true, endDate: false, status: false })
+  })
+})

--- a/apps/console/src/components/pages/protected/programs/[id]/hooks/use-timeline-readiness-form-schema.test.ts
+++ b/apps/console/src/components/pages/protected/programs/[id]/hooks/use-timeline-readiness-form-schema.test.ts
@@ -2,16 +2,9 @@ import { ProgramProgramStatus } from '@repo/codegen/src/schema'
 import { changedTimelineFields, type TimelineReadinessFormValues } from './use-timeline-readiness-form-schema'
 
 /**
- * ISS-2707 — an old program could not be marked complete. The timeline form
- * validated "end date must be in the future" unconditionally, so any program
- * whose audit period had already ended failed validation the moment you touched
- * its status — even though the end date was untouched.
- *
- * The fix makes the date rules conditional on the field actually having CHANGED,
- * which makes changedTimelineFields the load-bearing piece. It compares by DAY,
- * not by timestamp: the form hands back a Date built from a date-picker, so two
- * values for the same calendar day must not read as a change and re-trigger the
- * validation this bug was about.
+ * ISS-2707 — an old program could not be marked complete, because the timeline form validated
+ * "end date must be in the future" unconditionally. The fix makes the date rules conditional on
+ * the field having changed, compared by day so a re-created Date for the same day is not an edit.
  */
 
 const values = (over: Partial<TimelineReadinessFormValues> = {}): TimelineReadinessFormValues => ({
@@ -29,9 +22,8 @@ describe('changedTimelineFields', () => {
   })
 
   test('ignores a time-of-day difference on the same calendar day', () => {
-    // The whole point of comparing by day: a re-created Date for the same day
-    // must not look like an edit, or an untouched past end date would fail
-    // validation again.
+    // A re-created Date for the same day must not look like an edit, or an untouched past
+    // end date would fail validation again.
     const initial = values({ endDate: new Date('2026-12-31T00:00:00.000Z') })
     const current = values({ endDate: new Date('2026-12-31T18:45:00.000Z') })
 

--- a/apps/console/src/components/pages/protected/programs/[id]/hooks/use-timeline-readiness-form-schema.test.ts
+++ b/apps/console/src/components/pages/protected/programs/[id]/hooks/use-timeline-readiness-form-schema.test.ts
@@ -2,9 +2,9 @@ import { ProgramProgramStatus } from '@repo/codegen/src/schema'
 import { changedTimelineFields, type TimelineReadinessFormValues } from './use-timeline-readiness-form-schema'
 
 /**
- * ISS-2707 — an old program could not be marked complete, because the timeline form validated
- * "end date must be in the future" unconditionally. The fix makes the date rules conditional on
- * the field having changed, compared by day so a re-created Date for the same day is not an edit.
+ * An old program could not be marked complete, because the timeline form validated "end date must be in the
+ * future" unconditionally. The fix makes the date rules conditional on the field having changed, compared by
+ * day so a re-created Date for the same day is not an edit.
  */
 
 const values = (over: Partial<TimelineReadinessFormValues> = {}): TimelineReadinessFormValues => ({
@@ -22,8 +22,8 @@ describe('changedTimelineFields', () => {
   })
 
   test('ignores a time-of-day difference on the same calendar day', () => {
-    // A re-created Date for the same day must not look like an edit, or an untouched past
-    // end date would fail validation again.
+    // A re-created Date for the same day must not look like an edit, or an untouched past end date would fail
+    // validation again.
     const initial = values({ endDate: new Date('2026-12-31T00:00:00.000Z') })
     const current = values({ endDate: new Date('2026-12-31T18:45:00.000Z') })
 
@@ -53,8 +53,8 @@ describe('changedTimelineFields', () => {
     const initial = values({ endDate: new Date('2020-01-01'), status: ProgramProgramStatus.IN_PROGRESS })
     const current = values({ endDate: new Date('2020-01-01'), status: ProgramProgramStatus.COMPLETED })
 
-    // The exact bug scenario: a long-past end date, only the status touched.
-    // Dates must read as unchanged so the future-date rule stays out of the way.
+    // The exact bug scenario: a long-past end date, only the status touched. Dates must read as unchanged so
+    // the future-date rule stays out of the way.
     expect(changedTimelineFields(current, initial)).toEqual({ startDate: false, endDate: false, status: true })
   })
 

--- a/apps/console/src/components/pages/protected/user-management/members/actions/assignable-base-roles.test.ts
+++ b/apps/console/src/components/pages/protected/user-management/members/actions/assignable-base-roles.test.ts
@@ -1,0 +1,42 @@
+import { OrgMembershipRole } from '@repo/codegen/src/schema'
+import { ASSIGNABLE_BASE_ROLES } from './assignable-base-roles'
+
+/**
+ * #2132 — AUDITOR became an assignable role. It was previously filtered out
+ * alongside OWNER, so an org could not grant audit access from the members
+ * table at all.
+ *
+ * The remaining exclusions still matter: OWNER is transferred, never assigned,
+ * and the *_USER pseudo-roles are internal and must never appear in the picker.
+ */
+describe('ASSIGNABLE_BASE_ROLES', () => {
+  test('includes AUDITOR', () => {
+    expect(ASSIGNABLE_BASE_ROLES).toContain(OrgMembershipRole.AUDITOR)
+  })
+
+  test('includes the everyday roles', () => {
+    expect(ASSIGNABLE_BASE_ROLES).toContain(OrgMembershipRole.ADMIN)
+    expect(ASSIGNABLE_BASE_ROLES).toContain(OrgMembershipRole.MEMBER)
+  })
+
+  test('never offers OWNER, which is transferred rather than assigned', () => {
+    expect(ASSIGNABLE_BASE_ROLES).not.toContain(OrgMembershipRole.OWNER)
+  })
+
+  test('excludes every internal *_USER pseudo-role', () => {
+    expect(ASSIGNABLE_BASE_ROLES.filter((role) => role.includes('USER'))).toEqual([])
+  })
+
+  test('contains no duplicates', () => {
+    expect(new Set(ASSIGNABLE_BASE_ROLES).size).toBe(ASSIGNABLE_BASE_ROLES.length)
+  })
+
+  test('is a strict subset of the backend role enum', () => {
+    const known = new Set<string>(Object.values(OrgMembershipRole))
+
+    for (const role of ASSIGNABLE_BASE_ROLES) {
+      expect(known.has(role)).toBe(true)
+    }
+    expect(ASSIGNABLE_BASE_ROLES.length).toBeLessThan(known.size)
+  })
+})

--- a/apps/console/src/components/pages/protected/user-management/members/actions/assignable-base-roles.test.ts
+++ b/apps/console/src/components/pages/protected/user-management/members/actions/assignable-base-roles.test.ts
@@ -2,8 +2,8 @@ import { OrgMembershipRole } from '@repo/codegen/src/schema'
 import { ASSIGNABLE_BASE_ROLES } from './assignable-base-roles'
 
 /**
- * #2132 — AUDITOR became assignable; it was previously filtered out alongside OWNER. OWNER is
- * transferred rather than assigned and the *_USER pseudo-roles are internal, so both stay out.
+ * AUDITOR became assignable; it was previously filtered out alongside OWNER. OWNER is transferred rather than
+ * assigned and the *_USER pseudo-roles are internal, so both stay out.
  */
 describe('ASSIGNABLE_BASE_ROLES', () => {
   test('includes AUDITOR', () => {

--- a/apps/console/src/components/pages/protected/user-management/members/actions/assignable-base-roles.test.ts
+++ b/apps/console/src/components/pages/protected/user-management/members/actions/assignable-base-roles.test.ts
@@ -2,12 +2,8 @@ import { OrgMembershipRole } from '@repo/codegen/src/schema'
 import { ASSIGNABLE_BASE_ROLES } from './assignable-base-roles'
 
 /**
- * #2132 — AUDITOR became an assignable role. It was previously filtered out
- * alongside OWNER, so an org could not grant audit access from the members
- * table at all.
- *
- * The remaining exclusions still matter: OWNER is transferred, never assigned,
- * and the *_USER pseudo-roles are internal and must never appear in the picker.
+ * #2132 — AUDITOR became assignable; it was previously filtered out alongside OWNER. OWNER is
+ * transferred rather than assigned and the *_USER pseudo-roles are internal, so both stay out.
  */
 describe('ASSIGNABLE_BASE_ROLES', () => {
   test('includes AUDITOR', () => {

--- a/apps/console/src/components/shared/crud-base/columns/get-include-vars.test.ts
+++ b/apps/console/src/components/shared/crud-base/columns/get-include-vars.test.ts
@@ -2,12 +2,8 @@ import { type ColumnDef, type VisibilityState } from '@tanstack/react-table'
 import { getIncludeVars } from './get-include-vars'
 
 /**
- * ISS-2357 — tables only request the expensive GraphQL fields backing columns
- * that are actually visible. Column defs declare `meta.gqlInclude`, and
- * getIncludeVars folds those against the table's VisibilityState into the
- * `include*` variables sent with the query.
- *
- * The OR-fold matters: two columns can share an include key, and the field must
+ * ISS-2357 — folds each column's meta.gqlInclude against the table's VisibilityState into the
+ * include* query variables. The OR-fold matters: two columns can share a key, and the field must
  * still be fetched while either one is visible.
  */
 

--- a/apps/console/src/components/shared/crud-base/columns/get-include-vars.test.ts
+++ b/apps/console/src/components/shared/crud-base/columns/get-include-vars.test.ts
@@ -1,0 +1,82 @@
+import { type ColumnDef, type VisibilityState } from '@tanstack/react-table'
+import { getIncludeVars } from './get-include-vars'
+
+/**
+ * ISS-2357 — tables only request the expensive GraphQL fields backing columns
+ * that are actually visible. Column defs declare `meta.gqlInclude`, and
+ * getIncludeVars folds those against the table's VisibilityState into the
+ * `include*` variables sent with the query.
+ *
+ * The OR-fold matters: two columns can share an include key, and the field must
+ * still be fetched while either one is visible.
+ */
+
+type Row = { id: string }
+
+const column = (accessorKey: string, gqlInclude?: string[]): ColumnDef<Row> => ({ accessorKey, meta: gqlInclude ? { gqlInclude } : undefined }) as ColumnDef<Row>
+
+describe('getIncludeVars', () => {
+  test('returns nothing when no column declares an include key', () => {
+    expect(getIncludeVars<Row>([column('refCode'), column('status')], {})).toEqual({})
+  })
+
+  test('treats a column absent from the visibility map as visible', () => {
+    // getInitialVisibility only lists HIDDEN columns, so "not present" means on.
+    expect(getIncludeVars<Row>([column('description', ['includeDescription'])], {})).toEqual({ includeDescription: true })
+  })
+
+  test('drops the include key when the column is explicitly hidden', () => {
+    expect(getIncludeVars<Row>([column('description', ['includeDescription'])], { description: false })).toEqual({ includeDescription: false })
+  })
+
+  test('maps a multi-key column to every key it declares', () => {
+    const columns = [column('description', ['includeDescription', 'includeCategory', 'includeSubcategory'])]
+
+    expect(getIncludeVars<Row>(columns, {})).toEqual({
+      includeDescription: true,
+      includeCategory: true,
+      includeSubcategory: true,
+    })
+  })
+
+  test('ORs a shared key so it survives while any owning column is visible', () => {
+    const columns = [column('description', ['includeCategory']), column('category', ['includeCategory'])]
+
+    expect(getIncludeVars<Row>(columns, { description: false })).toEqual({ includeCategory: true })
+    expect(getIncludeVars<Row>(columns, { category: false })).toEqual({ includeCategory: true })
+    expect(getIncludeVars<Row>(columns, { description: false, category: false })).toEqual({ includeCategory: false })
+  })
+
+  test('keeps a column with no accessorKey included', () => {
+    // Display columns (select checkbox, row actions) have no accessorKey and
+    // cannot be looked up in VisibilityState, so they must not be dropped.
+    const columns = [{ id: 'actions', meta: { gqlInclude: ['includeRisks'] } } as ColumnDef<Row>]
+
+    expect(getIncludeVars<Row>(columns, { actions: false })).toEqual({ includeRisks: true })
+  })
+
+  test('ignores an empty gqlInclude list', () => {
+    const columns = [{ accessorKey: 'refCode', meta: { gqlInclude: [] } } as unknown as ColumnDef<Row>]
+
+    expect(getIncludeVars<Row>(columns, {})).toEqual({})
+  })
+
+  test('folds a realistic mixed column set', () => {
+    const columns = [
+      column('refCode', ['includeReferenceID']),
+      column('description', ['includeDescription']),
+      column('status', ['includeStatus']),
+      column('risks', ['includeRisks']),
+      column('programs', ['includePrograms']),
+    ]
+    const visibility: VisibilityState = { risks: false, programs: false }
+
+    expect(getIncludeVars<Row>(columns, visibility)).toEqual({
+      includeReferenceID: true,
+      includeDescription: true,
+      includeStatus: true,
+      includeRisks: false,
+      includePrograms: false,
+    })
+  })
+})

--- a/apps/console/src/components/shared/crud-base/columns/get-include-vars.test.ts
+++ b/apps/console/src/components/shared/crud-base/columns/get-include-vars.test.ts
@@ -2,9 +2,9 @@ import { type ColumnDef, type VisibilityState } from '@tanstack/react-table'
 import { getIncludeVars } from './get-include-vars'
 
 /**
- * ISS-2357 — folds each column's meta.gqlInclude against the table's VisibilityState into the
- * include* query variables. The OR-fold matters: two columns can share a key, and the field must
- * still be fetched while either one is visible.
+ * Folds each column's meta.gqlInclude against the table's VisibilityState into the include* query variables.
+ * The OR-fold matters: two columns can share a key, and the field must still be fetched while either one is
+ * visible.
  */
 
 type Row = { id: string }
@@ -44,8 +44,8 @@ describe('getIncludeVars', () => {
   })
 
   test('keeps a column with no accessorKey included', () => {
-    // Display columns (select checkbox, row actions) have no accessorKey and
-    // cannot be looked up in VisibilityState, so they must not be dropped.
+    // Display columns (select checkbox, row actions) have no accessorKey and cannot be looked up in
+    // VisibilityState, so they must not be dropped.
     const columns = [{ id: 'actions', meta: { gqlInclude: ['includeRisks'] } } as ColumnDef<Row>]
 
     expect(getIncludeVars<Row>(columns, { actions: false })).toEqual({ includeRisks: true })

--- a/apps/console/src/components/shared/enum-mapper/evidence-enum.test.ts
+++ b/apps/console/src/components/shared/enum-mapper/evidence-enum.test.ts
@@ -2,8 +2,8 @@ import { EvidenceEvidenceStatus } from '@repo/codegen/src/schema'
 import { EvidenceStatusColors, getEvidenceStatusLabel, getEvidenceStatusStyle } from './evidence-enum'
 
 /**
- * ISS-2594 — two statuses are abbreviated so they fit the chart legend; everything else falls
- * through to getEnumLabel. The colour map has to stay exhaustive or a chip renders transparent.
+ * Two statuses are abbreviated so they fit the chart legend; everything else falls through to getEnumLabel.
+ * The colour map has to stay exhaustive or a chip renders transparent.
  */
 describe('EvidenceStatusColors', () => {
   test('covers every evidence status', () => {

--- a/apps/console/src/components/shared/enum-mapper/evidence-enum.test.ts
+++ b/apps/console/src/components/shared/enum-mapper/evidence-enum.test.ts
@@ -2,13 +2,8 @@ import { EvidenceEvidenceStatus } from '@repo/codegen/src/schema'
 import { EvidenceStatusColors, getEvidenceStatusLabel, getEvidenceStatusStyle } from './evidence-enum'
 
 /**
- * ISS-2594 — the evidence dashboard chart needs a colour and a SHORT label per
- * status. Two statuses get abbreviated so they fit a chart legend
- * ("Auditor approved" → "Approved", "Ready for auditor" → "Ready"); everything
- * else falls through to the standard getEnumLabel form.
- *
- * The colour map must be exhaustive: a missing status yields `undefined` in the
- * style, which renders as a transparent chip rather than throwing.
+ * ISS-2594 — two statuses are abbreviated so they fit the chart legend; everything else falls
+ * through to getEnumLabel. The colour map has to stay exhaustive or a chip renders transparent.
  */
 describe('EvidenceStatusColors', () => {
   test('covers every evidence status', () => {

--- a/apps/console/src/components/shared/enum-mapper/evidence-enum.test.ts
+++ b/apps/console/src/components/shared/enum-mapper/evidence-enum.test.ts
@@ -1,0 +1,56 @@
+import { EvidenceEvidenceStatus } from '@repo/codegen/src/schema'
+import { EvidenceStatusColors, getEvidenceStatusLabel, getEvidenceStatusStyle } from './evidence-enum'
+
+/**
+ * ISS-2594 — the evidence dashboard chart needs a colour and a SHORT label per
+ * status. Two statuses get abbreviated so they fit a chart legend
+ * ("Auditor approved" → "Approved", "Ready for auditor" → "Ready"); everything
+ * else falls through to the standard getEnumLabel form.
+ *
+ * The colour map must be exhaustive: a missing status yields `undefined` in the
+ * style, which renders as a transparent chip rather than throwing.
+ */
+describe('EvidenceStatusColors', () => {
+  test('covers every evidence status', () => {
+    for (const status of Object.values(EvidenceEvidenceStatus)) {
+      expect(EvidenceStatusColors[status]).toMatch(/^#[0-9a-fA-F]{6}$/)
+    }
+  })
+})
+
+describe('getEvidenceStatusLabel', () => {
+  test('shortens the two long statuses for the chart legend', () => {
+    expect(getEvidenceStatusLabel(EvidenceEvidenceStatus.AUDITOR_APPROVED)).toBe('Approved')
+    expect(getEvidenceStatusLabel(EvidenceEvidenceStatus.READY_FOR_AUDITOR)).toBe('Ready')
+  })
+
+  test('falls back to the standard enum label for the rest', () => {
+    // getEnumLabel title-cases every word, so ALL_CAPS becomes "Missing Artifact".
+    expect(getEvidenceStatusLabel(EvidenceEvidenceStatus.MISSING_ARTIFACT)).toBe('Missing Artifact')
+    expect(getEvidenceStatusLabel(EvidenceEvidenceStatus.IN_REVIEW)).toBe('In Review')
+  })
+
+  test('never returns a raw ALL_CAPS value', () => {
+    for (const status of Object.values(EvidenceEvidenceStatus)) {
+      expect(getEvidenceStatusLabel(status)).not.toBe(status)
+    }
+  })
+})
+
+describe('getEvidenceStatusStyle', () => {
+  test('pairs a solid text colour with a translucent background of the same hue', () => {
+    const style = getEvidenceStatusStyle(EvidenceEvidenceStatus.REJECTED)
+
+    expect(style.color).toBe(EvidenceStatusColors[EvidenceEvidenceStatus.REJECTED])
+    expect(style.bg).toContain(EvidenceStatusColors[EvidenceEvidenceStatus.REJECTED])
+    expect(style.bg).toContain('color-mix')
+  })
+
+  test('resolves for every status without producing undefined', () => {
+    for (const status of Object.values(EvidenceEvidenceStatus)) {
+      const style = getEvidenceStatusStyle(status)
+      expect(style.color).toBeDefined()
+      expect(style.bg).not.toContain('undefined')
+    }
+  })
+})

--- a/apps/console/src/components/shared/merge-records/configs/merge-config-labels.test.ts
+++ b/apps/console/src/components/shared/merge-records/configs/merge-config-labels.test.ts
@@ -1,0 +1,65 @@
+import { assetMergeConfig, getAssetLabel } from './asset-merge-config'
+import { contactMergeConfig } from './contact-merge-config'
+import { personnelMergeConfig } from './personnel-merge-config'
+import { vendorMergeConfig } from './vendor-merge-config'
+
+/**
+ * ISS-2778 — records can be merged by dragging one row onto another, so the
+ * merge dialog must name both records unambiguously. Each config supplies a
+ * getDisplayName used for that.
+ *
+ * The fallback chain is what matters: a record with no display name still has to
+ * render as SOMETHING, or the confirmation reads "Merge  into " and the user
+ * cannot tell which record they are about to destroy. Falling back to the id is
+ * ugly but unambiguous.
+ */
+
+const configs = [
+  ['asset', assetMergeConfig],
+  ['contact', contactMergeConfig],
+  ['personnel', personnelMergeConfig],
+  ['vendor', vendorMergeConfig],
+] as const
+
+describe('getAssetLabel fallback chain', () => {
+  test('prefers the display name', () => {
+    expect(getAssetLabel({ id: 'a-1', name: 'raw-name', displayName: 'Pretty Name' })).toBe('Pretty Name')
+  })
+
+  test('falls back to the name when there is no display name', () => {
+    expect(getAssetLabel({ id: 'a-1', name: 'raw-name', displayName: '' })).toBe('raw-name')
+  })
+
+  test('falls back to the id when both names are empty', () => {
+    // Ugly but unambiguous — better than an empty label in a destructive dialog.
+    expect(getAssetLabel({ id: 'a-1', name: '', displayName: '' })).toBe('a-1')
+  })
+})
+
+describe('merge configs', () => {
+  test.each(configs)('%s config declares its entity type and labels', (_name, config) => {
+    expect(config.entityType).toBeTruthy()
+    expect(config.labelSingular).toBeTruthy()
+    expect(config.labelPlural).toBeTruthy()
+  })
+
+  test.each(configs)('%s config never yields an empty label for a record with an id', (_name, config) => {
+    // getDisplayName is optional on MergeConfig; where a config supplies one it
+    // must still produce something for a record with nothing but an id.
+    const label = config.getDisplayName?.({ id: 'record-id' } as never)
+
+    if (config.getDisplayName) expect(label).toBeTruthy()
+  })
+
+  test('every config targets a distinct entity type', () => {
+    const types = configs.map(([, config]) => config.entityType)
+
+    expect(new Set(types).size).toBe(types.length)
+  })
+
+  test('singular and plural labels differ', () => {
+    for (const [, config] of configs) {
+      expect(config.labelSingular).not.toBe(config.labelPlural)
+    }
+  })
+})

--- a/apps/console/src/components/shared/merge-records/configs/merge-config-labels.test.ts
+++ b/apps/console/src/components/shared/merge-records/configs/merge-config-labels.test.ts
@@ -4,14 +4,9 @@ import { personnelMergeConfig } from './personnel-merge-config'
 import { vendorMergeConfig } from './vendor-merge-config'
 
 /**
- * ISS-2778 — records can be merged by dragging one row onto another, so the
- * merge dialog must name both records unambiguously. Each config supplies a
- * getDisplayName used for that.
- *
- * The fallback chain is what matters: a record with no display name still has to
- * render as SOMETHING, or the confirmation reads "Merge  into " and the user
- * cannot tell which record they are about to destroy. Falling back to the id is
- * ugly but unambiguous.
+ * ISS-2778 — the merge dialog must name both records, or the confirmation reads "Merge  into "
+ * and the user cannot tell which record they are about to destroy. The fallback chain ends at
+ * the id.
  */
 
 const configs = [

--- a/apps/console/src/components/shared/merge-records/configs/merge-config-labels.test.ts
+++ b/apps/console/src/components/shared/merge-records/configs/merge-config-labels.test.ts
@@ -4,9 +4,8 @@ import { personnelMergeConfig } from './personnel-merge-config'
 import { vendorMergeConfig } from './vendor-merge-config'
 
 /**
- * ISS-2778 — the merge dialog must name both records, or the confirmation reads "Merge  into "
- * and the user cannot tell which record they are about to destroy. The fallback chain ends at
- * the id.
+ * The merge dialog must name both records, or the confirmation reads "Merge into " and the user cannot tell
+ * which record they are about to destroy. The fallback chain ends at the id.
  */
 
 const configs = [
@@ -39,8 +38,8 @@ describe('merge configs', () => {
   })
 
   test.each(configs)('%s config never yields an empty label for a record with an id', (_name, config) => {
-    // getDisplayName is optional on MergeConfig; where a config supplies one it
-    // must still produce something for a record with nothing but an id.
+    // getDisplayName is optional on MergeConfig; where a config supplies one it must still produce something
+    // for a record with nothing but an id.
     const label = config.getDisplayName?.({ id: 'record-id' } as never)
 
     if (config.getDisplayName) expect(label).toBeTruthy()

--- a/apps/console/src/components/shared/object-association/__tests__/object-association.test.ts
+++ b/apps/console/src/components/shared/object-association/__tests__/object-association.test.ts
@@ -408,9 +408,8 @@ describe('toRemoveFieldName', () => {
 })
 
 /**
- * #2014 — these helpers flatten a GraphQL edge list into a chip cell, and must survive the
- * shapes the API actually returns: a null connection, null edges inside it, and nodes missing
- * the field entirely.
+ * These helpers flatten a GraphQL edge list into a chip cell, and must survive the shapes the API actually
+ * returns: a null connection, null edges inside it, and nodes missing the field entirely.
  */
 describe('getEdgeValues', () => {
   it('maps each node to the requested field', () => {
@@ -452,9 +451,9 @@ describe('typed edge accessors', () => {
 })
 
 /**
- * #2055 — buildAssociationSections maps a section-key list onto whichever connections the query
- * returned. A missing connection is omitted rather than emitted empty, since a rendered-but-empty
- * accordion reads as "no associations" when the truth is "not queried".
+ * buildAssociationSections maps a section-key list onto whichever connections the query returned. A missing
+ * connection is omitted rather than emitted empty, since a rendered-but-empty accordion reads as "no
+ * associations" when the truth is "not queried".
  */
 describe('buildAssociationSections', () => {
   const connection = (count: number) => ({ totalCount: count, edges: [] })

--- a/apps/console/src/components/shared/object-association/__tests__/object-association.test.ts
+++ b/apps/console/src/components/shared/object-association/__tests__/object-association.test.ts
@@ -19,9 +19,6 @@ import {
   toRemoveFieldName,
 } from '../object-association-config'
 
-// ---------------------------------------------------------------------------
-// Suite 1: getAssociationDiffs
-// ---------------------------------------------------------------------------
 describe('getAssociationDiffs', () => {
   it('returns empty added/removed when there are no changes', () => {
     const map = { taskIDs: ['1', '2'] }
@@ -95,9 +92,6 @@ describe('getAssociationDiffs', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Suite 2: buildMutationKey
-// ---------------------------------------------------------------------------
 describe('buildMutationKey', () => {
   it('builds add key for taskIDs', () => {
     expect(buildMutationKey('add', 'taskIDs')).toBe('addTaskIDs')
@@ -116,9 +110,6 @@ describe('buildMutationKey', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Suite 3: getAssociationInput
-// ---------------------------------------------------------------------------
 describe('getAssociationInput', () => {
   it('returns empty object when there are no changes', () => {
     const map = { taskIDs: ['1'] }
@@ -156,9 +147,6 @@ describe('getAssociationInput', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Suite 4: buildAssociationPayload
-// ---------------------------------------------------------------------------
 describe('buildAssociationPayload', () => {
   const keys = ['taskIDs', 'riskIDs'] as const
 
@@ -196,9 +184,6 @@ describe('buildAssociationPayload', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Suite 5: generateWhere
-// ---------------------------------------------------------------------------
 describe('generateWhere', () => {
   const ownerID = 'org-123'
 
@@ -266,9 +251,6 @@ describe('generateWhere', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Suite 6: extractTableRows
-// ---------------------------------------------------------------------------
 describe('extractTableRows', () => {
   it('handles every responseObjectKey (no type returns empty due to missing case)', () => {
     const allObjectKeys = Object.values(OBJECT_QUERY_CONFIG).map((c) => c.responseObjectKey)
@@ -360,9 +342,6 @@ describe('extractTableRows', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Suite 7: Config integrity
-// ---------------------------------------------------------------------------
 describe('Config integrity', () => {
   it('every ObjectTypeObjects has an OBJECT_QUERY_CONFIG entry', () => {
     for (const objectType of Object.values(ObjectTypeObjects)) {
@@ -418,9 +397,6 @@ describe('Config integrity', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Suite 8: toRemoveFieldName
-// ---------------------------------------------------------------------------
 describe('toRemoveFieldName', () => {
   it('converts controlIDs to removeControlIDs', () => {
     expect(toRemoveFieldName('controlIDs')).toBe('removeControlIDs')
@@ -432,10 +408,9 @@ describe('toRemoveFieldName', () => {
 })
 
 /**
- * #2014 — system details gained many-to-many edges to platforms and programs, so
- * several tables now flatten a GraphQL edge list into a chip cell. These helpers
- * do that flattening and must survive the shapes the API actually returns: a
- * null connection, null edges inside it, and nodes missing the field entirely.
+ * #2014 — these helpers flatten a GraphQL edge list into a chip cell, and must survive the
+ * shapes the API actually returns: a null connection, null edges inside it, and nodes missing
+ * the field entirely.
  */
 describe('getEdgeValues', () => {
   it('maps each node to the requested field', () => {
@@ -477,14 +452,9 @@ describe('typed edge accessors', () => {
 })
 
 /**
- * #2055 — association sections were being assembled by hand at each call site.
- * buildAssociationSections now maps a section-key list onto whichever connections
- * the query actually returned, and each object type declares its section list as
- * a shared constant.
- *
- * The important behaviour is that a MISSING connection is omitted rather than
- * emitted as an empty/undefined section — a rendered-but-empty accordion looks
- * like "no associations" when the truth is "not queried".
+ * #2055 — buildAssociationSections maps a section-key list onto whichever connections the query
+ * returned. A missing connection is omitted rather than emitted empty, since a rendered-but-empty
+ * accordion reads as "no associations" when the truth is "not queried".
  */
 describe('buildAssociationSections', () => {
   const connection = (count: number) => ({ totalCount: count, edges: [] })

--- a/apps/console/src/components/shared/object-association/__tests__/object-association.test.ts
+++ b/apps/console/src/components/shared/object-association/__tests__/object-association.test.ts
@@ -1,5 +1,13 @@
-import { getAssociationDiffs, buildMutationKey, getAssociationInput, buildAssociationPayload } from '../utils'
+import { getAssociationDiffs, buildMutationKey, getAssociationInput, buildAssociationPayload, getEdgeValues, getEdgeIds, getEdgeNames, getEdgeNodes } from '../utils'
 import {
+  buildAssociationSections,
+  CONTROL_ASSOCIATION_SECTIONS,
+  SUBCONTROL_ASSOCIATION_SECTIONS,
+  POLICY_ASSOCIATION_SECTIONS,
+  PROCEDURE_ASSOCIATION_SECTIONS,
+  RISK_ASSOCIATION_SECTIONS,
+  ENTITY_ASSOCIATION_SECTIONS,
+  IDENTITY_HOLDER_ASSOCIATION_SECTIONS,
   ObjectTypeObjects,
   OBJECT_QUERY_CONFIG,
   ASSOCIATION_SECTION_CONFIG,
@@ -420,5 +428,121 @@ describe('toRemoveFieldName', () => {
 
   it('converts internalPolicyIDs to removeInternalPolicyIDs', () => {
     expect(toRemoveFieldName('internalPolicyIDs')).toBe('removeInternalPolicyIDs')
+  })
+})
+
+/**
+ * #2014 — system details gained many-to-many edges to platforms and programs, so
+ * several tables now flatten a GraphQL edge list into a chip cell. These helpers
+ * do that flattening and must survive the shapes the API actually returns: a
+ * null connection, null edges inside it, and nodes missing the field entirely.
+ */
+describe('getEdgeValues', () => {
+  it('maps each node to the requested field', () => {
+    expect(getEdgeValues([{ node: { name: 'AWS' } }, { node: { name: 'GCP' } }], 'name')).toEqual(['AWS', 'GCP'])
+  })
+
+  it('returns an empty array for a null or undefined connection', () => {
+    expect(getEdgeValues(null, 'name')).toEqual([])
+    expect(getEdgeValues(undefined, 'name')).toEqual([])
+  })
+
+  it('skips null edges and null nodes', () => {
+    expect(getEdgeValues([null, { node: null }, { node: { name: 'AWS' } }], 'name')).toEqual(['AWS'])
+  })
+
+  it('skips nodes where the field is null or missing', () => {
+    expect(getEdgeValues([{ node: { name: null } }, { node: {} }, { node: { name: 'AWS' } }], 'name')).toEqual(['AWS'])
+  })
+})
+
+describe('typed edge accessors', () => {
+  it('extracts ids', () => {
+    expect(getEdgeIds([{ node: { id: 'a' } }, { node: { id: null } }, { node: { id: 'b' } }])).toEqual(['a', 'b'])
+  })
+
+  it('extracts names', () => {
+    expect(getEdgeNames([{ node: { name: 'Platform A' } }])).toEqual(['Platform A'])
+  })
+
+  it('unwraps whole nodes, dropping null edges and null nodes', () => {
+    expect(getEdgeNodes([{ node: { id: 'a' } }, null, { node: null }, { node: { id: 'b' } }])).toEqual([{ id: 'a' }, { id: 'b' }])
+  })
+
+  it('returns an empty array when the connection is absent', () => {
+    expect(getEdgeIds(null)).toEqual([])
+    expect(getEdgeNames(undefined)).toEqual([])
+    expect(getEdgeNodes(null)).toEqual([])
+  })
+})
+
+/**
+ * #2055 — association sections were being assembled by hand at each call site.
+ * buildAssociationSections now maps a section-key list onto whichever connections
+ * the query actually returned, and each object type declares its section list as
+ * a shared constant.
+ *
+ * The important behaviour is that a MISSING connection is omitted rather than
+ * emitted as an empty/undefined section — a rendered-but-empty accordion looks
+ * like "no associations" when the truth is "not queried".
+ */
+describe('buildAssociationSections', () => {
+  const connection = (count: number) => ({ totalCount: count, edges: [] })
+
+  it('maps requested section keys onto the connections present on the root', () => {
+    const sections = buildAssociationSections(['controls', 'tasks'], {
+      controls: connection(2),
+      tasks: connection(1),
+    } as Parameters<typeof buildAssociationSections>[1])
+
+    expect(Object.keys(sections).sort()).toEqual(['controls', 'tasks'])
+  })
+
+  it('omits a section whose connection is absent or null', () => {
+    const sections = buildAssociationSections(['controls', 'tasks'], {
+      controls: connection(2),
+      tasks: null,
+    } as Parameters<typeof buildAssociationSections>[1])
+
+    expect(Object.keys(sections)).toEqual(['controls'])
+  })
+
+  it('ignores connections the caller did not ask for', () => {
+    const sections = buildAssociationSections(['controls'], {
+      controls: connection(1),
+      tasks: connection(5),
+    } as Parameters<typeof buildAssociationSections>[1])
+
+    expect(Object.keys(sections)).toEqual(['controls'])
+  })
+
+  it('returns an empty object for an undefined root', () => {
+    expect(buildAssociationSections(['controls'], undefined)).toEqual({})
+  })
+
+  it('returns an empty object when no section keys are requested', () => {
+    expect(buildAssociationSections([], { controls: connection(1) } as Parameters<typeof buildAssociationSections>[1])).toEqual({})
+  })
+})
+
+describe('Section list integrity', () => {
+  const SECTION_LISTS: Record<string, readonly string[]> = {
+    CONTROL: CONTROL_ASSOCIATION_SECTIONS,
+    SUBCONTROL: SUBCONTROL_ASSOCIATION_SECTIONS,
+    POLICY: POLICY_ASSOCIATION_SECTIONS,
+    PROCEDURE: PROCEDURE_ASSOCIATION_SECTIONS,
+    RISK: RISK_ASSOCIATION_SECTIONS,
+    ENTITY: ENTITY_ASSOCIATION_SECTIONS,
+    IDENTITY_HOLDER: IDENTITY_HOLDER_ASSOCIATION_SECTIONS,
+  }
+
+  it.each(Object.entries(SECTION_LISTS))('%s sections all exist in ASSOCIATION_SECTION_CONFIG', (_name, keys) => {
+    for (const key of keys) {
+      expect(ASSOCIATION_SECTION_CONFIG).toHaveProperty(key)
+    }
+  })
+
+  it.each(Object.entries(SECTION_LISTS))('%s sections contain no duplicates', (_name, keys) => {
+    expect(new Set(keys).size).toBe(keys.length)
   })
 })

--- a/apps/console/src/components/shared/object-association/join-table-links.test.ts
+++ b/apps/console/src/components/shared/object-association/join-table-links.test.ts
@@ -1,9 +1,8 @@
 import { splitJoinTableInput } from './join-table-links'
 
 /**
- * #2054 — finding/control links live in a join table, so they cannot ride along in the entity's
- * own update input. The bare key and its add… variant both mean add, and add wins over remove
- * for the same id.
+ * Finding/control links live in a join table, so they cannot ride along in the entity's own update input. The
+ * bare key and its add… variant both mean add, and add wins over remove for the same id.
  */
 describe('splitJoinTableInput', () => {
   test('leaves an input with no join keys untouched', () => {

--- a/apps/console/src/components/shared/object-association/join-table-links.test.ts
+++ b/apps/console/src/components/shared/object-association/join-table-links.test.ts
@@ -1,15 +1,9 @@
 import { splitJoinTableInput } from './join-table-links'
 
 /**
- * #2054 — finding↔control links live in a join table (findingControl), so they
- * cannot ride along in the entity's own update input. splitJoinTableInput peels
- * the join-table keys out of a mutation input and returns them as an add/remove
- * diff to be applied separately.
- *
- * Two rules carry the weight:
- *  - the bare key and its `add…` variant both mean "add" (callers use either)
- *  - add wins over remove for the same id, so a re-link in the same edit cannot
- *    be undone by a stale removal
+ * #2054 — finding/control links live in a join table, so they cannot ride along in the entity's
+ * own update input. The bare key and its add… variant both mean add, and add wins over remove
+ * for the same id.
  */
 describe('splitJoinTableInput', () => {
   test('leaves an input with no join keys untouched', () => {

--- a/apps/console/src/components/shared/object-association/join-table-links.test.ts
+++ b/apps/console/src/components/shared/object-association/join-table-links.test.ts
@@ -1,0 +1,82 @@
+import { splitJoinTableInput } from './join-table-links'
+
+/**
+ * #2054 — finding↔control links live in a join table (findingControl), so they
+ * cannot ride along in the entity's own update input. splitJoinTableInput peels
+ * the join-table keys out of a mutation input and returns them as an add/remove
+ * diff to be applied separately.
+ *
+ * Two rules carry the weight:
+ *  - the bare key and its `add…` variant both mean "add" (callers use either)
+ *  - add wins over remove for the same id, so a re-link in the same edit cannot
+ *    be undone by a stale removal
+ */
+describe('splitJoinTableInput', () => {
+  test('leaves an input with no join keys untouched', () => {
+    const { entityInput, links } = splitJoinTableInput({ refCode: 'CC1.1', status: 'APPROVED' }, 'findingIDs')
+
+    expect(entityInput).toEqual({ refCode: 'CC1.1', status: 'APPROVED' })
+    expect(links).toEqual({ add: [], remove: [] })
+  })
+
+  test('treats the bare key as an add', () => {
+    const { entityInput, links } = splitJoinTableInput({ findingIDs: ['f-1'] }, 'findingIDs')
+
+    expect(entityInput).toEqual({})
+    expect(links.add).toEqual(['f-1'])
+  })
+
+  test('treats the add-prefixed key as an add', () => {
+    const { links } = splitJoinTableInput({ addFindingIDs: ['f-1', 'f-2'] }, 'findingIDs')
+
+    expect(links.add).toEqual(['f-1', 'f-2'])
+  })
+
+  test('merges the bare and add-prefixed keys', () => {
+    const { links } = splitJoinTableInput({ findingIDs: ['f-1'], addFindingIDs: ['f-2'] }, 'findingIDs')
+
+    expect(new Set(links.add)).toEqual(new Set(['f-1', 'f-2']))
+  })
+
+  test('collects the remove-prefixed key', () => {
+    const { links } = splitJoinTableInput({ removeFindingIDs: ['f-9'] }, 'findingIDs')
+
+    expect(links.remove).toEqual(['f-9'])
+  })
+
+  test('keeps every non-join field on the entity input', () => {
+    const { entityInput } = splitJoinTableInput({ refCode: 'CC1.1', addFindingIDs: ['f-1'], removeFindingIDs: ['f-2'] }, 'findingIDs')
+
+    expect(entityInput).toEqual({ refCode: 'CC1.1' })
+  })
+
+  test('dedupes ids on both sides', () => {
+    const { links } = splitJoinTableInput({ addFindingIDs: ['f-1', 'f-1'], removeFindingIDs: ['f-9', 'f-9'] }, 'findingIDs')
+
+    expect(links.add).toEqual(['f-1'])
+    expect(links.remove).toEqual(['f-9'])
+  })
+
+  test('lets add win over remove for the same id', () => {
+    // Re-linking within one edit must not be cancelled by a stale removal.
+    const { links } = splitJoinTableInput({ addFindingIDs: ['f-1'], removeFindingIDs: ['f-1', 'f-2'] }, 'findingIDs')
+
+    expect(links.add).toEqual(['f-1'])
+    expect(links.remove).toEqual(['f-2'])
+  })
+
+  test('ignores non-string entries and non-array values', () => {
+    const input = { addFindingIDs: ['f-1', 42, null], removeFindingIDs: 'not-an-array' } as unknown as { addFindingIDs?: string[]; removeFindingIDs?: string[] }
+    const { links } = splitJoinTableInput(input, 'findingIDs')
+
+    expect(links.add).toEqual(['f-1'])
+    expect(links.remove).toEqual([])
+  })
+
+  test('works for a different join field without touching similarly-named keys', () => {
+    const { entityInput, links } = splitJoinTableInput({ addControlIDs: ['c-1'], addFindingIDs: ['f-1'] }, 'controlIDs')
+
+    expect(links.add).toEqual(['c-1'])
+    expect(entityInput).toEqual({ addFindingIDs: ['f-1'] })
+  })
+})

--- a/apps/console/src/components/shared/plate/plate-utils.test.ts
+++ b/apps/console/src/components/shared/plate/plate-utils.test.ts
@@ -2,17 +2,9 @@ import { type Value } from 'platejs'
 import { canonicalizeDetails, isPlateValueEmpty, trimPlateValue } from './plate-utils'
 
 /**
- * ISS-2646 — trust center overview values were saved with leading and trailing
- * blank paragraphs, which the editor produces freely.
- *
- * The rules being pinned:
- *  - "empty" is a structural question, not a truthiness one. A Plate value is a
- *    non-null array of nodes with blank text, so `!!value` says nothing; this is
- *    what several callers rely on to hide a panel (#88) or skip a save.
- *  - a VOID node (an image, a divider) is content even with no text, so a value
- *    containing one is not empty.
- *  - trimPlateValue must not mutate its input — callers keep the original form
- *    state while saving the trimmed copy.
+ * ISS-2646 — trust center values were saved with the blank leading and trailing paragraphs the
+ * editor produces freely. "Empty" is structural rather than truthiness here, since a Plate value
+ * is always a non-null array, and a void node counts as content.
  */
 
 const p = (text: string): Value[number] => ({ type: 'p', children: [{ text }] }) as Value[number]

--- a/apps/console/src/components/shared/plate/plate-utils.test.ts
+++ b/apps/console/src/components/shared/plate/plate-utils.test.ts
@@ -1,0 +1,108 @@
+import { type Value } from 'platejs'
+import { canonicalizeDetails, isPlateValueEmpty, trimPlateValue } from './plate-utils'
+
+/**
+ * ISS-2646 — trust center overview values were saved with leading and trailing
+ * blank paragraphs, which the editor produces freely.
+ *
+ * The rules being pinned:
+ *  - "empty" is a structural question, not a truthiness one. A Plate value is a
+ *    non-null array of nodes with blank text, so `!!value` says nothing; this is
+ *    what several callers rely on to hide a panel (#88) or skip a save.
+ *  - a VOID node (an image, a divider) is content even with no text, so a value
+ *    containing one is not empty.
+ *  - trimPlateValue must not mutate its input — callers keep the original form
+ *    state while saving the trimmed copy.
+ */
+
+const p = (text: string): Value[number] => ({ type: 'p', children: [{ text }] }) as Value[number]
+
+describe('isPlateValueEmpty', () => {
+  test('treats null, undefined and an empty string as empty', () => {
+    expect(isPlateValueEmpty(null)).toBe(true)
+    expect(isPlateValueEmpty(undefined)).toBe(true)
+    expect(isPlateValueEmpty('')).toBe(true)
+  })
+
+  test('treats an empty node array as empty', () => {
+    expect(isPlateValueEmpty([])).toBe(true)
+  })
+
+  test('treats a single blank paragraph as empty', () => {
+    // The editor's default value — non-null, so a truthiness check would call
+    // this content.
+    expect(isPlateValueEmpty([p('')])).toBe(true)
+  })
+
+  test('treats whitespace-only text as empty', () => {
+    expect(isPlateValueEmpty([p('   ')])).toBe(true)
+    expect(isPlateValueEmpty([p('\n\t ')])).toBe(true)
+  })
+
+  test('treats several blank paragraphs as empty', () => {
+    expect(isPlateValueEmpty([p(''), p('  '), p('')])).toBe(true)
+  })
+
+  test('treats any real text as non-empty', () => {
+    expect(isPlateValueEmpty([p('hello')])).toBe(false)
+    expect(isPlateValueEmpty([p(''), p('hello')])).toBe(false)
+  })
+})
+
+describe('trimPlateValue', () => {
+  test('returns an empty value unchanged', () => {
+    expect(trimPlateValue([])).toEqual([])
+  })
+
+  test('drops leading and trailing blank paragraphs', () => {
+    const trimmed = trimPlateValue([p(''), p('hello'), p('')])
+
+    expect(trimmed).toHaveLength(1)
+    expect(trimmed[0]).toMatchObject({ type: 'p' })
+  })
+
+  test('keeps blank paragraphs in the MIDDLE, which are deliberate spacing', () => {
+    const trimmed = trimPlateValue([p(''), p('a'), p(''), p('b'), p('')])
+
+    expect(trimmed).toHaveLength(3)
+  })
+
+  test('trims whitespace at the very start and end of the text', () => {
+    const trimmed = trimPlateValue([p('  hello  ')])
+
+    expect(JSON.stringify(trimmed)).toContain('hello')
+    expect(JSON.stringify(trimmed)).not.toContain('  hello')
+  })
+
+  test('collapses an all-blank value to nothing', () => {
+    expect(trimPlateValue([p(''), p('  ')])).toEqual([])
+  })
+
+  test('does not mutate the input value', () => {
+    const original: Value = [p(''), p('  hello  '), p('')]
+    const snapshot = JSON.stringify(original)
+
+    trimPlateValue(original)
+
+    expect(JSON.stringify(original)).toBe(snapshot)
+  })
+
+  test('leaves an already-trimmed value alone', () => {
+    const value: Value = [p('hello')]
+
+    expect(JSON.stringify(trimPlateValue(value))).toBe(JSON.stringify(value))
+  })
+})
+
+describe('canonicalizeDetails', () => {
+  test('produces the same string regardless of key order', () => {
+    const a = [{ type: 'p', children: [{ text: 'hi' }] }] as Value
+    const b = [{ children: [{ text: 'hi' }], type: 'p' }] as Value
+
+    expect(canonicalizeDetails(a)).toBe(canonicalizeDetails(b))
+  })
+
+  test('distinguishes different content', () => {
+    expect(canonicalizeDetails([p('a')] as Value)).not.toBe(canonicalizeDetails([p('b')] as Value))
+  })
+})

--- a/apps/console/src/components/shared/plate/plate-utils.test.ts
+++ b/apps/console/src/components/shared/plate/plate-utils.test.ts
@@ -2,9 +2,9 @@ import { type Value } from 'platejs'
 import { canonicalizeDetails, isPlateValueEmpty, trimPlateValue } from './plate-utils'
 
 /**
- * ISS-2646 — trust center values were saved with the blank leading and trailing paragraphs the
- * editor produces freely. "Empty" is structural rather than truthiness here, since a Plate value
- * is always a non-null array, and a void node counts as content.
+ * Trust center values were saved with the blank leading and trailing paragraphs the editor produces freely.
+ * "Empty" is structural rather than truthiness here, since a Plate value is always a non-null array, and a
+ * void node counts as content.
  */
 
 const p = (text: string): Value[number] => ({ type: 'p', children: [{ text }] }) as Value[number]
@@ -21,8 +21,7 @@ describe('isPlateValueEmpty', () => {
   })
 
   test('treats a single blank paragraph as empty', () => {
-    // The editor's default value — non-null, so a truthiness check would call
-    // this content.
+    // The editor's default value — non-null, so a truthiness check would call this content.
     expect(isPlateValueEmpty([p('')])).toBe(true)
   })
 

--- a/apps/console/src/components/shared/scopes-selector/scope-presets.test.ts
+++ b/apps/console/src/components/shared/scopes-selector/scope-presets.test.ts
@@ -1,9 +1,9 @@
 import { buildPresetScopes, getActivePresetKey, SCOPE_PRESETS, type TScopeGroup, type TScopePreset } from './scope-presets'
 
 /**
- * #2077 — buildPresetScopes expands a preset over the object groups and getActivePresetKey does
- * the reverse. That reverse mapping has to be an exact set match, or a hand-picked selection is
- * mislabelled as a preset and silently widened when the preset is re-applied.
+ * buildPresetScopes expands a preset over the object groups and getActivePresetKey does the reverse. That
+ * reverse mapping has to be an exact set match, or a hand-picked selection is mislabelled as a preset and
+ * silently widened when the preset is re-applied.
  */
 
 const groups: TScopeGroup[] = [

--- a/apps/console/src/components/shared/scopes-selector/scope-presets.test.ts
+++ b/apps/console/src/components/shared/scopes-selector/scope-presets.test.ts
@@ -1,14 +1,9 @@
 import { buildPresetScopes, getActivePresetKey, SCOPE_PRESETS, type TScopeGroup, type TScopePreset } from './scope-presets'
 
 /**
- * #2077 — API token scope selection gained read-only / read-write / full-access
- * presets. buildPresetScopes expands a preset over the available object groups,
- * and getActivePresetKey does the reverse: it decides whether an arbitrary
- * selection happens to equal a preset, so the UI can show it as selected.
- *
- * The reverse mapping has to be an EXACT set match. A subset or superset must
- * report "no preset" — otherwise a hand-picked selection would be mislabelled as
- * a preset and silently widened the next time the preset is re-applied.
+ * #2077 — buildPresetScopes expands a preset over the object groups and getActivePresetKey does
+ * the reverse. That reverse mapping has to be an exact set match, or a hand-picked selection is
+ * mislabelled as a preset and silently widened when the preset is re-applied.
  */
 
 const groups: TScopeGroup[] = [

--- a/apps/console/src/components/shared/scopes-selector/scope-presets.test.ts
+++ b/apps/console/src/components/shared/scopes-selector/scope-presets.test.ts
@@ -1,0 +1,82 @@
+import { buildPresetScopes, getActivePresetKey, SCOPE_PRESETS, type TScopeGroup, type TScopePreset } from './scope-presets'
+
+/**
+ * #2077 — API token scope selection gained read-only / read-write / full-access
+ * presets. buildPresetScopes expands a preset over the available object groups,
+ * and getActivePresetKey does the reverse: it decides whether an arbitrary
+ * selection happens to equal a preset, so the UI can show it as selected.
+ *
+ * The reverse mapping has to be an EXACT set match. A subset or superset must
+ * report "no preset" — otherwise a hand-picked selection would be mislabelled as
+ * a preset and silently widened the next time the preset is re-applied.
+ */
+
+const groups: TScopeGroup[] = [
+  ['control', ['read', 'write', 'delete']],
+  ['policy', ['read', 'write']],
+]
+
+const preset = (key: string): TScopePreset => {
+  const found = SCOPE_PRESETS.find((p) => p.key === key)
+  if (!found) throw new Error(`no scope preset named ${key}`)
+  return found
+}
+
+describe('SCOPE_PRESETS', () => {
+  test('exposes the three presets in widening order', () => {
+    expect(SCOPE_PRESETS.map((p) => p.key)).toEqual(['read-only', 'read-write', 'full-access'])
+  })
+})
+
+describe('buildPresetScopes', () => {
+  test('read-only selects just the read permission of each object', () => {
+    expect(buildPresetScopes(groups, preset('read-only'))).toEqual(['control:read', 'policy:read'])
+  })
+
+  test('read-write adds write but never delete', () => {
+    const scopes = buildPresetScopes(groups, preset('read-write'))
+
+    expect(scopes).toEqual(['control:read', 'control:write', 'policy:read', 'policy:write'])
+    expect(scopes).not.toContain('control:delete')
+  })
+
+  test('full-access selects every permission of every object', () => {
+    expect(buildPresetScopes(groups, preset('full-access'))).toEqual(['control:read', 'control:write', 'control:delete', 'policy:read', 'policy:write'])
+  })
+
+  test('returns nothing when there are no groups', () => {
+    expect(buildPresetScopes([], preset('full-access'))).toEqual([])
+  })
+
+  test('skips an object that has no matching permission', () => {
+    expect(buildPresetScopes([['audit', ['delete']]], preset('read-only'))).toEqual([])
+  })
+})
+
+describe('getActivePresetKey', () => {
+  test('returns null for an empty selection', () => {
+    expect(getActivePresetKey(groups, [])).toBeNull()
+  })
+
+  test.each(['read-only', 'read-write', 'full-access'])('recognises an exact %s selection', (key) => {
+    expect(getActivePresetKey(groups, buildPresetScopes(groups, preset(key)))).toBe(key)
+  })
+
+  test('recognises a preset regardless of selection order', () => {
+    const shuffled = [...buildPresetScopes(groups, preset('read-write'))].reverse()
+
+    expect(getActivePresetKey(groups, shuffled)).toBe('read-write')
+  })
+
+  test('returns null for a subset of a preset', () => {
+    expect(getActivePresetKey(groups, ['control:read'])).toBeNull()
+  })
+
+  test('returns null for a preset plus one extra scope', () => {
+    expect(getActivePresetKey(groups, [...buildPresetScopes(groups, preset('read-only')), 'control:delete'])).toBeNull()
+  })
+
+  test('returns null for a hand-picked mix that matches no preset', () => {
+    expect(getActivePresetKey(groups, ['control:write', 'policy:read'])).toBeNull()
+  })
+})

--- a/apps/console/src/components/shared/table-filter/allowed-statuses.test.ts
+++ b/apps/console/src/components/shared/table-filter/allowed-statuses.test.ts
@@ -1,0 +1,93 @@
+import { resolveAllowedStatuses } from './allowed-statuses'
+import { type StatusFilterableWhere } from './has-status-condition'
+
+/**
+ * ISS-2715 — the tasks card/board view renders one column per status, but only
+ * for statuses the current filter can actually match. resolveAllowedStatuses
+ * works that out by intersecting the filter against the full status list.
+ *
+ * Getting it wrong is visible either way: too narrow and a column with tasks in
+ * it disappears; too wide and the board fills with permanently-empty columns.
+ *
+ * The and/or handling is the subtle part — `and` narrows cumulatively while `or`
+ * keeps the union of what its branches allow.
+ */
+
+type Status = 'OPEN' | 'IN_PROGRESS' | 'IN_REVIEW' | 'COMPLETED' | 'WONT_DO'
+
+const ALL: readonly Status[] = ['OPEN', 'IN_PROGRESS', 'IN_REVIEW', 'COMPLETED', 'WONT_DO']
+
+const where = (value: StatusFilterableWhere): StatusFilterableWhere => value
+
+describe('resolveAllowedStatuses', () => {
+  test('allows every status when there is no filter', () => {
+    expect(resolveAllowedStatuses(null, ALL)).toEqual([...ALL])
+    expect(resolveAllowedStatuses(undefined, ALL)).toEqual([...ALL])
+  })
+
+  test('allows every status for an empty filter', () => {
+    expect(resolveAllowedStatuses(where({}), ALL)).toEqual([...ALL])
+  })
+
+  test('narrows to a single status', () => {
+    expect(resolveAllowedStatuses(where({ status: 'OPEN' }), ALL)).toEqual(['OPEN'])
+  })
+
+  test('narrows to a statusIn list', () => {
+    expect(resolveAllowedStatuses(where({ statusIn: ['OPEN', 'IN_REVIEW'] }), ALL)).toEqual(['OPEN', 'IN_REVIEW'])
+  })
+
+  test('excludes a statusNEQ', () => {
+    expect(resolveAllowedStatuses(where({ statusNEQ: 'COMPLETED' }), ALL)).not.toContain('COMPLETED')
+  })
+
+  test('excludes a statusNotIn list', () => {
+    const allowed = resolveAllowedStatuses(where({ statusNotIn: ['COMPLETED', 'WONT_DO'] }), ALL)
+
+    expect(allowed).toEqual(['OPEN', 'IN_PROGRESS', 'IN_REVIEW'])
+  })
+
+  test('treats an empty statusIn as no constraint', () => {
+    // An empty array means "nothing selected", not "match nothing" — otherwise
+    // clearing a filter would blank the board.
+    expect(resolveAllowedStatuses(where({ statusIn: [] }), ALL)).toEqual([...ALL])
+  })
+
+  test('combines several top-level constraints', () => {
+    const allowed = resolveAllowedStatuses(where({ statusIn: ['OPEN', 'IN_PROGRESS', 'COMPLETED'], statusNEQ: 'COMPLETED' }), ALL)
+
+    expect(allowed).toEqual(['OPEN', 'IN_PROGRESS'])
+  })
+
+  test('narrows cumulatively through an and-group', () => {
+    const allowed = resolveAllowedStatuses(where({ and: [{ statusIn: ['OPEN', 'IN_PROGRESS', 'IN_REVIEW'] }, { statusNotIn: ['IN_REVIEW'] }] }), ALL)
+
+    expect(allowed).toEqual(['OPEN', 'IN_PROGRESS'])
+  })
+
+  test('keeps the union of an or-group', () => {
+    const allowed = resolveAllowedStatuses(where({ or: [{ status: 'OPEN' }, { status: 'COMPLETED' }] }), ALL)
+
+    expect(new Set(allowed)).toEqual(new Set(['OPEN', 'COMPLETED']))
+  })
+
+  test('applies a top-level constraint before an or-group', () => {
+    const allowed = resolveAllowedStatuses(where({ statusNotIn: ['COMPLETED'], or: [{ status: 'OPEN' }, { status: 'COMPLETED' }] }), ALL)
+
+    expect(allowed).toEqual(['OPEN'])
+  })
+
+  test('can resolve to nothing when the filter is contradictory', () => {
+    expect(resolveAllowedStatuses(where({ status: 'OPEN', statusNEQ: 'OPEN' }), ALL)).toEqual([])
+  })
+
+  test('handles nesting several levels deep', () => {
+    const allowed = resolveAllowedStatuses(where({ and: [{ or: [{ statusIn: ['OPEN', 'IN_PROGRESS'] }] }, { statusNEQ: 'IN_PROGRESS' }] }), ALL)
+
+    expect(allowed).toEqual(['OPEN'])
+  })
+
+  test('preserves the order of the supplied status list', () => {
+    expect(resolveAllowedStatuses(where({ statusIn: ['WONT_DO', 'OPEN'] }), ALL)).toEqual(['OPEN', 'WONT_DO'])
+  })
+})

--- a/apps/console/src/components/shared/table-filter/allowed-statuses.test.ts
+++ b/apps/console/src/components/shared/table-filter/allowed-statuses.test.ts
@@ -2,15 +2,9 @@ import { resolveAllowedStatuses } from './allowed-statuses'
 import { type StatusFilterableWhere } from './has-status-condition'
 
 /**
- * ISS-2715 — the tasks card/board view renders one column per status, but only
- * for statuses the current filter can actually match. resolveAllowedStatuses
- * works that out by intersecting the filter against the full status list.
- *
- * Getting it wrong is visible either way: too narrow and a column with tasks in
- * it disappears; too wide and the board fills with permanently-empty columns.
- *
- * The and/or handling is the subtle part — `and` narrows cumulatively while `or`
- * keeps the union of what its branches allow.
+ * ISS-2715 — the tasks board renders one column per status the current filter can match; too
+ * narrow hides a column with tasks in it, too wide fills the board with empty ones. `and` narrows
+ * cumulatively while `or` keeps the union of what its branches allow.
  */
 
 type Status = 'OPEN' | 'IN_PROGRESS' | 'IN_REVIEW' | 'COMPLETED' | 'WONT_DO'

--- a/apps/console/src/components/shared/table-filter/allowed-statuses.test.ts
+++ b/apps/console/src/components/shared/table-filter/allowed-statuses.test.ts
@@ -2,9 +2,9 @@ import { resolveAllowedStatuses } from './allowed-statuses'
 import { type StatusFilterableWhere } from './has-status-condition'
 
 /**
- * ISS-2715 — the tasks board renders one column per status the current filter can match; too
- * narrow hides a column with tasks in it, too wide fills the board with empty ones. `and` narrows
- * cumulatively while `or` keeps the union of what its branches allow.
+ * The tasks board renders one column per status the current filter can match; too narrow hides a column with
+ * tasks in it, too wide fills the board with empty ones. `and` narrows cumulatively while `or` keeps the
+ * union of what its branches allow.
  */
 
 type Status = 'OPEN' | 'IN_PROGRESS' | 'IN_REVIEW' | 'COMPLETED' | 'WONT_DO'
@@ -42,8 +42,8 @@ describe('resolveAllowedStatuses', () => {
   })
 
   test('treats an empty statusIn as no constraint', () => {
-    // An empty array means "nothing selected", not "match nothing" — otherwise
-    // clearing a filter would blank the board.
+    // An empty array means "nothing selected", not "match nothing" — otherwise clearing a filter would blank
+    // the board.
     expect(resolveAllowedStatuses(where({ statusIn: [] }), ALL)).toEqual([...ALL])
   })
 

--- a/apps/console/src/components/shared/table-filter/filter-storage.test.ts
+++ b/apps/console/src/components/shared/table-filter/filter-storage.test.ts
@@ -2,14 +2,9 @@ import { type FilterField } from '@/types'
 import { getFiltersUpdatedEvent, loadFilters, pickDeclaredFilterKeys, saveFilters } from './filter-storage'
 
 /**
- * ISS-2398 — clicking a severity chart segment used to apply BOTH a local
- * additionalWhereFilter and the persisted table filter, so the list was filtered
- * twice. The charts now route entirely through this shared filter storage and
- * re-sync from a CustomEvent, which makes the round-trip and the event name the
- * load-bearing parts.
- *
- * The event name is org-scoped: two organizations must not wake each other's
- * tables.
+ * ISS-2398 — chart segments now route through this shared storage instead of also applying a
+ * local additionalWhereFilter, which filtered the list twice. The re-sync event name is
+ * org-scoped so two organizations cannot wake each other's tables.
  */
 
 const store = new Map<string, string>()
@@ -64,7 +59,6 @@ describe('saveFilters / loadFilters round-trip', () => {
 
   test('returns null for corrupt JSON rather than throwing', () => {
     saveFilters(PAGE, { refCodeContainsFold: 'CC1' }, ORG)
-    // Corrupt the stored value directly.
     for (const key of store.keys()) store.set(key, '{not json')
 
     expect(loadFilters(PAGE, undefined, ORG)).toBeNull()

--- a/apps/console/src/components/shared/table-filter/filter-storage.test.ts
+++ b/apps/console/src/components/shared/table-filter/filter-storage.test.ts
@@ -1,0 +1,158 @@
+import { type FilterField } from '@/types'
+import { getFiltersUpdatedEvent, loadFilters, pickDeclaredFilterKeys, saveFilters } from './filter-storage'
+
+/**
+ * ISS-2398 — clicking a severity chart segment used to apply BOTH a local
+ * additionalWhereFilter and the persisted table filter, so the list was filtered
+ * twice. The charts now route entirely through this shared filter storage and
+ * re-sync from a CustomEvent, which makes the round-trip and the event name the
+ * load-bearing parts.
+ *
+ * The event name is org-scoped: two organizations must not wake each other's
+ * tables.
+ */
+
+const store = new Map<string, string>()
+
+const globals = globalThis as unknown as { window?: unknown; localStorage?: unknown }
+const originalWindow = globals.window
+const originalLocalStorage = globals.localStorage
+
+globals.window = globalThis
+globals.localStorage = {
+  getItem: (key: string) => store.get(key) ?? null,
+  setItem: (key: string, value: string) => store.set(key, String(value)),
+  removeItem: (key: string) => store.delete(key),
+}
+
+afterAll(() => {
+  globals.window = originalWindow
+  globals.localStorage = originalLocalStorage
+})
+
+beforeEach(() => store.clear())
+
+const PAGE = 'CONTROL' as Parameters<typeof saveFilters>[0]
+const ORG = 'org-123'
+const OTHER_ORG = 'org-456'
+
+const fields: FilterField[] = [
+  { key: 'refCodeContainsFold', label: 'Ref Code', type: 'text' },
+  { key: 'statusIn', label: 'Status', type: 'multiselect', options: [{ value: 'APPROVED', label: 'Approved' }] },
+  { key: 'createdAt', label: 'Created', type: 'date' },
+] as FilterField[]
+
+describe('saveFilters / loadFilters round-trip', () => {
+  test('reads back what was written', () => {
+    saveFilters(PAGE, { refCodeContainsFold: 'CC1' }, ORG)
+
+    expect(loadFilters(PAGE, undefined, ORG)).toEqual({ refCodeContainsFold: 'CC1' })
+  })
+
+  test('returns null when nothing was stored', () => {
+    expect(loadFilters(PAGE, undefined, ORG)).toBeNull()
+  })
+
+  test('revives ISO date strings back into Date objects', () => {
+    const created = new Date('2026-07-09T12:00:00.000Z')
+    saveFilters(PAGE, { createdAt: created }, ORG)
+
+    const loaded = loadFilters(PAGE, undefined, ORG)
+    expect(loaded?.createdAt).toBeInstanceOf(Date)
+    expect((loaded?.createdAt as Date).toISOString()).toBe(created.toISOString())
+  })
+
+  test('returns null for corrupt JSON rather than throwing', () => {
+    saveFilters(PAGE, { refCodeContainsFold: 'CC1' }, ORG)
+    // Corrupt the stored value directly.
+    for (const key of store.keys()) store.set(key, '{not json')
+
+    expect(loadFilters(PAGE, undefined, ORG)).toBeNull()
+  })
+
+  test('keeps organizations isolated', () => {
+    saveFilters(PAGE, { refCodeContainsFold: 'for-123' }, ORG)
+    saveFilters(PAGE, { refCodeContainsFold: 'for-456' }, OTHER_ORG)
+
+    expect(loadFilters(PAGE, undefined, ORG)).toEqual({ refCodeContainsFold: 'for-123' })
+    expect(loadFilters(PAGE, undefined, OTHER_ORG)).toEqual({ refCodeContainsFold: 'for-456' })
+  })
+})
+
+describe('loadFilters validation against declared fields', () => {
+  test('drops keys that are not declared filter fields', () => {
+    saveFilters(PAGE, { refCodeContainsFold: 'CC1', bogusKey: 'x' }, ORG)
+
+    expect(loadFilters(PAGE, fields, ORG)).toEqual({ refCodeContainsFold: 'CC1' })
+  })
+
+  test('drops an empty text value', () => {
+    saveFilters(PAGE, { refCodeContainsFold: '   ' }, ORG)
+
+    expect(loadFilters(PAGE, fields, ORG)).toEqual({})
+  })
+
+  test('drops multiselect values that are not declared options', () => {
+    saveFilters(PAGE, { statusIn: ['APPROVED', 'NOT_A_STATUS'] }, ORG)
+
+    expect(loadFilters(PAGE, fields, ORG)).toEqual({ statusIn: ['APPROVED'] })
+  })
+
+  test('drops a multiselect whose every value is unknown', () => {
+    saveFilters(PAGE, { statusIn: ['NOT_A_STATUS'] }, ORG)
+
+    expect(loadFilters(PAGE, fields, ORG)).toEqual({})
+  })
+})
+
+describe('pickDeclaredFilterKeys', () => {
+  test('keeps only declared keys', () => {
+    const declared = new Set(['statusIn'])
+    expect(pickDeclaredFilterKeys({ statusIn: ['APPROVED'], other: 'x' }, declared, PAGE)).toEqual({ statusIn: ['APPROVED'] })
+  })
+
+  test('returns an empty object when nothing matches', () => {
+    expect(pickDeclaredFilterKeys({ other: 'x' }, new Set(['statusIn']), PAGE)).toEqual({})
+  })
+})
+
+describe('getFiltersUpdatedEvent', () => {
+  test('is stable for the same page and organization', () => {
+    expect(getFiltersUpdatedEvent(PAGE, ORG)).toBe(getFiltersUpdatedEvent(PAGE, ORG))
+  })
+
+  test('differs across organizations so one org cannot wake another', () => {
+    expect(getFiltersUpdatedEvent(PAGE, ORG)).not.toBe(getFiltersUpdatedEvent(PAGE, OTHER_ORG))
+  })
+
+  test('differs across pages', () => {
+    const otherPage = 'RISK' as typeof PAGE
+    expect(getFiltersUpdatedEvent(PAGE, ORG)).not.toBe(getFiltersUpdatedEvent(otherPage, ORG))
+  })
+})
+
+describe('saveFilters notification', () => {
+  test('dispatches the org-scoped event carrying the new state', () => {
+    const received: unknown[] = []
+    const handler = (event: Event) => received.push((event as CustomEvent).detail)
+    const eventName = getFiltersUpdatedEvent(PAGE, ORG)
+
+    globalThis.addEventListener(eventName, handler)
+    saveFilters(PAGE, { statusIn: ['APPROVED'] }, ORG)
+    globalThis.removeEventListener(eventName, handler)
+
+    expect(received).toEqual([{ statusIn: ['APPROVED'] }])
+  })
+
+  test('does not notify a different organization', () => {
+    const received: unknown[] = []
+    const handler = () => received.push(true)
+    const otherEvent = getFiltersUpdatedEvent(PAGE, OTHER_ORG)
+
+    globalThis.addEventListener(otherEvent, handler)
+    saveFilters(PAGE, { statusIn: ['APPROVED'] }, ORG)
+    globalThis.removeEventListener(otherEvent, handler)
+
+    expect(received).toEqual([])
+  })
+})

--- a/apps/console/src/components/shared/table-filter/filter-storage.test.ts
+++ b/apps/console/src/components/shared/table-filter/filter-storage.test.ts
@@ -2,9 +2,9 @@ import { type FilterField } from '@/types'
 import { getFiltersUpdatedEvent, loadFilters, pickDeclaredFilterKeys, saveFilters } from './filter-storage'
 
 /**
- * ISS-2398 — chart segments now route through this shared storage instead of also applying a
- * local additionalWhereFilter, which filtered the list twice. The re-sync event name is
- * org-scoped so two organizations cannot wake each other's tables.
+ * Chart segments now route through this shared storage instead of also applying a local
+ * additionalWhereFilter, which filtered the list twice. The re-sync event name is org-scoped so two
+ * organizations cannot wake each other's tables.
  */
 
 const store = new Map<string, string>()

--- a/apps/console/src/components/shared/table-filter/has-status-condition.test.ts
+++ b/apps/console/src/components/shared/table-filter/has-status-condition.test.ts
@@ -1,9 +1,8 @@
 import { hasStatusCondition, type StatusFilterableWhere } from './has-status-condition'
 
 /**
- * ISS-2418 — linked-controls tables default to hiding archived, but must back off the moment the
- * user filters by status themselves. The check is key-presence rather than truthiness, and has to
- * look inside nested and/or groups.
+ * Linked-controls tables default to hiding archived, but must back off the moment the user filters by status
+ * themselves. The check is key-presence rather than truthiness, and has to look inside nested and/or groups.
  */
 describe('hasStatusCondition', () => {
   test('is false for an empty filter', () => {
@@ -19,8 +18,8 @@ describe('hasStatusCondition', () => {
   })
 
   test('treats an explicitly null/empty status key as a user-set condition', () => {
-    // Key presence, not value — clearing a status filter in the UI leaves the
-    // key behind, and re-applying the default would fight the user.
+    // Key presence, not value — clearing a status filter in the UI leaves the key behind, and re-applying the
+    // default would fight the user.
     expect(hasStatusCondition({ status: null })).toBe(true)
     expect(hasStatusCondition({ statusIn: [] })).toBe(true)
   })

--- a/apps/console/src/components/shared/table-filter/has-status-condition.test.ts
+++ b/apps/console/src/components/shared/table-filter/has-status-condition.test.ts
@@ -1,14 +1,9 @@
 import { hasStatusCondition, type StatusFilterableWhere } from './has-status-condition'
 
 /**
- * ISS-2418 — linked-controls tables apply a default "hide archived" status
- * filter, but must back off the moment the user filters by status themselves.
- * hasStatusCondition answers "did the user already constrain status?" and has to
- * look inside nested and/or groups, because TableFilter composes multi-condition
- * filters that way.
- *
- * The `in` check is key-presence, not truthiness: an explicitly empty or null
- * status filter still counts as the user having taken control.
+ * ISS-2418 — linked-controls tables default to hiding archived, but must back off the moment the
+ * user filters by status themselves. The check is key-presence rather than truthiness, and has to
+ * look inside nested and/or groups.
  */
 describe('hasStatusCondition', () => {
   test('is false for an empty filter', () => {

--- a/apps/console/src/components/shared/table-filter/has-status-condition.test.ts
+++ b/apps/console/src/components/shared/table-filter/has-status-condition.test.ts
@@ -1,0 +1,56 @@
+import { hasStatusCondition, type StatusFilterableWhere } from './has-status-condition'
+
+/**
+ * ISS-2418 — linked-controls tables apply a default "hide archived" status
+ * filter, but must back off the moment the user filters by status themselves.
+ * hasStatusCondition answers "did the user already constrain status?" and has to
+ * look inside nested and/or groups, because TableFilter composes multi-condition
+ * filters that way.
+ *
+ * The `in` check is key-presence, not truthiness: an explicitly empty or null
+ * status filter still counts as the user having taken control.
+ */
+describe('hasStatusCondition', () => {
+  test('is false for an empty filter', () => {
+    expect(hasStatusCondition({})).toBe(false)
+  })
+
+  test('is false for unrelated top-level keys', () => {
+    expect(hasStatusCondition({ and: [] } as StatusFilterableWhere)).toBe(false)
+  })
+
+  test.each(['status', 'statusNEQ', 'statusIn', 'statusNotIn'])('detects a top-level %s condition', (key) => {
+    expect(hasStatusCondition({ [key]: 'APPROVED' } as StatusFilterableWhere)).toBe(true)
+  })
+
+  test('treats an explicitly null/empty status key as a user-set condition', () => {
+    // Key presence, not value — clearing a status filter in the UI leaves the
+    // key behind, and re-applying the default would fight the user.
+    expect(hasStatusCondition({ status: null })).toBe(true)
+    expect(hasStatusCondition({ statusIn: [] })).toBe(true)
+  })
+
+  test('finds a status condition nested in an and-group', () => {
+    expect(hasStatusCondition({ and: [{ statusIn: ['APPROVED'] }] })).toBe(true)
+  })
+
+  test('finds a status condition nested in an or-group', () => {
+    expect(hasStatusCondition({ or: [{ statusNEQ: 'ARCHIVED' }] })).toBe(true)
+  })
+
+  test('recurses through several levels of nesting', () => {
+    expect(hasStatusCondition({ and: [{ or: [{ and: [{ status: 'PREPARING' }] }] }] })).toBe(true)
+  })
+
+  test('is false when nested groups hold only non-status conditions', () => {
+    expect(hasStatusCondition({ and: [{ or: [{}] }, {}] })).toBe(false)
+  })
+
+  test('tolerates null and/or groups', () => {
+    expect(hasStatusCondition({ and: null, or: null })).toBe(false)
+  })
+
+  test('is true when only one branch of a mixed group constrains status', () => {
+    expect(hasStatusCondition({ or: [{}, { statusIn: ['ARCHIVED'] }] })).toBe(true)
+  })
+})

--- a/apps/console/src/components/shared/table-filter/program-filter-field.test.ts
+++ b/apps/console/src/components/shared/table-filter/program-filter-field.test.ts
@@ -1,9 +1,9 @@
 import { getProgramFilterFields } from './program-filter-field'
 
 /**
- * ISS-2725 — browse-by links wrote filter state whose keys did not match the declared filter
- * fields, so loadFilters silently dropped them. A user without program access gets no field at
- * all rather than an empty-optioned one.
+ * Browse-by links wrote filter state whose keys did not match the declared filter fields, so loadFilters
+ * silently dropped them. A user without program access gets no field at all rather than an empty-optioned
+ * one.
  */
 describe('getProgramFilterFields', () => {
   const options = [
@@ -38,8 +38,8 @@ describe('getProgramFilterFields', () => {
   })
 
   test('always uses the same key so written filter state survives validation', () => {
-    // loadFilters drops keys that are not declared filter fields; a mismatch
-    // here is exactly what silently broke the browse-by links.
+    // loadFilters drops keys that are not declared filter fields; a mismatch here is exactly what silently
+    // broke the browse-by links.
     for (const label of ['Program Name', 'Program', 'Programs']) {
       expect(getProgramFilterFields(options, true, label)[0].key).toBe('hasProgramsWith')
     }

--- a/apps/console/src/components/shared/table-filter/program-filter-field.test.ts
+++ b/apps/console/src/components/shared/table-filter/program-filter-field.test.ts
@@ -1,0 +1,53 @@
+import { getProgramFilterFields } from './program-filter-field'
+
+/**
+ * ISS-2725 — "browse by" links stopped working: they wrote filter state whose
+ * keys did not match the declared filter fields, so loadFilters' validation
+ * (which drops undeclared keys) silently discarded them. The program filter was
+ * consolidated into this shared builder so the writer and the declaration cannot
+ * drift apart.
+ *
+ * The access gate matters as much as the shape: a user without program access
+ * gets NO field, not an empty-optioned one, so the filter panel does not show a
+ * control that can never match.
+ */
+describe('getProgramFilterFields', () => {
+  const options = [
+    { value: 'p-1', label: 'SOC 2' },
+    { value: 'p-2', label: 'ISO 27001' },
+  ]
+
+  test('returns nothing when the user has no program access', () => {
+    expect(getProgramFilterFields(options, false)).toEqual([])
+  })
+
+  test('returns a single multiselect field keyed on hasProgramsWith', () => {
+    const [field] = getProgramFilterFields(options, true)
+
+    expect(field).toMatchObject({ key: 'hasProgramsWith', type: 'multiselect', label: 'Program Name' })
+  })
+
+  test('passes the program options straight through', () => {
+    expect(getProgramFilterFields(options, true)[0].options).toEqual(options)
+  })
+
+  test('honours a custom label', () => {
+    expect(getProgramFilterFields(options, true, 'Program')[0].label).toBe('Program')
+  })
+
+  test('still returns the field when there are no program options', () => {
+    // Access, not option count, decides whether the control is offered.
+    const fields = getProgramFilterFields([], true)
+
+    expect(fields).toHaveLength(1)
+    expect(fields[0].options).toEqual([])
+  })
+
+  test('always uses the same key so written filter state survives validation', () => {
+    // loadFilters drops keys that are not declared filter fields; a mismatch
+    // here is exactly what silently broke the browse-by links.
+    for (const label of ['Program Name', 'Program', 'Programs']) {
+      expect(getProgramFilterFields(options, true, label)[0].key).toBe('hasProgramsWith')
+    }
+  })
+})

--- a/apps/console/src/components/shared/table-filter/program-filter-field.test.ts
+++ b/apps/console/src/components/shared/table-filter/program-filter-field.test.ts
@@ -1,15 +1,9 @@
 import { getProgramFilterFields } from './program-filter-field'
 
 /**
- * ISS-2725 — "browse by" links stopped working: they wrote filter state whose
- * keys did not match the declared filter fields, so loadFilters' validation
- * (which drops undeclared keys) silently discarded them. The program filter was
- * consolidated into this shared builder so the writer and the declaration cannot
- * drift apart.
- *
- * The access gate matters as much as the shape: a user without program access
- * gets NO field, not an empty-optioned one, so the filter panel does not show a
- * control that can never match.
+ * ISS-2725 — browse-by links wrote filter state whose keys did not match the declared filter
+ * fields, so loadFilters silently dropped them. A user without program access gets no field at
+ * all rather than an empty-optioned one.
  */
 describe('getProgramFilterFields', () => {
   const options = [

--- a/apps/console/src/constants/standards.test.ts
+++ b/apps/console/src/constants/standards.test.ts
@@ -1,0 +1,64 @@
+import {
+  EXCLUDE_SYSTEM_FRAMEWORK_CONTROLS_WHERE,
+  EXCLUDE_SYSTEM_STANDARDS_WHERE,
+  isSystemStandardRecord,
+  OPENLANE_BASELINE_STANDARD,
+  OPENLANE_SYSTEM_FRAMEWORKS,
+  OPENLANE_TRUST_CENTER_STANDARD,
+  TEMPLATE_CONTROLS_WHERE,
+} from './standards'
+
+/**
+ * ISS-2603 — Openlane ships two system-owned standards (OL Baseline and OTS)
+ * that must be hidden from org-facing lists while staying reachable through
+ * their own routes.
+ *
+ * The subtle part is SQL, not TypeScript: a bare `frameworkNotIn [...]` silently
+ * drops rows whose framework is NULL, because NULL NOT IN (...) is NULL, not
+ * true. Every exclusion clause therefore has to be an OR with an IsNil branch —
+ * without it, custom standards with no framework vanish from the list. These
+ * assertions exist to stop that OR being "simplified" away.
+ */
+describe('system standard exclusion clauses', () => {
+  test('excluding system standards keeps records with a null framework', () => {
+    expect(EXCLUDE_SYSTEM_STANDARDS_WHERE.or).toEqual([{ frameworkIsNil: true }, { frameworkNotIn: OPENLANE_SYSTEM_FRAMEWORKS }])
+  })
+
+  test('excluding system framework controls keeps records with a null referenceFramework', () => {
+    const branches = EXCLUDE_SYSTEM_FRAMEWORK_CONTROLS_WHERE.or
+
+    expect(branches?.[0]).toEqual({ referenceFrameworkIsNil: true })
+    expect(branches?.[1]).toHaveProperty('referenceFrameworkNotIn')
+  })
+
+  test('both system frameworks are covered by the exclusion list', () => {
+    expect(OPENLANE_SYSTEM_FRAMEWORKS).toContain(OPENLANE_BASELINE_STANDARD.framework)
+    expect(OPENLANE_SYSTEM_FRAMEWORKS).toContain(OPENLANE_TRUST_CENTER_STANDARD.framework)
+  })
+
+  test('template controls are scoped to system-owned OL Baseline records', () => {
+    expect(TEMPLATE_CONTROLS_WHERE).toEqual({ systemOwned: true, referenceFramework: OPENLANE_BASELINE_STANDARD.shortName })
+  })
+})
+
+describe('isSystemStandardRecord', () => {
+  test('is true for a system-owned record on a system framework', () => {
+    expect(isSystemStandardRecord({ systemOwned: true, framework: OPENLANE_BASELINE_STANDARD.framework })).toBe(true)
+    expect(isSystemStandardRecord({ systemOwned: true, framework: OPENLANE_TRUST_CENTER_STANDARD.framework })).toBe(true)
+  })
+
+  test('is false when the record is not system-owned, even on a system framework', () => {
+    // An org can legitimately create its own standard naming the same framework.
+    expect(isSystemStandardRecord({ systemOwned: false, framework: OPENLANE_BASELINE_STANDARD.framework })).toBe(false)
+  })
+
+  test('is false for a system-owned record on an unknown framework', () => {
+    expect(isSystemStandardRecord({ systemOwned: true, framework: 'soc2' })).toBe(false)
+  })
+
+  test('is false when either field is missing or null', () => {
+    expect(isSystemStandardRecord({})).toBe(false)
+    expect(isSystemStandardRecord({ systemOwned: null, framework: OPENLANE_BASELINE_STANDARD.framework })).toBe(false)
+    expect(isSystemStandardRecord({ systemOwned: true, framework: null })).toBe(false)
+  })
+})

--- a/apps/console/src/constants/standards.test.ts
+++ b/apps/console/src/constants/standards.test.ts
@@ -9,15 +9,9 @@ import {
 } from './standards'
 
 /**
- * ISS-2603 — Openlane ships two system-owned standards (OL Baseline and OTS)
- * that must be hidden from org-facing lists while staying reachable through
- * their own routes.
- *
- * The subtle part is SQL, not TypeScript: a bare `frameworkNotIn [...]` silently
- * drops rows whose framework is NULL, because NULL NOT IN (...) is NULL, not
- * true. Every exclusion clause therefore has to be an OR with an IsNil branch —
- * without it, custom standards with no framework vanish from the list. These
- * assertions exist to stop that OR being "simplified" away.
+ * ISS-2603 — a bare `frameworkNotIn [...]` silently drops rows whose framework is NULL, because
+ * NULL NOT IN (...) is NULL rather than true. Every exclusion clause therefore needs an OR'd
+ * IsNil branch, and these assertions exist to stop it being simplified away.
  */
 describe('system standard exclusion clauses', () => {
   test('excluding system standards keeps records with a null framework', () => {

--- a/apps/console/src/constants/standards.test.ts
+++ b/apps/console/src/constants/standards.test.ts
@@ -9,9 +9,9 @@ import {
 } from './standards'
 
 /**
- * ISS-2603 — a bare `frameworkNotIn [...]` silently drops rows whose framework is NULL, because
- * NULL NOT IN (...) is NULL rather than true. Every exclusion clause therefore needs an OR'd
- * IsNil branch, and these assertions exist to stop it being simplified away.
+ * A bare `frameworkNotIn [...]` silently drops rows whose framework is NULL, because NULL NOT IN (...) is
+ * NULL rather than true. Every exclusion clause therefore needs an OR'd IsNil branch, and these assertions
+ * exist to stop it being simplified away.
  */
 describe('system standard exclusion clauses', () => {
   test('excluding system standards keeps records with a null framework', () => {

--- a/apps/console/src/lib/docs-help/section-cache.test.ts
+++ b/apps/console/src/lib/docs-help/section-cache.test.ts
@@ -3,8 +3,8 @@ import type { SectionLookup, SectionResult } from '@/lib/docs-help/types'
 import { cacheKeyOf, readSectionCache, writeSectionCache } from './section-cache'
 
 /**
- * #2148 — an in-process LRU with a TTL. A read re-inserts the entry as most-recently-used;
- * without that, eviction throws out entries that are actively in use.
+ * An in-process LRU with a TTL. A read re-inserts the entry as most-recently-used; without that, eviction
+ * throws out entries that are actively in use.
  */
 
 const result = (text: string): SectionResult => ({ text }) as unknown as SectionResult

--- a/apps/console/src/lib/docs-help/section-cache.test.ts
+++ b/apps/console/src/lib/docs-help/section-cache.test.ts
@@ -3,18 +3,8 @@ import type { SectionLookup, SectionResult } from '@/lib/docs-help/types'
 import { cacheKeyOf, readSectionCache, writeSectionCache } from './section-cache'
 
 /**
- * #2148 — resolved docs sections are cached in-process. It is an LRU with a TTL,
- * and both halves have a subtle rule:
- *
- *  - a READ re-inserts the entry so it becomes most-recently-used. Without that
- *    the map keeps insertion order and eviction throws out entries that are
- *    being actively used.
- *  - the cache key must distinguish every field of the lookup, including an
- *    extractSection given as an array vs the same value as a string, otherwise
- *    two different requests share one answer.
- *
- * The cache is module-level state shared across tests, so keys here are unique
- * per test rather than reset between them.
+ * #2148 — an in-process LRU with a TTL. A read re-inserts the entry as most-recently-used;
+ * without that, eviction throws out entries that are actively in use.
  */
 
 const result = (text: string): SectionResult => ({ text }) as unknown as SectionResult
@@ -43,11 +33,6 @@ describe('cacheKeyOf', () => {
   })
 
   test('produces a stable key when the optional fields are absent', () => {
-    // `prefer` and `section` collapse to '' but a missing `extractSection`
-    // stringifies to the literal "undefined". That is untidy rather than wrong:
-    // it is consistent, so two lookups without one still share a key. Only a
-    // lookup whose extractSection is literally the string "undefined" would
-    // collide, which is not a real input.
     expect(cacheKeyOf(lookup())).toBe(cacheKeyOf(lookup()))
     expect(cacheKeyOf(lookup())).toBe('controls||undefined|')
   })
@@ -79,7 +64,6 @@ describe('LRU eviction', () => {
       writeSectionCache(`${prefix}${i}`, result(String(i)))
     }
 
-    // The first writes are gone; the most recent survive.
     expect(readSectionCache(`${prefix}0`)).toBeNull()
     expect(readSectionCache(`${prefix}${SECTION_CACHE_MAX + 4}`)).toEqual(result(String(SECTION_CACHE_MAX + 4)))
   })
@@ -88,7 +72,6 @@ describe('LRU eviction', () => {
     const prefix = `lru-${Date.now()}-`
     writeSectionCache(`${prefix}kept`, result('kept'))
 
-    // Fill past the cap, re-reading the entry partway so it becomes MRU.
     for (let i = 0; i < SECTION_CACHE_MAX - 1; i++) {
       writeSectionCache(`${prefix}${i}`, result(String(i)))
       if (i === Math.floor(SECTION_CACHE_MAX / 2)) readSectionCache(`${prefix}kept`)

--- a/apps/console/src/lib/docs-help/section-cache.test.ts
+++ b/apps/console/src/lib/docs-help/section-cache.test.ts
@@ -1,0 +1,100 @@
+import { SECTION_CACHE_MAX } from '@/lib/docs-help/constants'
+import type { SectionLookup, SectionResult } from '@/lib/docs-help/types'
+import { cacheKeyOf, readSectionCache, writeSectionCache } from './section-cache'
+
+/**
+ * #2148 — resolved docs sections are cached in-process. It is an LRU with a TTL,
+ * and both halves have a subtle rule:
+ *
+ *  - a READ re-inserts the entry so it becomes most-recently-used. Without that
+ *    the map keeps insertion order and eviction throws out entries that are
+ *    being actively used.
+ *  - the cache key must distinguish every field of the lookup, including an
+ *    extractSection given as an array vs the same value as a string, otherwise
+ *    two different requests share one answer.
+ *
+ * The cache is module-level state shared across tests, so keys here are unique
+ * per test rather than reset between them.
+ */
+
+const result = (text: string): SectionResult => ({ text }) as unknown as SectionResult
+
+const lookup = (over: Partial<SectionLookup> = {}): SectionLookup => ({ query: 'controls', ...over }) as SectionLookup
+
+describe('cacheKeyOf', () => {
+  test('is stable for the same lookup', () => {
+    expect(cacheKeyOf(lookup())).toBe(cacheKeyOf(lookup()))
+  })
+
+  test('distinguishes different queries', () => {
+    expect(cacheKeyOf(lookup({ query: 'a' }))).not.toBe(cacheKeyOf(lookup({ query: 'b' })))
+  })
+
+  test('distinguishes the prefer field', () => {
+    expect(cacheKeyOf(lookup({ prefer: 'x' }))).not.toBe(cacheKeyOf(lookup({ prefer: 'y' })))
+  })
+
+  test('distinguishes the section argument', () => {
+    expect(cacheKeyOf(lookup(), 'one')).not.toBe(cacheKeyOf(lookup(), 'two'))
+  })
+
+  test('joins an array extractSection so multi-section lookups stay distinct', () => {
+    expect(cacheKeyOf(lookup({ extractSection: ['a', 'b'] }))).not.toBe(cacheKeyOf(lookup({ extractSection: ['a'] })))
+  })
+
+  test('produces a stable key when the optional fields are absent', () => {
+    // `prefer` and `section` collapse to '' but a missing `extractSection`
+    // stringifies to the literal "undefined". That is untidy rather than wrong:
+    // it is consistent, so two lookups without one still share a key. Only a
+    // lookup whose extractSection is literally the string "undefined" would
+    // collide, which is not a real input.
+    expect(cacheKeyOf(lookup())).toBe(cacheKeyOf(lookup()))
+    expect(cacheKeyOf(lookup())).toBe('controls||undefined|')
+  })
+})
+
+describe('read/write round-trip', () => {
+  test('returns null for a key that was never written', () => {
+    expect(readSectionCache('never-written-key')).toBeNull()
+  })
+
+  test('reads back a written result', () => {
+    writeSectionCache('roundtrip-key', result('hello'))
+
+    expect(readSectionCache('roundtrip-key')).toEqual(result('hello'))
+  })
+
+  test('a later write for the same key replaces the earlier one', () => {
+    writeSectionCache('replace-key', result('first'))
+    writeSectionCache('replace-key', result('second'))
+
+    expect(readSectionCache('replace-key')).toEqual(result('second'))
+  })
+})
+
+describe('LRU eviction', () => {
+  test('evicts the oldest entries once the cache exceeds its maximum', () => {
+    const prefix = `evict-${Date.now()}-`
+    for (let i = 0; i < SECTION_CACHE_MAX + 5; i++) {
+      writeSectionCache(`${prefix}${i}`, result(String(i)))
+    }
+
+    // The first writes are gone; the most recent survive.
+    expect(readSectionCache(`${prefix}0`)).toBeNull()
+    expect(readSectionCache(`${prefix}${SECTION_CACHE_MAX + 4}`)).toEqual(result(String(SECTION_CACHE_MAX + 4)))
+  })
+
+  test('reading an entry protects it from the next eviction sweep', () => {
+    const prefix = `lru-${Date.now()}-`
+    writeSectionCache(`${prefix}kept`, result('kept'))
+
+    // Fill past the cap, re-reading the entry partway so it becomes MRU.
+    for (let i = 0; i < SECTION_CACHE_MAX - 1; i++) {
+      writeSectionCache(`${prefix}${i}`, result(String(i)))
+      if (i === Math.floor(SECTION_CACHE_MAX / 2)) readSectionCache(`${prefix}kept`)
+    }
+    writeSectionCache(`${prefix}last`, result('last'))
+
+    expect(readSectionCache(`${prefix}kept`)).toEqual(result('kept'))
+  })
+})

--- a/apps/console/src/lib/graphql-hooks/task-where.test.ts
+++ b/apps/console/src/lib/graphql-hooks/task-where.test.ts
@@ -2,13 +2,9 @@ import { type TaskWhereInput } from '@repo/codegen/src/schema'
 import { EXCLUDE_TEMPLATES_WHERE, resolveTasksWhere } from './task-where'
 
 /**
- * ISS-2714 — task templates are stored as tasks with isTemplate:true, so every
- * ordinary task query has to exclude them or the list fills with templates.
- *
- * The back-off rule is the interesting part: the exclusion is dropped when the
- * caller ALREADY constrains isTemplate anywhere in its filter (including inside
- * a nested and/or), so the template picker can ask for templates without the
- * default silently contradicting it and returning nothing.
+ * ISS-2714 — task templates are stored as tasks with isTemplate:true, so ordinary queries have to
+ * exclude them. The exclusion backs off when the caller already constrains isTemplate anywhere in
+ * its filter, including inside a nested and/or.
  */
 describe('resolveTasksWhere', () => {
   test('excludes templates when there is no filter at all', () => {

--- a/apps/console/src/lib/graphql-hooks/task-where.test.ts
+++ b/apps/console/src/lib/graphql-hooks/task-where.test.ts
@@ -1,0 +1,58 @@
+import { type TaskWhereInput } from '@repo/codegen/src/schema'
+import { EXCLUDE_TEMPLATES_WHERE, resolveTasksWhere } from './task-where'
+
+/**
+ * ISS-2714 — task templates are stored as tasks with isTemplate:true, so every
+ * ordinary task query has to exclude them or the list fills with templates.
+ *
+ * The back-off rule is the interesting part: the exclusion is dropped when the
+ * caller ALREADY constrains isTemplate anywhere in its filter (including inside
+ * a nested and/or), so the template picker can ask for templates without the
+ * default silently contradicting it and returning nothing.
+ */
+describe('resolveTasksWhere', () => {
+  test('excludes templates when there is no filter at all', () => {
+    expect(resolveTasksWhere(null)).toEqual(EXCLUDE_TEMPLATES_WHERE)
+    expect(resolveTasksWhere(undefined)).toEqual(EXCLUDE_TEMPLATES_WHERE)
+  })
+
+  test('excludes templates alongside an unrelated filter', () => {
+    const resolved = resolveTasksWhere({ titleContainsFold: 'audit' })
+
+    expect(resolved.and).toEqual([{ titleContainsFold: 'audit' }, EXCLUDE_TEMPLATES_WHERE])
+  })
+
+  test('drops the exclusion when the caller asks for templates explicitly', () => {
+    expect(resolveTasksWhere(null, true)).toEqual({})
+  })
+
+  test('keeps the caller filter untouched when templates are requested', () => {
+    expect(resolveTasksWhere({ titleContainsFold: 'audit' }, true)).toEqual({ titleContainsFold: 'audit' })
+  })
+
+  test('backs off when the caller already constrains isTemplate', () => {
+    // Otherwise the default would AND isTemplate:false onto isTemplate:true and
+    // the template picker would return nothing.
+    expect(resolveTasksWhere({ isTemplate: true })).toEqual({ isTemplate: true })
+  })
+
+  test('backs off for an isTemplate constraint nested in an and-group', () => {
+    const where: TaskWhereInput = { and: [{ isTemplate: true }] }
+
+    expect(resolveTasksWhere(where)).toEqual(where)
+  })
+
+  test('backs off for an isTemplate constraint nested in an or-group', () => {
+    const where: TaskWhereInput = { or: [{ isTemplate: true }, { isTemplate: false }] }
+
+    expect(resolveTasksWhere(where)).toEqual(where)
+  })
+
+  test('an explicit includeTemplates:false still excludes templates', () => {
+    expect(resolveTasksWhere({ titleContainsFold: 'audit' }, false).and).toEqual([{ titleContainsFold: 'audit' }, EXCLUDE_TEMPLATES_WHERE])
+  })
+
+  test('includeTemplates wins over an existing isTemplate constraint', () => {
+    expect(resolveTasksWhere({ isTemplate: false }, true)).toEqual({ isTemplate: false })
+  })
+})

--- a/apps/console/src/lib/graphql-hooks/task-where.test.ts
+++ b/apps/console/src/lib/graphql-hooks/task-where.test.ts
@@ -2,9 +2,9 @@ import { type TaskWhereInput } from '@repo/codegen/src/schema'
 import { EXCLUDE_TEMPLATES_WHERE, resolveTasksWhere } from './task-where'
 
 /**
- * ISS-2714 — task templates are stored as tasks with isTemplate:true, so ordinary queries have to
- * exclude them. The exclusion backs off when the caller already constrains isTemplate anywhere in
- * its filter, including inside a nested and/or.
+ * Task templates are stored as tasks with isTemplate:true, so ordinary queries have to exclude them. The
+ * exclusion backs off when the caller already constrains isTemplate anywhere in its filter, including inside
+ * a nested and/or.
  */
 describe('resolveTasksWhere', () => {
   test('excludes templates when there is no filter at all', () => {
@@ -27,8 +27,8 @@ describe('resolveTasksWhere', () => {
   })
 
   test('backs off when the caller already constrains isTemplate', () => {
-    // Otherwise the default would AND isTemplate:false onto isTemplate:true and
-    // the template picker would return nothing.
+    // Otherwise the default would AND isTemplate:false onto isTemplate:true and the template picker would
+    // return nothing.
     expect(resolveTasksWhere({ isTemplate: true })).toEqual({ isTemplate: true })
   })
 

--- a/apps/console/src/lib/merge-where.test.ts
+++ b/apps/console/src/lib/merge-where.test.ts
@@ -1,0 +1,65 @@
+import { mergeWhere } from './merge-where'
+
+/**
+ * ISS-2687 — system-standard exclusions have to be combined with whatever filter
+ * the user has set, without either clobbering the other. mergeWhere does that
+ * combination.
+ *
+ * Two details carry weight:
+ *  - an EMPTY object is dropped, not merged. `{}` in an `and` array is harmless
+ *    to some backends and a match-nothing to others; dropping it is the safe
+ *    reading, and it means "no filter set" contributes nothing.
+ *  - a single surviving condition is returned UNWRAPPED. Wrapping one clause in
+ *    `and: [...]` needlessly nests every query and defeats predicate checks like
+ *    hasStatusCondition that inspect top-level keys.
+ */
+
+type Where = { and?: Where[] | null; status?: string; refCode?: string; systemOwned?: boolean }
+
+describe('mergeWhere', () => {
+  test('returns an empty object when there is nothing to merge', () => {
+    expect(mergeWhere<Where>([])).toEqual({})
+    expect(mergeWhere<Where>([null, undefined])).toEqual({})
+  })
+
+  test('drops empty objects', () => {
+    expect(mergeWhere<Where>([{}, {}])).toEqual({})
+  })
+
+  test('returns a single condition unwrapped', () => {
+    // Wrapping one clause in `and` nests every query for no benefit.
+    expect(mergeWhere<Where>([{ status: 'APPROVED' }])).toEqual({ status: 'APPROVED' })
+  })
+
+  test('returns the only non-empty condition unwrapped', () => {
+    expect(mergeWhere<Where>([null, { status: 'APPROVED' }, {}, undefined])).toEqual({ status: 'APPROVED' })
+  })
+
+  test('wraps two or more conditions in an and', () => {
+    expect(mergeWhere<Where>([{ status: 'APPROVED' }, { systemOwned: false }])).toEqual({
+      and: [{ status: 'APPROVED' }, { systemOwned: false }],
+    })
+  })
+
+  test('preserves order so the caller controls precedence', () => {
+    const merged = mergeWhere<Where>([{ systemOwned: false }, { status: 'APPROVED' }, { refCode: 'CC1.1' }])
+
+    expect(merged.and).toEqual([{ systemOwned: false }, { status: 'APPROVED' }, { refCode: 'CC1.1' }])
+  })
+
+  test('keeps a nested and intact rather than flattening it', () => {
+    const exclusion: Where = { and: [{ systemOwned: false }] }
+    const merged = mergeWhere<Where>([exclusion, { status: 'APPROVED' }])
+
+    expect(merged.and?.[0]).toEqual(exclusion)
+  })
+
+  test('does not mutate the inputs', () => {
+    const a: Where = { status: 'APPROVED' }
+    const b: Where = { systemOwned: false }
+    mergeWhere<Where>([a, b])
+
+    expect(a).toEqual({ status: 'APPROVED' })
+    expect(b).toEqual({ systemOwned: false })
+  })
+})

--- a/apps/console/src/lib/merge-where.test.ts
+++ b/apps/console/src/lib/merge-where.test.ts
@@ -1,9 +1,9 @@
 import { mergeWhere } from './merge-where'
 
 /**
- * ISS-2687 — combines system-standard exclusions with whatever filter the user has set, without
- * either clobbering the other. An empty object is dropped, and a single surviving condition is
- * returned unwrapped rather than nested in an `and`.
+ * Combines system-standard exclusions with whatever filter the user has set, without either clobbering the
+ * other. An empty object is dropped, and a single surviving condition is returned unwrapped rather than
+ * nested in an `and`.
  */
 
 type Where = { and?: Where[] | null; status?: string; refCode?: string; systemOwned?: boolean }

--- a/apps/console/src/lib/merge-where.test.ts
+++ b/apps/console/src/lib/merge-where.test.ts
@@ -1,17 +1,9 @@
 import { mergeWhere } from './merge-where'
 
 /**
- * ISS-2687 — system-standard exclusions have to be combined with whatever filter
- * the user has set, without either clobbering the other. mergeWhere does that
- * combination.
- *
- * Two details carry weight:
- *  - an EMPTY object is dropped, not merged. `{}` in an `and` array is harmless
- *    to some backends and a match-nothing to others; dropping it is the safe
- *    reading, and it means "no filter set" contributes nothing.
- *  - a single surviving condition is returned UNWRAPPED. Wrapping one clause in
- *    `and: [...]` needlessly nests every query and defeats predicate checks like
- *    hasStatusCondition that inspect top-level keys.
+ * ISS-2687 — combines system-standard exclusions with whatever filter the user has set, without
+ * either clobbering the other. An empty object is dropped, and a single surviving condition is
+ * returned unwrapped rather than nested in an `and`.
  */
 
 type Where = { and?: Where[] | null; status?: string; refCode?: string; systemOwned?: boolean }

--- a/apps/console/src/lib/sla.test.ts
+++ b/apps/console/src/lib/sla.test.ts
@@ -1,0 +1,134 @@
+import { addDays, startOfDay, subDays } from 'date-fns'
+import { type Condition, type ConditionValue } from '@/types'
+import { type SlaDefinitionsNodeNonNull } from '@/lib/graphql-hooks/sla-definition'
+import { buildDueSoonCondition, buildPastDueCondition, buildSlaDaysByLevel, DUE_SOON_WINDOW_DAYS, getSlaDueDate, isSlaPastDue } from './sla'
+
+/**
+ * ISS-2482 — the past-due calculation was duplicated across the attention table,
+ * the vulnerability/finding tables and the SLA badge, each with its own casing
+ * and null handling. It now lives here.
+ *
+ * The rules worth pinning: security levels are matched case-insensitively via an
+ * uppercase index, the FIRST definition for a level wins (later duplicates are
+ * ignored), non-positive or non-numeric slaDays are dropped entirely, and the
+ * query conditions are built from day boundaries rather than "now" so they stay
+ * stable within a day.
+ */
+
+const def = (securityLevel: string | null, slaDays: number | null): SlaDefinitionsNodeNonNull => ({ securityLevel, slaDays }) as unknown as SlaDefinitionsNodeNonNull
+
+// `Condition.or` is typed as the broad ConditionValue union. The builders emit
+// flat `{ securityLevel, createdAt* }` records, which is ConditionValue's
+// `{ [operator: string]: string | number }` member — narrow to exactly that
+// rather than indexing through the union at every assertion.
+type SlaBranch = { [operator: string]: string | number }
+
+const isBranchList = (value: ConditionValue | undefined): value is SlaBranch[] => Array.isArray(value)
+
+const orBranches = (condition: Condition): SlaBranch[] => {
+  const branches = condition.or
+  if (!isBranchList(branches)) throw new Error('expected the condition to carry an or[] branch list')
+  return branches
+}
+
+describe('buildSlaDaysByLevel', () => {
+  test('indexes definitions by uppercased security level', () => {
+    expect(buildSlaDaysByLevel([def('critical', 7), def('High', 30)])).toEqual({ CRITICAL: 7, HIGH: 30 })
+  })
+
+  test('keeps the first definition for a level and ignores later duplicates', () => {
+    expect(buildSlaDaysByLevel([def('CRITICAL', 7), def('critical', 99)])).toEqual({ CRITICAL: 7 })
+  })
+
+  test('drops definitions with no security level', () => {
+    expect(buildSlaDaysByLevel([def(null, 7)])).toEqual({})
+  })
+
+  test('drops non-positive and non-numeric slaDays', () => {
+    expect(buildSlaDaysByLevel([def('LOW', 0), def('MEDIUM', -1), def('HIGH', null)])).toEqual({})
+  })
+
+  test('returns an empty index for no definitions', () => {
+    expect(buildSlaDaysByLevel([])).toEqual({})
+  })
+})
+
+describe('getSlaDueDate', () => {
+  const levels = { CRITICAL: 7 }
+
+  test('adds the level slaDays to the created date', () => {
+    const due = getSlaDueDate('2026-07-01T00:00:00.000Z', 'CRITICAL', levels)
+    expect(due?.toISOString()).toBe(addDays(new Date('2026-07-01T00:00:00.000Z'), 7).toISOString())
+  })
+
+  test('matches the security level case-insensitively', () => {
+    expect(getSlaDueDate('2026-07-01T00:00:00.000Z', 'critical', levels)).not.toBeNull()
+  })
+
+  test('returns null when the level has no SLA', () => {
+    expect(getSlaDueDate('2026-07-01T00:00:00.000Z', 'LOW', levels)).toBeNull()
+  })
+
+  test('returns null for missing createdAt or securityLevel', () => {
+    expect(getSlaDueDate(null, 'CRITICAL', levels)).toBeNull()
+    expect(getSlaDueDate('2026-07-01T00:00:00.000Z', null, levels)).toBeNull()
+    expect(getSlaDueDate('', 'CRITICAL', levels)).toBeNull()
+  })
+
+  test('returns null for an unparseable createdAt', () => {
+    expect(getSlaDueDate('not-a-date', 'CRITICAL', levels)).toBeNull()
+  })
+})
+
+describe('isSlaPastDue', () => {
+  test('is true for a date in the past', () => {
+    expect(isSlaPastDue(subDays(new Date(), 1))).toBe(true)
+  })
+
+  test('is false for a date in the future', () => {
+    expect(isSlaPastDue(addDays(new Date(), 1))).toBe(false)
+  })
+
+  test('is false for null and undefined', () => {
+    expect(isSlaPastDue(null)).toBe(false)
+    expect(isSlaPastDue(undefined)).toBe(false)
+  })
+})
+
+describe('buildPastDueCondition', () => {
+  test('scopes to open records and one or-branch per level', () => {
+    const condition = buildPastDueCondition({ CRITICAL: 7, HIGH: 30 })
+
+    expect(condition.open).toBe(true)
+    expect(orBranches(condition)).toHaveLength(2)
+    expect(orBranches(condition)[0]).toMatchObject({ securityLevel: 'CRITICAL' })
+  })
+
+  test('anchors each branch to the start of the day minus slaDays', () => {
+    const condition = buildPastDueCondition({ CRITICAL: 7 })
+    const expected = subDays(startOfDay(new Date()), 7).toISOString()
+
+    expect(orBranches(condition)[0]).toMatchObject({ createdAtLT: expected })
+  })
+
+  test('produces no branches when there are no SLA definitions', () => {
+    expect(orBranches(buildPastDueCondition({}))).toEqual([])
+  })
+})
+
+describe('buildDueSoonCondition', () => {
+  test('brackets each level between its due date and the look-ahead window', () => {
+    const condition = buildDueSoonCondition({ CRITICAL: 7 })
+    const lower = subDays(startOfDay(new Date()), 7)
+
+    expect(orBranches(condition)[0]).toMatchObject({
+      securityLevel: 'CRITICAL',
+      createdAtGTE: lower.toISOString(),
+      createdAtLT: addDays(lower, DUE_SOON_WINDOW_DAYS).toISOString(),
+    })
+  })
+
+  test('uses a 14-day look-ahead window', () => {
+    expect(DUE_SOON_WINDOW_DAYS).toBe(14)
+  })
+})

--- a/apps/console/src/lib/sla.test.ts
+++ b/apps/console/src/lib/sla.test.ts
@@ -4,15 +4,14 @@ import { type SlaDefinitionsNodeNonNull } from '@/lib/graphql-hooks/sla-definiti
 import { buildDueSoonCondition, buildPastDueCondition, buildSlaDaysByLevel, DUE_SOON_WINDOW_DAYS, getSlaDueDate, isSlaPastDue } from './sla'
 
 /**
- * ISS-2482 — the past-due calculation was duplicated across the attention table, the
- * vulnerability/finding tables and the SLA badge, each with its own casing and null handling.
- * It now lives here.
+ * The past-due calculation was duplicated across the attention table, the vulnerability/finding tables and
+ * the SLA badge, each with its own casing and null handling. It now lives here.
  */
 
 const def = (securityLevel: string | null, slaDays: number | null): SlaDefinitionsNodeNonNull => ({ securityLevel, slaDays }) as unknown as SlaDefinitionsNodeNonNull
 
-// The builders emit flat `{ securityLevel, createdAt* }` records; narrow to exactly that
-// member of ConditionValue rather than indexing through the union at every assertion.
+// The builders emit flat `{ securityLevel, createdAt* }` records; narrow to exactly that member of
+// ConditionValue rather than indexing through the union at every assertion.
 type SlaBranch = { [operator: string]: string | number }
 
 const isBranchList = (value: ConditionValue | undefined): value is SlaBranch[] => Array.isArray(value)

--- a/apps/console/src/lib/sla.test.ts
+++ b/apps/console/src/lib/sla.test.ts
@@ -4,23 +4,15 @@ import { type SlaDefinitionsNodeNonNull } from '@/lib/graphql-hooks/sla-definiti
 import { buildDueSoonCondition, buildPastDueCondition, buildSlaDaysByLevel, DUE_SOON_WINDOW_DAYS, getSlaDueDate, isSlaPastDue } from './sla'
 
 /**
- * ISS-2482 — the past-due calculation was duplicated across the attention table,
- * the vulnerability/finding tables and the SLA badge, each with its own casing
- * and null handling. It now lives here.
- *
- * The rules worth pinning: security levels are matched case-insensitively via an
- * uppercase index, the FIRST definition for a level wins (later duplicates are
- * ignored), non-positive or non-numeric slaDays are dropped entirely, and the
- * query conditions are built from day boundaries rather than "now" so they stay
- * stable within a day.
+ * ISS-2482 — the past-due calculation was duplicated across the attention table, the
+ * vulnerability/finding tables and the SLA badge, each with its own casing and null handling.
+ * It now lives here.
  */
 
 const def = (securityLevel: string | null, slaDays: number | null): SlaDefinitionsNodeNonNull => ({ securityLevel, slaDays }) as unknown as SlaDefinitionsNodeNonNull
 
-// `Condition.or` is typed as the broad ConditionValue union. The builders emit
-// flat `{ securityLevel, createdAt* }` records, which is ConditionValue's
-// `{ [operator: string]: string | number }` member — narrow to exactly that
-// rather than indexing through the union at every assertion.
+// The builders emit flat `{ securityLevel, createdAt* }` records; narrow to exactly that
+// member of ConditionValue rather than indexing through the union at every assertion.
 type SlaBranch = { [operator: string]: string | number }
 
 const isBranchList = (value: ConditionValue | undefined): value is SlaBranch[] => Array.isArray(value)

--- a/apps/console/src/lib/sort.test.ts
+++ b/apps/console/src/lib/sort.test.ts
@@ -1,9 +1,8 @@
 import { compareNatural } from './sort'
 
 /**
- * ISS-2550 — compareNatural reuses one Intl.Collator instead of building one per comparison,
- * which dominated the sort on large control reports. Behaviour has to stay identical to the
- * localeCompare call it replaced.
+ * compareNatural reuses one Intl.Collator instead of building one per comparison, which dominated the sort on
+ * large control reports. Behaviour has to stay identical to the localeCompare call it replaced.
  */
 describe('compareNatural', () => {
   const sorted = (values: string[]): string[] => [...values].sort(compareNatural)

--- a/apps/console/src/lib/sort.test.ts
+++ b/apps/console/src/lib/sort.test.ts
@@ -1,0 +1,50 @@
+import { compareNatural } from './sort'
+
+/**
+ * ISS-2550 — the control report sorted ref codes with a fresh
+ * `localeCompare(..., { numeric: true })` on every comparison, which builds a
+ * collator per call and dominated the sort on large reports. compareNatural
+ * reuses one Intl.Collator.
+ *
+ * The behaviour must be identical to the call it replaced, so these pin the
+ * natural-ordering contract that control ref codes depend on: CC1.2 before
+ * CC1.10, not after.
+ */
+describe('compareNatural', () => {
+  const sorted = (values: string[]): string[] => [...values].sort(compareNatural)
+
+  test('orders embedded numbers numerically, not lexically', () => {
+    expect(sorted(['CC1.10', 'CC1.2', 'CC1.1'])).toEqual(['CC1.1', 'CC1.2', 'CC1.10'])
+  })
+
+  test('orders multi-segment ref codes correctly', () => {
+    expect(sorted(['A.10.1', 'A.2.1', 'A.2.10', 'A.2.2'])).toEqual(['A.2.1', 'A.2.2', 'A.2.10', 'A.10.1'])
+  })
+
+  test('returns 0 for identical values', () => {
+    expect(compareNatural('CC1.1', 'CC1.1')).toBe(0)
+  })
+
+  test('is antisymmetric', () => {
+    expect(Math.sign(compareNatural('CC1.2', 'CC1.10'))).toBe(-Math.sign(compareNatural('CC1.10', 'CC1.2')))
+  })
+
+  test('sorts an empty string first', () => {
+    expect(sorted(['CC1.1', ''])).toEqual(['', 'CC1.1'])
+  })
+
+  test('handles pure numbers', () => {
+    expect(sorted(['10', '9', '100', '1'])).toEqual(['1', '9', '10', '100'])
+  })
+
+  test('handles values with no digits', () => {
+    expect(sorted(['beta', 'alpha', 'gamma'])).toEqual(['alpha', 'beta', 'gamma'])
+  })
+
+  test('produces a stable total order over a mixed set', () => {
+    const values = ['CC2.1', 'CC1.10', 'A.1', 'CC1.2', 'B.10', 'B.2']
+    const once = sorted(values)
+
+    expect(sorted(once)).toEqual(once)
+  })
+})

--- a/apps/console/src/lib/sort.test.ts
+++ b/apps/console/src/lib/sort.test.ts
@@ -1,14 +1,9 @@
 import { compareNatural } from './sort'
 
 /**
- * ISS-2550 — the control report sorted ref codes with a fresh
- * `localeCompare(..., { numeric: true })` on every comparison, which builds a
- * collator per call and dominated the sort on large reports. compareNatural
- * reuses one Intl.Collator.
- *
- * The behaviour must be identical to the call it replaced, so these pin the
- * natural-ordering contract that control ref codes depend on: CC1.2 before
- * CC1.10, not after.
+ * ISS-2550 — compareNatural reuses one Intl.Collator instead of building one per comparison,
+ * which dominated the sort on large control reports. Behaviour has to stay identical to the
+ * localeCompare call it replaced.
  */
 describe('compareNatural', () => {
   const sorted = (values: string[]): string[] => [...values].sort(compareNatural)

--- a/apps/console/src/lib/storage/announcement-dismissal.test.ts
+++ b/apps/console/src/lib/storage/announcement-dismissal.test.ts
@@ -1,9 +1,9 @@
 import { getDismissedAnnouncement, recordDismissedAnnouncement } from './announcement-dismissal'
 
 /**
- * ISS-2770 — the banner stores the dismissed message rather than a boolean, which is what makes a
- * new announcement reappear for someone who dismissed the previous one. Deliberately not
- * org-scoped, since an announcement is global to the deployment.
+ * The banner stores the dismissed message rather than a boolean, which is what makes a new announcement
+ * reappear for someone who dismissed the previous one. Deliberately not org-scoped, since an announcement is
+ * global to the deployment.
  */
 
 const store = new Map<string, string>()
@@ -43,8 +43,7 @@ describe('announcement dismissal', () => {
   })
 
   test('a newer announcement replaces the stored one', () => {
-    // The banner compares stored-vs-current, so a new message must not read as
-    // already dismissed.
+    // The banner compares stored-vs-current, so a new message must not read as already dismissed.
     recordDismissedAnnouncement('Old announcement')
     recordDismissedAnnouncement('New announcement')
 

--- a/apps/console/src/lib/storage/announcement-dismissal.test.ts
+++ b/apps/console/src/lib/storage/announcement-dismissal.test.ts
@@ -1,12 +1,9 @@
 import { getDismissedAnnouncement, recordDismissedAnnouncement } from './announcement-dismissal'
 
 /**
- * ISS-2770 — the announcement banner remembers a dismissal by storing the
- * MESSAGE, not a boolean. That is what makes a NEW announcement reappear for
- * someone who dismissed the previous one: the banner compares the stored string
- * against the current message rather than checking a dismissed flag.
- *
- * Not org-scoped, deliberately — an announcement is global to the deployment.
+ * ISS-2770 — the banner stores the dismissed message rather than a boolean, which is what makes a
+ * new announcement reappear for someone who dismissed the previous one. Deliberately not
+ * org-scoped, since an announcement is global to the deployment.
  */
 
 const store = new Map<string, string>()

--- a/apps/console/src/lib/storage/announcement-dismissal.test.ts
+++ b/apps/console/src/lib/storage/announcement-dismissal.test.ts
@@ -1,0 +1,89 @@
+import { getDismissedAnnouncement, recordDismissedAnnouncement } from './announcement-dismissal'
+
+/**
+ * ISS-2770 — the announcement banner remembers a dismissal by storing the
+ * MESSAGE, not a boolean. That is what makes a NEW announcement reappear for
+ * someone who dismissed the previous one: the banner compares the stored string
+ * against the current message rather than checking a dismissed flag.
+ *
+ * Not org-scoped, deliberately — an announcement is global to the deployment.
+ */
+
+const store = new Map<string, string>()
+
+const globals = globalThis as unknown as { window?: unknown; localStorage?: unknown }
+const originalWindow = globals.window
+const originalLocalStorage = globals.localStorage
+
+const workingStorage = {
+  getItem: (key: string) => store.get(key) ?? null,
+  setItem: (key: string, value: string) => store.set(key, String(value)),
+  removeItem: (key: string) => store.delete(key),
+}
+
+globals.window = globalThis
+globals.localStorage = workingStorage
+
+afterAll(() => {
+  globals.window = originalWindow
+  globals.localStorage = originalLocalStorage
+})
+
+beforeEach(() => {
+  store.clear()
+  globals.localStorage = workingStorage
+})
+
+describe('announcement dismissal', () => {
+  test('reads null before anything is dismissed', () => {
+    expect(getDismissedAnnouncement()).toBeNull()
+  })
+
+  test('records and reads back the dismissed message', () => {
+    recordDismissedAnnouncement('Scheduled maintenance on Friday')
+
+    expect(getDismissedAnnouncement()).toBe('Scheduled maintenance on Friday')
+  })
+
+  test('a newer announcement replaces the stored one', () => {
+    // The banner compares stored-vs-current, so a new message must not read as
+    // already dismissed.
+    recordDismissedAnnouncement('Old announcement')
+    recordDismissedAnnouncement('New announcement')
+
+    expect(getDismissedAnnouncement()).toBe('New announcement')
+    expect(getDismissedAnnouncement()).not.toBe('Old announcement')
+  })
+
+  test('stores an empty message without collapsing it to null', () => {
+    recordDismissedAnnouncement('')
+
+    expect(getDismissedAnnouncement()).toBe('')
+  })
+})
+
+describe('when localStorage throws', () => {
+  beforeEach(() => {
+    globals.localStorage = {
+      getItem: () => {
+        throw new Error('SecurityError')
+      },
+      setItem: () => {
+        throw new Error('SecurityError')
+      },
+      removeItem: () => {
+        throw new Error('SecurityError')
+      },
+    }
+  })
+
+  test('reading degrades to null rather than throwing', () => {
+    expect(() => getDismissedAnnouncement()).not.toThrow()
+    expect(getDismissedAnnouncement()).toBeNull()
+  })
+
+  test('recording swallows the failure', () => {
+    // Worst case the banner reappears; it must never break the page shell.
+    expect(() => recordDismissedAnnouncement('anything')).not.toThrow()
+  })
+})

--- a/apps/console/src/lib/storage/org-persisted-store.test.ts
+++ b/apps/console/src/lib/storage/org-persisted-store.test.ts
@@ -1,9 +1,8 @@
 import { createOrgPersistedStore, parseString, parseStringUnion } from './org-persisted-store'
 
 /**
- * ISS-2614 — backs a useSyncExternalStore with org-scoped localStorage. Snapshots are cached per
- * org so one org's choice cannot leak into another, and getSnapshot must be referentially stable
- * or the store re-renders forever.
+ * Backs a useSyncExternalStore with org-scoped localStorage. Snapshots are cached per org so one org's choice
+ * cannot leak into another, and getSnapshot must be referentially stable or the store re-renders forever.
  */
 
 const store = new Map<string, string>()

--- a/apps/console/src/lib/storage/org-persisted-store.test.ts
+++ b/apps/console/src/lib/storage/org-persisted-store.test.ts
@@ -1,15 +1,9 @@
 import { createOrgPersistedStore, parseString, parseStringUnion } from './org-persisted-store'
 
 /**
- * ISS-2614 — the dashboard's work-item "Group by" choice had to survive a
- * reload, per organization. createOrgPersistedStore backs a useSyncExternalStore
- * with org-scoped localStorage.
- *
- * The store is a plain factory, so it is testable without React. What matters:
- * snapshots are cached PER ORG (a shared cache would leak one org's choice into
- * another), getSnapshot must be referentially stable so useSyncExternalStore
- * does not loop, a corrupt or unknown stored value falls back to the default
- * rather than throwing, and the server snapshot is never hydrated.
+ * ISS-2614 — backs a useSyncExternalStore with org-scoped localStorage. Snapshots are cached per
+ * org so one org's choice cannot leak into another, and getSnapshot must be referentially stable
+ * or the store re-renders forever.
  */
 
 const store = new Map<string, string>()

--- a/apps/console/src/lib/storage/org-persisted-store.test.ts
+++ b/apps/console/src/lib/storage/org-persisted-store.test.ts
@@ -1,0 +1,149 @@
+import { createOrgPersistedStore, parseString, parseStringUnion } from './org-persisted-store'
+
+/**
+ * ISS-2614 — the dashboard's work-item "Group by" choice had to survive a
+ * reload, per organization. createOrgPersistedStore backs a useSyncExternalStore
+ * with org-scoped localStorage.
+ *
+ * The store is a plain factory, so it is testable without React. What matters:
+ * snapshots are cached PER ORG (a shared cache would leak one org's choice into
+ * another), getSnapshot must be referentially stable so useSyncExternalStore
+ * does not loop, a corrupt or unknown stored value falls back to the default
+ * rather than throwing, and the server snapshot is never hydrated.
+ */
+
+const store = new Map<string, string>()
+
+const globals = globalThis as unknown as { window?: unknown; localStorage?: unknown }
+const originalWindow = globals.window
+const originalLocalStorage = globals.localStorage
+
+globals.window = globalThis
+globals.localStorage = {
+  getItem: (key: string) => store.get(key) ?? null,
+  setItem: (key: string, value: string) => store.set(key, String(value)),
+  removeItem: (key: string) => store.delete(key),
+}
+
+afterAll(() => {
+  globals.window = originalWindow
+  globals.localStorage = originalLocalStorage
+})
+
+beforeEach(() => store.clear())
+
+type GroupBy = 'type' | 'kind'
+const isGroupBy = (value: string): value is GroupBy => value === 'type' || value === 'kind'
+const makeStore = () =>
+  createOrgPersistedStore<GroupBy>(
+    'group-by:work-items',
+    (raw) => parseStringUnion(raw, isGroupBy),
+    () => 'type',
+  )
+
+const ORG = 'org-123'
+const OTHER_ORG = 'org-456'
+
+describe('createOrgPersistedStore', () => {
+  test('falls back to the default when nothing is stored', () => {
+    expect(makeStore().getSnapshot(ORG)).toEqual({ value: 'type', isHydrated: true })
+  })
+
+  test('reads back a value written through set', () => {
+    const s = makeStore()
+    s.set(ORG, 'kind')
+
+    expect(s.getSnapshot(ORG).value).toBe('kind')
+  })
+
+  test('persists across store instances (i.e. across a reload)', () => {
+    makeStore().set(ORG, 'kind')
+
+    expect(makeStore().getSnapshot(ORG).value).toBe('kind')
+  })
+
+  test('keeps organizations isolated', () => {
+    const s = makeStore()
+    s.set(ORG, 'kind')
+
+    expect(s.getSnapshot(ORG).value).toBe('kind')
+    expect(s.getSnapshot(OTHER_ORG).value).toBe('type')
+  })
+
+  test('returns a referentially stable snapshot for repeat reads', () => {
+    // useSyncExternalStore re-renders forever if getSnapshot returns a new object.
+    const s = makeStore()
+
+    expect(s.getSnapshot(ORG)).toBe(s.getSnapshot(ORG))
+  })
+
+  test('returns a new snapshot object after a set', () => {
+    const s = makeStore()
+    const before = s.getSnapshot(ORG)
+    s.set(ORG, 'kind')
+
+    expect(s.getSnapshot(ORG)).not.toBe(before)
+  })
+
+  test('notifies subscribers on change and stops after unsubscribe', () => {
+    const s = makeStore()
+    let calls = 0
+    const unsubscribe = s.subscribe(() => {
+      calls++
+    })
+
+    s.set(ORG, 'kind')
+    expect(calls).toBe(1)
+
+    unsubscribe()
+    s.set(ORG, 'type')
+    expect(calls).toBe(1)
+  })
+
+  test('does not notify when the value is unchanged', () => {
+    const s = makeStore()
+    let calls = 0
+    s.subscribe(() => {
+      calls++
+    })
+
+    s.set(ORG, 'kind')
+    s.set(ORG, 'kind')
+
+    expect(calls).toBe(1)
+  })
+
+  test('falls back to the default for a corrupt or unknown stored value', () => {
+    const s = makeStore()
+    s.set(ORG, 'kind')
+    for (const key of store.keys()) store.set(key, '"not-a-group-by"')
+
+    expect(makeStore().getSnapshot(ORG).value).toBe('type')
+  })
+
+  test('reports the server snapshot as not hydrated', () => {
+    expect(makeStore().getServerSnapshot()).toEqual({ value: 'type', isHydrated: false })
+  })
+})
+
+describe('parseString', () => {
+  test('accepts a non-empty JSON string', () => {
+    expect(parseString('"kind"')).toBe('kind')
+  })
+
+  test('rejects an empty string, a non-string, and invalid JSON', () => {
+    expect(parseString('""')).toBeNull()
+    expect(parseString('42')).toBeNull()
+    expect(parseString('{')).toBeNull()
+  })
+})
+
+describe('parseStringUnion', () => {
+  test('accepts a value the guard allows', () => {
+    expect(parseStringUnion('"kind"', isGroupBy)).toBe('kind')
+  })
+
+  test('rejects a value outside the union', () => {
+    expect(parseStringUnion('"other"', isGroupBy)).toBeNull()
+  })
+})

--- a/apps/console/src/lib/storage/organization-storage.test.ts
+++ b/apps/console/src/lib/storage/organization-storage.test.ts
@@ -85,10 +85,9 @@ describe('organization storage legacy fallback', () => {
 })
 
 /**
- * The shipped cases cover key construction and the legacy-key retirement rules.
- * These add the property the feature actually exists for — one org's stored
- * state must never be visible to another — plus the throw-safe path, since
- * localStorage access itself raises in private mode / blocked-cookie contexts.
+ * Adds the property the feature exists for — one org's stored state must never be visible to
+ * another — plus the throw-safe path, since localStorage access itself raises in private mode and
+ * blocked-cookie contexts.
  */
 describe('cross-organization isolation', () => {
   beforeEach(() => store.clear())

--- a/apps/console/src/lib/storage/organization-storage.test.ts
+++ b/apps/console/src/lib/storage/organization-storage.test.ts
@@ -83,3 +83,77 @@ describe('organization storage legacy fallback', () => {
     expect(store.has(getOrganizationStorageKey(KEY))).toBe(false)
   })
 })
+
+/**
+ * The shipped cases cover key construction and the legacy-key retirement rules.
+ * These add the property the feature actually exists for — one org's stored
+ * state must never be visible to another — plus the throw-safe path, since
+ * localStorage access itself raises in private mode / blocked-cookie contexts.
+ */
+describe('cross-organization isolation', () => {
+  beforeEach(() => store.clear())
+
+  it('keeps values written under different organizations separate', () => {
+    setOrganizationStorageItem(KEY, 'controls-for-org-123', ORG_ID)
+    setOrganizationStorageItem(KEY, 'controls-for-org-456', OTHER_ORG_ID)
+
+    expect(getOrganizationStorageItem(KEY, ORG_ID)).toBe('controls-for-org-123')
+    expect(getOrganizationStorageItem(KEY, OTHER_ORG_ID)).toBe('controls-for-org-456')
+  })
+
+  it('does not leak a value into an organization that never wrote one', () => {
+    setOrganizationStorageItem(KEY, 'only-org-123', ORG_ID)
+
+    expect(getOrganizationStorageItem(KEY, OTHER_ORG_ID)).toBeNull()
+  })
+
+  it('removing one organization value leaves the other intact', () => {
+    setOrganizationStorageItem(KEY, 'a', ORG_ID)
+    setOrganizationStorageItem(KEY, 'b', OTHER_ORG_ID)
+
+    removeOrganizationStorageItem(KEY, ORG_ID)
+
+    expect(getOrganizationStorageItem(KEY, ORG_ID)).toBeNull()
+    expect(getOrganizationStorageItem(KEY, OTHER_ORG_ID)).toBe('b')
+  })
+
+  it('treats the unresolved organization as its own scope', () => {
+    // A render before the org id resolves must not read or clobber a real org's value.
+    setOrganizationStorageItem(KEY, 'resolved', ORG_ID)
+    setOrganizationStorageItem(KEY, 'unresolved', undefined)
+
+    expect(getOrganizationStorageItem(KEY, ORG_ID)).toBe('resolved')
+    expect(getOrganizationStorageItem(KEY, undefined)).toBe('unresolved')
+  })
+})
+
+describe('when localStorage itself throws', () => {
+  const workingLocalStorage = globals.localStorage
+
+  beforeEach(() => {
+    globals.localStorage = {
+      getItem: () => {
+        throw new Error('SecurityError')
+      },
+      setItem: () => {
+        throw new Error('SecurityError')
+      },
+      removeItem: () => {
+        throw new Error('SecurityError')
+      },
+    }
+  })
+
+  afterEach(() => {
+    globals.localStorage = workingLocalStorage
+  })
+
+  it('reads null instead of propagating', () => {
+    expect(getOrganizationStorageItem(KEY, ORG_ID)).toBeNull()
+  })
+
+  it('swallows write and remove failures', () => {
+    expect(() => setOrganizationStorageItem(KEY, 'x', ORG_ID)).not.toThrow()
+    expect(() => removeOrganizationStorageItem(KEY, ORG_ID)).not.toThrow()
+  })
+})

--- a/apps/console/src/lib/storage/organization-storage.test.ts
+++ b/apps/console/src/lib/storage/organization-storage.test.ts
@@ -85,9 +85,8 @@ describe('organization storage legacy fallback', () => {
 })
 
 /**
- * Adds the property the feature exists for — one org's stored state must never be visible to
- * another — plus the throw-safe path, since localStorage access itself raises in private mode and
- * blocked-cookie contexts.
+ * Adds the property the feature exists for — one org's stored state must never be visible to another — plus
+ * the throw-safe path, since localStorage access itself raises in private mode and blocked-cookie contexts.
  */
 describe('cross-organization isolation', () => {
   beforeEach(() => store.clear())

--- a/apps/console/src/lib/subscription-plan/plans.test.ts
+++ b/apps/console/src/lib/subscription-plan/plans.test.ts
@@ -3,9 +3,9 @@ import { arePlanChecksDisabled, featureUtil } from './plans'
 import { PlanEnum } from './plan-enum'
 
 /**
- * #1969 — support sessions carry no subscription modules, so every module gate has to treat an
- * impersonation session as fully entitled. Without the bypass a support engineer lands in an org
- * with the whole sidebar locked and the billing reported as expired.
+ * Support sessions carry no subscription modules, so every module gate has to treat an impersonation session
+ * as fully entitled. Without the bypass a support engineer lands in an org with the whole sidebar locked and
+ * the billing reported as expired.
  */
 
 const session = (over: Partial<Session['user']> = {}): Session =>
@@ -18,8 +18,8 @@ const support = () => session({ isImpersonation: true })
 const originalEnablePlan = process.env.NEXT_PUBLIC_ENABLE_PLAN
 
 beforeEach(() => {
-  // Plan checks ON unless a test opts out, so the impersonation bypass is what
-  // is actually under test rather than the env short-circuit.
+  // Plan checks ON unless a test opts out, so the impersonation bypass is what is actually under test rather
+  // than the env short-circuit.
   process.env.NEXT_PUBLIC_ENABLE_PLAN = 'true'
 })
 
@@ -65,8 +65,8 @@ describe('featureUtil.hasNoModules', () => {
   })
 
   test('is false for a support session despite an empty module list', () => {
-    // This is the bug the commit fixed: a support session would otherwise read
-    // as billing-expired and hide the whole nav.
+    // This is the bug the commit fixed: a support session would otherwise read as billing-expired and hide
+    // the whole nav.
     expect(featureUtil.hasNoModules(support())).toBe(false)
   })
 
@@ -88,11 +88,8 @@ describe('featureUtil.hasObjectType', () => {
 })
 
 /**
- * ISS-2588 — module gating was consolidated so tables, filters and layouts all
- * consult the same map instead of hand-rolled FeatureGate wrappers.
- * getUpgradeModules is the lookup: an object type ABSENT from the map requires
- * nothing, which is what keeps ungated features working rather than locking them
- * out by default.
+ * getUpgradeModules is the lookup behind module gating. An object type absent from the map requires nothing,
+ * which is what keeps ungated features working rather than locking them out by default.
  */
 describe('featureUtil.getUpgradeModules', () => {
   test('requires nothing for an object type that is not module-gated', () => {

--- a/apps/console/src/lib/subscription-plan/plans.test.ts
+++ b/apps/console/src/lib/subscription-plan/plans.test.ts
@@ -1,0 +1,144 @@
+import { type Session } from 'next-auth'
+import { arePlanChecksDisabled, featureUtil } from './plans'
+import { PlanEnum } from './plan-enum'
+
+/**
+ * #1969 — Openlane support sessions carry no subscription modules, so every
+ * module gate has to treat an impersonation session as fully entitled. Without
+ * the bypass a support engineer lands in an org where the whole sidebar is
+ * locked and `hasNoModules` reports the billing as expired.
+ *
+ * The env-var escape hatch (NEXT_PUBLIC_ENABLE_PLAN=false) short-circuits the
+ * same checks, so it is asserted alongside to keep the two paths distinct.
+ */
+
+const session = (over: Partial<Session['user']> = {}): Session =>
+  ({
+    user: { modules: [], ...over },
+  }) as unknown as Session
+
+const support = () => session({ isImpersonation: true })
+
+const originalEnablePlan = process.env.NEXT_PUBLIC_ENABLE_PLAN
+
+beforeEach(() => {
+  // Plan checks ON unless a test opts out, so the impersonation bypass is what
+  // is actually under test rather than the env short-circuit.
+  process.env.NEXT_PUBLIC_ENABLE_PLAN = 'true'
+})
+
+afterAll(() => {
+  if (originalEnablePlan === undefined) delete process.env.NEXT_PUBLIC_ENABLE_PLAN
+  else process.env.NEXT_PUBLIC_ENABLE_PLAN = originalEnablePlan
+})
+
+describe('featureUtil.hasModule', () => {
+  test('is true when the user holds the required module', () => {
+    expect(featureUtil.hasModule([PlanEnum.COMPLIANCE_MODULE], PlanEnum.COMPLIANCE_MODULE)).toBe(true)
+  })
+
+  test('is false when the user does not hold it', () => {
+    expect(featureUtil.hasModule([], PlanEnum.COMPLIANCE_MODULE)).toBe(false)
+  })
+
+  test('is true for a support session that holds no modules at all', () => {
+    expect(featureUtil.hasModule([], PlanEnum.COMPLIANCE_MODULE, support())).toBe(true)
+  })
+
+  test('still gates a normal session even when one is passed', () => {
+    expect(featureUtil.hasModule([], PlanEnum.COMPLIANCE_MODULE, session())).toBe(false)
+  })
+
+  test('is true for everyone when plan checks are disabled', () => {
+    process.env.NEXT_PUBLIC_ENABLE_PLAN = 'false'
+    expect(featureUtil.hasModule([], PlanEnum.COMPLIANCE_MODULE)).toBe(true)
+  })
+})
+
+describe('featureUtil.hasNoModules', () => {
+  test('is false without a session', () => {
+    expect(featureUtil.hasNoModules(null)).toBe(false)
+  })
+
+  test('is true for a normal session with an empty module list', () => {
+    expect(featureUtil.hasNoModules(session({ modules: [] }))).toBe(true)
+  })
+
+  test('is false for a normal session that holds a module', () => {
+    expect(featureUtil.hasNoModules(session({ modules: [PlanEnum.COMPLIANCE_MODULE] }))).toBe(false)
+  })
+
+  test('is false for a support session despite an empty module list', () => {
+    // This is the bug the commit fixed: a support session would otherwise read
+    // as billing-expired and hide the whole nav.
+    expect(featureUtil.hasNoModules(support())).toBe(false)
+  })
+
+  test('is false for everyone when plan checks are disabled', () => {
+    process.env.NEXT_PUBLIC_ENABLE_PLAN = 'false'
+    expect(featureUtil.hasNoModules(session({ modules: [] }))).toBe(false)
+  })
+})
+
+describe('featureUtil.hasObjectType', () => {
+  test('is true for a support session regardless of modules', () => {
+    expect(featureUtil.hasObjectType([], 'Control' as never, support())).toBe(true)
+  })
+
+  test('is true when the object type is not module-gated', () => {
+    // Object types absent from MODULES_BY_OBJECT_TYPE require nothing.
+    expect(featureUtil.hasObjectType([], '__NotGated__' as never)).toBe(true)
+  })
+})
+
+/**
+ * ISS-2588 — module gating was consolidated so tables, filters and layouts all
+ * consult the same map instead of hand-rolled FeatureGate wrappers.
+ * getUpgradeModules is the lookup: an object type ABSENT from the map requires
+ * nothing, which is what keeps ungated features working rather than locking them
+ * out by default.
+ */
+describe('featureUtil.getUpgradeModules', () => {
+  test('requires nothing for an object type that is not module-gated', () => {
+    expect(featureUtil.getUpgradeModules('__NotGated__' as never)).toEqual([])
+  })
+
+  test('returns modules for a gated object type', () => {
+    const modules = featureUtil.getUpgradeModules('Control' as never)
+
+    expect(Array.isArray(modules)).toBe(true)
+  })
+
+  test('never returns undefined, so callers can spread the result safely', () => {
+    for (const objectType of ['Control', 'Evidence', '__Unknown__']) {
+      expect(featureUtil.getUpgradeModules(objectType as never)).toBeDefined()
+    }
+  })
+})
+
+describe('featureUtil.getPlanName', () => {
+  test('gives every plan a human name', () => {
+    expect(featureUtil.getPlanName(PlanEnum.COMPLIANCE_MODULE)).toBe('Compliance')
+    expect(featureUtil.getPlanName(PlanEnum.TRUST_CENTER_MODULE)).toBe('Trust Center')
+  })
+
+  test('names every member of the plan enum', () => {
+    for (const plan of Object.values(PlanEnum)) {
+      expect(featureUtil.getPlanName(plan)).toBeTruthy()
+    }
+  })
+})
+
+describe('arePlanChecksDisabled', () => {
+  test('tracks the env flag exactly, not merely its truthiness', () => {
+    process.env.NEXT_PUBLIC_ENABLE_PLAN = 'false'
+    expect(arePlanChecksDisabled()).toBe(true)
+
+    process.env.NEXT_PUBLIC_ENABLE_PLAN = 'true'
+    expect(arePlanChecksDisabled()).toBe(false)
+
+    // Anything other than the literal 'false' leaves checks ON.
+    process.env.NEXT_PUBLIC_ENABLE_PLAN = ''
+    expect(arePlanChecksDisabled()).toBe(false)
+  })
+})

--- a/apps/console/src/lib/subscription-plan/plans.test.ts
+++ b/apps/console/src/lib/subscription-plan/plans.test.ts
@@ -3,13 +3,9 @@ import { arePlanChecksDisabled, featureUtil } from './plans'
 import { PlanEnum } from './plan-enum'
 
 /**
- * #1969 — Openlane support sessions carry no subscription modules, so every
- * module gate has to treat an impersonation session as fully entitled. Without
- * the bypass a support engineer lands in an org where the whole sidebar is
- * locked and `hasNoModules` reports the billing as expired.
- *
- * The env-var escape hatch (NEXT_PUBLIC_ENABLE_PLAN=false) short-circuits the
- * same checks, so it is asserted alongside to keep the two paths distinct.
+ * #1969 — support sessions carry no subscription modules, so every module gate has to treat an
+ * impersonation session as fully entitled. Without the bypass a support engineer lands in an org
+ * with the whole sidebar locked and the billing reported as expired.
  */
 
 const session = (over: Partial<Session['user']> = {}): Session =>

--- a/apps/console/src/lib/validators.test.ts
+++ b/apps/console/src/lib/validators.test.ts
@@ -1,13 +1,9 @@
 import { dedupeEmails, isDuplicateEmail, isUlid, isValidEmail, normalizeEmail } from './validators'
 
 /**
- * ISS-2428 — pressing Tab in the invite email input added a duplicate chip,
- * because the two call sites hand-rolled their own case-insensitive comparison
- * and one of them compared un-normalised strings. The comparison is now a single
- * shared helper.
- *
- * Case and surrounding whitespace are the whole point: "User@Acme.com " and
- * "user@acme.com" are the same invitee.
+ * ISS-2428 — pressing Tab in the invite email input added a duplicate chip, because the two call
+ * sites hand-rolled their own comparison and one of them compared un-normalised strings. Case and
+ * surrounding whitespace are the whole point.
  */
 describe('normalizeEmail', () => {
   test('lowercases and trims', () => {

--- a/apps/console/src/lib/validators.test.ts
+++ b/apps/console/src/lib/validators.test.ts
@@ -1,9 +1,9 @@
 import { dedupeEmails, isDuplicateEmail, isUlid, isValidEmail, normalizeEmail } from './validators'
 
 /**
- * ISS-2428 — pressing Tab in the invite email input added a duplicate chip, because the two call
- * sites hand-rolled their own comparison and one of them compared un-normalised strings. Case and
- * surrounding whitespace are the whole point.
+ * Pressing Tab in the invite email input added a duplicate chip, because the two call sites hand-rolled their
+ * own comparison and one of them compared un-normalised strings. Case and surrounding whitespace are the
+ * whole point.
  */
 describe('normalizeEmail', () => {
   test('lowercases and trims', () => {

--- a/apps/console/src/lib/validators.test.ts
+++ b/apps/console/src/lib/validators.test.ts
@@ -1,0 +1,87 @@
+import { dedupeEmails, isDuplicateEmail, isUlid, isValidEmail, normalizeEmail } from './validators'
+
+/**
+ * ISS-2428 — pressing Tab in the invite email input added a duplicate chip,
+ * because the two call sites hand-rolled their own case-insensitive comparison
+ * and one of them compared un-normalised strings. The comparison is now a single
+ * shared helper.
+ *
+ * Case and surrounding whitespace are the whole point: "User@Acme.com " and
+ * "user@acme.com" are the same invitee.
+ */
+describe('normalizeEmail', () => {
+  test('lowercases and trims', () => {
+    expect(normalizeEmail('  User@Acme.COM  ')).toBe('user@acme.com')
+  })
+})
+
+describe('isDuplicateEmail', () => {
+  test('is false against an empty list', () => {
+    expect(isDuplicateEmail('user@acme.com', [])).toBe(false)
+  })
+
+  test('detects an exact match', () => {
+    expect(isDuplicateEmail('user@acme.com', ['user@acme.com'])).toBe(true)
+  })
+
+  test('detects a match differing only by case', () => {
+    expect(isDuplicateEmail('User@Acme.COM', ['user@acme.com'])).toBe(true)
+  })
+
+  test('detects a match differing only by surrounding whitespace', () => {
+    // This is the Tab-key path: the raw input still carries whitespace.
+    expect(isDuplicateEmail('  user@acme.com  ', ['user@acme.com'])).toBe(true)
+  })
+
+  test('normalises the existing entries too, not just the candidate', () => {
+    expect(isDuplicateEmail('user@acme.com', ['  USER@ACME.COM '])).toBe(true)
+  })
+
+  test('is false for a genuinely different address', () => {
+    expect(isDuplicateEmail('other@acme.com', ['user@acme.com'])).toBe(false)
+  })
+})
+
+describe('dedupeEmails', () => {
+  test('returns an empty list unchanged', () => {
+    expect(dedupeEmails([])).toEqual([])
+  })
+
+  test('keeps the first occurrence and its original casing', () => {
+    expect(dedupeEmails(['User@Acme.com', 'user@acme.com', 'USER@ACME.COM'])).toEqual(['User@Acme.com'])
+  })
+
+  test('preserves order across distinct addresses', () => {
+    expect(dedupeEmails(['b@acme.com', 'a@acme.com', 'b@acme.com'])).toEqual(['b@acme.com', 'a@acme.com'])
+  })
+
+  test('treats whitespace-padded duplicates as the same address', () => {
+    expect(dedupeEmails(['user@acme.com', ' user@acme.com '])).toHaveLength(1)
+  })
+})
+
+describe('isValidEmail', () => {
+  test.each(['user@acme.com', 'first.last@sub.acme.co.uk', 'user+tag@acme.io'])('accepts %s', (email) => {
+    expect(isValidEmail(email)).toBe(true)
+  })
+
+  test.each(['', 'user', 'user@', '@acme.com', 'user@acme', 'user @acme.com', 'user@ acme.com'])('rejects %s', (email) => {
+    expect(isValidEmail(email)).toBe(false)
+  })
+})
+
+describe('isUlid', () => {
+  test('accepts a 26-character ULID in either case', () => {
+    expect(isUlid('01HXAMPLEUSER0000000000000')).toBe(true)
+    expect(isUlid('01hxampleuser0000000000000')).toBe(true)
+  })
+
+  test.each([
+    ['too short', '01HXAMPLE'],
+    ['too long', '01HXAMPLEUSER00000000000000'],
+    ['a hyphenated uuid', '123e4567-e89b-12d3-a456-426614174000'],
+    ['empty', ''],
+  ])('rejects %s', (_label, value) => {
+    expect(isUlid(value)).toBe(false)
+  })
+})

--- a/apps/console/src/lib/vendor-logo.test.ts
+++ b/apps/console/src/lib/vendor-logo.test.ts
@@ -1,11 +1,9 @@
 import { buildVendorLogoProxyUrl, getVendorLogoUrl, toVendorLogoHost, VENDOR_LOGO_SIZE } from './vendor-logo'
 
 /**
- * ISS-2486 — vendor logos are looked up by domain through an authenticated proxy
- * route. toVendorLogoHost is what decides whether a user-typed website value is
- * safe to forward: it accepts a bare domain or a full URL, strips scheme/path/
- * port down to the hostname, and returns null for anything that is not a real
- * registrable domain — so junk never reaches the outbound favicon request.
+ * ISS-2486 — decides whether a user-typed website value is safe to forward to the authenticated
+ * logo proxy. Anything that is not a real registrable domain returns null, so junk never reaches
+ * the outbound request.
  */
 describe('toVendorLogoHost', () => {
   test.each([

--- a/apps/console/src/lib/vendor-logo.test.ts
+++ b/apps/console/src/lib/vendor-logo.test.ts
@@ -1,0 +1,73 @@
+import { buildVendorLogoProxyUrl, getVendorLogoUrl, toVendorLogoHost, VENDOR_LOGO_SIZE } from './vendor-logo'
+
+/**
+ * ISS-2486 — vendor logos are looked up by domain through an authenticated proxy
+ * route. toVendorLogoHost is what decides whether a user-typed website value is
+ * safe to forward: it accepts a bare domain or a full URL, strips scheme/path/
+ * port down to the hostname, and returns null for anything that is not a real
+ * registrable domain — so junk never reaches the outbound favicon request.
+ */
+describe('toVendorLogoHost', () => {
+  test.each([
+    ['a bare domain', 'acme.com', 'acme.com'],
+    ['a subdomain', 'www.acme.com', 'www.acme.com'],
+    ['a full https url', 'https://acme.com', 'acme.com'],
+    ['a url with a path', 'https://acme.com/about', 'acme.com'],
+    ['a url with a port', 'https://acme.com:8443', 'acme.com'],
+    ['mixed case and padding', '  ACME.com  ', 'acme.com'],
+    ['a multi-label tld', 'acme.co.uk', 'acme.co.uk'],
+  ])('extracts the host from %s', (_label, input, expected) => {
+    expect(toVendorLogoHost(input)).toBe(expected)
+  })
+
+  test.each([
+    ['an empty string', ''],
+    ['whitespace only', '   '],
+    ['a bare hostname with no dot', 'localhost'],
+    ['a trailing-dot domain', 'acme.com.'],
+    ['a numeric tld', 'acme.123'],
+    ['an ip address', '127.0.0.1'],
+  ])('returns null for %s', (_label, input) => {
+    expect(toVendorLogoHost(input)).toBeNull()
+  })
+})
+
+describe('buildVendorLogoProxyUrl', () => {
+  test('targets the internal proxy route with the default size', () => {
+    expect(buildVendorLogoProxyUrl('acme.com')).toBe(`/api/vendor-logo?domain=acme.com&sz=${VENDOR_LOGO_SIZE.default}`)
+  })
+
+  test('honours an explicit size', () => {
+    expect(buildVendorLogoProxyUrl('acme.com', 64)).toBe('/api/vendor-logo?domain=acme.com&sz=64')
+  })
+
+  test('encodes the domain into the query string', () => {
+    expect(buildVendorLogoProxyUrl('acme corp.com')).toContain('domain=acme%20corp.com')
+  })
+
+  test('never points at the third-party favicon service directly', () => {
+    // The lookup must go through the authenticated proxy, not the browser.
+    expect(buildVendorLogoProxyUrl('acme.com')).not.toContain('google.com')
+  })
+})
+
+describe('getVendorLogoUrl', () => {
+  test('returns a data uri for a stored logo', () => {
+    const base64 = btoa('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+    expect(getVendorLogoUrl({ base64 })).toBe(`data:image/svg+xml;base64,${base64}`)
+  })
+
+  test('returns undefined when there is no logo file', () => {
+    expect(getVendorLogoUrl(null)).toBeUndefined()
+    expect(getVendorLogoUrl(undefined)).toBeUndefined()
+    expect(getVendorLogoUrl({ base64: null })).toBeUndefined()
+    expect(getVendorLogoUrl({})).toBeUndefined()
+  })
+})
+
+describe('VENDOR_LOGO_SIZE', () => {
+  test('bounds the proxy size range', () => {
+    expect(VENDOR_LOGO_SIZE.min).toBeLessThan(VENDOR_LOGO_SIZE.default)
+    expect(VENDOR_LOGO_SIZE.default).toBeLessThan(VENDOR_LOGO_SIZE.max)
+  })
+})

--- a/apps/console/src/lib/vendor-logo.test.ts
+++ b/apps/console/src/lib/vendor-logo.test.ts
@@ -1,9 +1,8 @@
 import { buildVendorLogoProxyUrl, getVendorLogoUrl, toVendorLogoHost, VENDOR_LOGO_SIZE } from './vendor-logo'
 
 /**
- * ISS-2486 — decides whether a user-typed website value is safe to forward to the authenticated
- * logo proxy. Anything that is not a real registrable domain returns null, so junk never reaches
- * the outbound request.
+ * Decides whether a user-typed website value is safe to forward to the authenticated logo proxy. Anything
+ * that is not a real registrable domain returns null, so junk never reaches the outbound request.
  */
 describe('toVendorLogoHost', () => {
   test.each([

--- a/apps/console/src/lib/vendor-risk-rating.test.ts
+++ b/apps/console/src/lib/vendor-risk-rating.test.ts
@@ -1,0 +1,79 @@
+import { isVendorRiskRating, riskRatingFromScore, VendorRiskRating, VENDOR_RISK_RATING_OPTIONS } from './vendor-risk-rating'
+
+/**
+ * ISS-2749 — the vendor risk review slideout derives a rating band from a
+ * numeric risk score. The thresholds are inclusive upper bounds, so every band
+ * boundary is an off-by-one waiting to happen: 5 is LOW, 6 is MEDIUM.
+ *
+ * Absent input must return undefined (no rating shown) rather than falling into
+ * NONE, which would claim a vendor was assessed as no-risk when it was never
+ * scored at all.
+ */
+describe('riskRatingFromScore — band boundaries', () => {
+  test.each([
+    [0, VendorRiskRating.NONE],
+    [1, VendorRiskRating.VERY_LOW],
+    [3, VendorRiskRating.VERY_LOW],
+    [4, VendorRiskRating.LOW],
+    [5, VendorRiskRating.LOW],
+    [6, VendorRiskRating.MEDIUM],
+    [11, VendorRiskRating.MEDIUM],
+    [12, VendorRiskRating.HIGH],
+    [15, VendorRiskRating.HIGH],
+    [16, VendorRiskRating.CRITICAL],
+    [100, VendorRiskRating.CRITICAL],
+  ])('scores %i as %s', (score, expected) => {
+    expect(riskRatingFromScore(score)).toBe(expected)
+  })
+
+  test('treats a negative score as NONE rather than falling through', () => {
+    expect(riskRatingFromScore(-1)).toBe(VendorRiskRating.NONE)
+  })
+
+  test('accepts a numeric string', () => {
+    expect(riskRatingFromScore('12')).toBe(VendorRiskRating.HIGH)
+  })
+})
+
+describe('riskRatingFromScore — absent or invalid input', () => {
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['an empty string', ''],
+    ['a non-numeric string', 'high'],
+  ])('returns undefined for %s', (_label, value) => {
+    // Deliberately NOT NONE — an unscored vendor must not read as assessed.
+    expect(riskRatingFromScore(value)).toBeUndefined()
+  })
+
+  test('distinguishes an unscored vendor from one scored zero', () => {
+    expect(riskRatingFromScore(null)).toBeUndefined()
+    expect(riskRatingFromScore(0)).toBe(VendorRiskRating.NONE)
+  })
+})
+
+describe('isVendorRiskRating', () => {
+  test('accepts every defined rating', () => {
+    for (const rating of Object.values(VendorRiskRating)) {
+      expect(isVendorRiskRating(rating)).toBe(true)
+    }
+  })
+
+  test('rejects unknown values', () => {
+    expect(isVendorRiskRating('EXTREME')).toBe(false)
+    expect(isVendorRiskRating('')).toBe(false)
+    expect(isVendorRiskRating('high')).toBe(false)
+  })
+})
+
+describe('VENDOR_RISK_RATING_OPTIONS', () => {
+  test('offers one option per rating', () => {
+    expect(VENDOR_RISK_RATING_OPTIONS).toHaveLength(Object.keys(VendorRiskRating).length)
+  })
+
+  test('labels are humanised, not raw enum values', () => {
+    const veryLow = VENDOR_RISK_RATING_OPTIONS.find((option) => option.value === VendorRiskRating.VERY_LOW)
+
+    expect(veryLow?.label).not.toBe('VERY_LOW')
+  })
+})

--- a/apps/console/src/lib/vendor-risk-rating.test.ts
+++ b/apps/console/src/lib/vendor-risk-rating.test.ts
@@ -1,9 +1,9 @@
 import { isVendorRiskRating, riskRatingFromScore, VendorRiskRating, VENDOR_RISK_RATING_OPTIONS } from './vendor-risk-rating'
 
 /**
- * ISS-2749 — the thresholds are inclusive upper bounds, so every band boundary is an off-by-one
- * waiting to happen: 5 is LOW, 6 is MEDIUM. Absent input returns undefined rather than NONE,
- * which would claim an unscored vendor had been assessed as no-risk.
+ * The thresholds are inclusive upper bounds, so every band boundary is an off-by-one waiting to happen: 5 is
+ * LOW, 6 is MEDIUM. Absent input returns undefined rather than NONE, which would claim an unscored vendor had
+ * been assessed as no-risk.
  */
 describe('riskRatingFromScore — band boundaries', () => {
   test.each([

--- a/apps/console/src/lib/vendor-risk-rating.test.ts
+++ b/apps/console/src/lib/vendor-risk-rating.test.ts
@@ -1,13 +1,9 @@
 import { isVendorRiskRating, riskRatingFromScore, VendorRiskRating, VENDOR_RISK_RATING_OPTIONS } from './vendor-risk-rating'
 
 /**
- * ISS-2749 — the vendor risk review slideout derives a rating band from a
- * numeric risk score. The thresholds are inclusive upper bounds, so every band
- * boundary is an off-by-one waiting to happen: 5 is LOW, 6 is MEDIUM.
- *
- * Absent input must return undefined (no rating shown) rather than falling into
- * NONE, which would claim a vendor was assessed as no-risk when it was never
- * scored at all.
+ * ISS-2749 — the thresholds are inclusive upper bounds, so every band boundary is an off-by-one
+ * waiting to happen: 5 is LOW, 6 is MEDIUM. Absent input returns undefined rather than NONE,
+ * which would claim an unscored vendor had been assessed as no-risk.
  */
 describe('riskRatingFromScore — band boundaries', () => {
   test.each([

--- a/apps/console/src/providers/sheet-navigation-provider.test.ts
+++ b/apps/console/src/providers/sheet-navigation-provider.test.ts
@@ -1,0 +1,49 @@
+import { ObjectAssociationNodeEnum } from '@/components/shared/object-association/types/object-association-types'
+import { FULL_PAGE_KINDS, isSheetKind } from './sheet-navigation-provider'
+
+/**
+ * ISS-2593 — association links open their target's slideout IN PLACE instead of
+ * navigating away, but only for object kinds that actually have a sheet.
+ * isSheetKind is the switch; FULL_PAGE_KINDS names the kinds that must still
+ * navigate (controls and subcontrols have full detail pages, not sheets).
+ *
+ * Getting this wrong is silent in one direction: a kind wrongly listed as a
+ * sheet kind renders a link that opens nothing.
+ */
+describe('isSheetKind', () => {
+  test.each([
+    ObjectAssociationNodeEnum.POLICY,
+    ObjectAssociationNodeEnum.PROCEDURE,
+    ObjectAssociationNodeEnum.TASK,
+    ObjectAssociationNodeEnum.EVIDENCE,
+    ObjectAssociationNodeEnum.RISKS,
+    ObjectAssociationNodeEnum.ASSET,
+    ObjectAssociationNodeEnum.ENTITY,
+  ])('is true for %s, which has a slideout', (kind) => {
+    expect(isSheetKind(kind)).toBe(true)
+  })
+
+  test('is false for kinds that have a full detail page instead', () => {
+    expect(isSheetKind(ObjectAssociationNodeEnum.CONTROL)).toBe(false)
+    expect(isSheetKind(ObjectAssociationNodeEnum.SUBCONTROL)).toBe(false)
+  })
+
+  test('is false for an unknown kind', () => {
+    expect(isSheetKind('not-a-kind')).toBe(false)
+    expect(isSheetKind('')).toBe(false)
+  })
+})
+
+describe('FULL_PAGE_KINDS', () => {
+  test('holds controls and subcontrols', () => {
+    expect(FULL_PAGE_KINDS.has(ObjectAssociationNodeEnum.CONTROL)).toBe(true)
+    expect(FULL_PAGE_KINDS.has(ObjectAssociationNodeEnum.SUBCONTROL)).toBe(true)
+  })
+
+  test('never overlaps the sheet kinds', () => {
+    // A kind in both sets would both navigate and try to open a sheet.
+    for (const kind of FULL_PAGE_KINDS) {
+      expect(isSheetKind(kind)).toBe(false)
+    }
+  })
+})

--- a/apps/console/src/providers/sheet-navigation-provider.test.ts
+++ b/apps/console/src/providers/sheet-navigation-provider.test.ts
@@ -2,13 +2,8 @@ import { ObjectAssociationNodeEnum } from '@/components/shared/object-associatio
 import { FULL_PAGE_KINDS, isSheetKind } from './sheet-navigation-provider'
 
 /**
- * ISS-2593 — association links open their target's slideout IN PLACE instead of
- * navigating away, but only for object kinds that actually have a sheet.
- * isSheetKind is the switch; FULL_PAGE_KINDS names the kinds that must still
- * navigate (controls and subcontrols have full detail pages, not sheets).
- *
- * Getting this wrong is silent in one direction: a kind wrongly listed as a
- * sheet kind renders a link that opens nothing.
+ * ISS-2593 — association links open their target's slideout in place, but only for object kinds
+ * that actually have a sheet. FULL_PAGE_KINDS names the kinds that must still navigate.
  */
 describe('isSheetKind', () => {
   test.each([

--- a/apps/console/src/providers/sheet-navigation-provider.test.ts
+++ b/apps/console/src/providers/sheet-navigation-provider.test.ts
@@ -2,8 +2,8 @@ import { ObjectAssociationNodeEnum } from '@/components/shared/object-associatio
 import { FULL_PAGE_KINDS, isSheetKind } from './sheet-navigation-provider'
 
 /**
- * ISS-2593 — association links open their target's slideout in place, but only for object kinds
- * that actually have a sheet. FULL_PAGE_KINDS names the kinds that must still navigate.
+ * Association links open their target's slideout in place, but only for object kinds that actually have a
+ * sheet. FULL_PAGE_KINDS names the kinds that must still navigate.
  */
 describe('isSheetKind', () => {
   test.each([

--- a/apps/console/src/routes/get-nav-landing-href.test.ts
+++ b/apps/console/src/routes/get-nav-landing-href.test.ts
@@ -2,9 +2,8 @@ import { type NavItem } from '@/types'
 import { getNavLandingHref } from './get-nav-landing-href'
 
 /**
- * ISS-2591 — clicking a nav section lands on its first usable child. Prefer one that is neither
- * hidden nor plan-locked, then fall back to a locked-but-visible child so the user reaches the
- * upgrade prompt instead of a dead link.
+ * Clicking a nav section lands on its first usable child. Prefer one that is neither hidden nor plan-locked,
+ * then fall back to a locked-but-visible child so the user reaches the upgrade prompt instead of a dead link.
  */
 
 const item = (href: string, children?: NavItem[]): NavItem => ({ title: href, href, children }) as NavItem

--- a/apps/console/src/routes/get-nav-landing-href.test.ts
+++ b/apps/console/src/routes/get-nav-landing-href.test.ts
@@ -2,11 +2,9 @@ import { type NavItem } from '@/types'
 import { getNavLandingHref } from './get-nav-landing-href'
 
 /**
- * ISS-2591 — clicking a nav SECTION now lands on its first usable child rather
- * than a bare section URL. The precedence matters: prefer a child that is
- * neither hidden nor plan-locked, fall back to a locked-but-visible child so the
- * user reaches the upgrade prompt instead of a dead link, and only then fall
- * back to the section's own href.
+ * ISS-2591 — clicking a nav section lands on its first usable child. Prefer one that is neither
+ * hidden nor plan-locked, then fall back to a locked-but-visible child so the user reaches the
+ * upgrade prompt instead of a dead link.
  */
 
 const item = (href: string, children?: NavItem[]): NavItem => ({ title: href, href, children }) as NavItem

--- a/apps/console/src/routes/get-nav-landing-href.test.ts
+++ b/apps/console/src/routes/get-nav-landing-href.test.ts
@@ -1,0 +1,50 @@
+import { type NavItem } from '@/types'
+import { getNavLandingHref } from './get-nav-landing-href'
+
+/**
+ * ISS-2591 — clicking a nav SECTION now lands on its first usable child rather
+ * than a bare section URL. The precedence matters: prefer a child that is
+ * neither hidden nor plan-locked, fall back to a locked-but-visible child so the
+ * user reaches the upgrade prompt instead of a dead link, and only then fall
+ * back to the section's own href.
+ */
+
+const item = (href: string, children?: NavItem[]): NavItem => ({ title: href, href, children }) as NavItem
+const child = (href: string, hidden = false): NavItem => ({ title: href, href, hidden }) as NavItem
+
+describe('getNavLandingHref', () => {
+  test('returns the section href when it has no children', () => {
+    expect(getNavLandingHref(item('/registry'))).toBe('/registry')
+  })
+
+  test('returns the first visible child', () => {
+    expect(getNavLandingHref(item('/registry', [child('/registry/platforms'), child('/registry/assets')]))).toBe('/registry/platforms')
+  })
+
+  test('skips hidden children', () => {
+    expect(getNavLandingHref(item('/registry', [child('/registry/platforms', true), child('/registry/assets')]))).toBe('/registry/assets')
+  })
+
+  test('prefers an unlocked child over a locked one', () => {
+    const isLocked = (candidate: NavItem) => candidate.href === '/registry/platforms'
+
+    expect(getNavLandingHref(item('/registry', [child('/registry/platforms'), child('/registry/assets')]), isLocked)).toBe('/registry/assets')
+  })
+
+  test('falls back to a locked but visible child rather than the bare section', () => {
+    // Better to land on the upgrade prompt than a section URL with no page.
+    const isLocked = () => true
+
+    expect(getNavLandingHref(item('/registry', [child('/registry/platforms')]), isLocked)).toBe('/registry/platforms')
+  })
+
+  test('falls back to the section href when every child is hidden', () => {
+    const isLocked = () => true
+
+    expect(getNavLandingHref(item('/registry', [child('/registry/platforms', true)]), isLocked)).toBe('/registry')
+  })
+
+  test('treats an empty children list as no children', () => {
+    expect(getNavLandingHref(item('/registry', []))).toBe('/registry')
+  })
+})

--- a/apps/console/src/utils/brandingString.test.ts
+++ b/apps/console/src/utils/brandingString.test.ts
@@ -1,0 +1,74 @@
+import { parseBrandingString } from './brandingString'
+
+/**
+ * #2092 — trust center branding can be imported from a pasted "branding string".
+ * parseBrandingString is a parser for untrusted user input, so its refusals
+ * matter more than its happy path: a wrong version prefix, a missing colour, or
+ * an oversized payload must all yield null rather than a half-applied palette.
+ *
+ * Colours are normalised through normalizeHexColor (tested separately), so
+ * shorthand and casing are accepted here too.
+ */
+
+const VALID = 'olbrand1:bg=#ffffff;fg=#000000;accent=#ff0000;secBg=#eeeeee;secFg=#333333'
+
+describe('parseBrandingString', () => {
+  test('parses a complete string into all five colours', () => {
+    expect(parseBrandingString(VALID)).toEqual({
+      backgroundColor: '#ffffff',
+      foregroundColor: '#000000',
+      accentColor: '#ff0000',
+      secondaryBackgroundColor: '#eeeeee',
+      secondaryForegroundColor: '#333333',
+    })
+  })
+
+  test('normalises shorthand and uppercase colours', () => {
+    const parsed = parseBrandingString('olbrand1:bg=#FFF;fg=000;accent=#Ff0000;secBg=#eee;secFg=#333')
+
+    expect(parsed?.backgroundColor).toBe('#ffffff')
+    expect(parsed?.foregroundColor).toBe('#000000')
+    expect(parsed?.accentColor).toBe('#ff0000')
+  })
+
+  test('tolerates surrounding whitespace and spaced keys', () => {
+    expect(parseBrandingString(`  ${VALID}  `)).not.toBeNull()
+  })
+
+  test('ignores pair order', () => {
+    const reordered = 'olbrand1:secFg=#333333;accent=#ff0000;fg=#000000;secBg=#eeeeee;bg=#ffffff'
+
+    expect(parseBrandingString(reordered)).toEqual(parseBrandingString(VALID))
+  })
+
+  test.each([
+    ['an empty string', ''],
+    ['no version separator', 'bg=#ffffff;fg=#000000'],
+    ['an unknown version', 'olbrand2:bg=#ffffff;fg=#000000;accent=#ff0000;secBg=#eeeeee;secFg=#333333'],
+  ])('returns null for %s', (_label, input) => {
+    expect(parseBrandingString(input)).toBeNull()
+  })
+
+  test.each(['bg', 'fg', 'accent', 'secBg', 'secFg'])('returns null when the %s colour is missing', (key) => {
+    const withoutKey = VALID.split(';')
+      .filter((pair) => !pair.startsWith(`${key}=`) && !pair.startsWith(`olbrand1:${key}=`))
+      .join(';')
+
+    expect(parseBrandingString(withoutKey)).toBeNull()
+  })
+
+  test('returns null when any colour is not a valid hex', () => {
+    expect(parseBrandingString(VALID.replace('#ff0000', 'rebeccapurple'))).toBeNull()
+  })
+
+  test('rejects an oversized payload without parsing it', () => {
+    // Guards against a pasted blob being walked pair by pair.
+    const huge = `${VALID};${'x'.repeat(600)}`
+
+    expect(parseBrandingString(huge)).toBeNull()
+  })
+
+  test('ignores unknown extra keys as long as the five required ones are present', () => {
+    expect(parseBrandingString(`${VALID};somethingElse=#123456`)).toEqual(parseBrandingString(VALID))
+  })
+})

--- a/apps/console/src/utils/brandingString.test.ts
+++ b/apps/console/src/utils/brandingString.test.ts
@@ -1,9 +1,8 @@
 import { parseBrandingString } from './brandingString'
 
 /**
- * #2092 — a parser for untrusted pasted input, so its refusals matter more than its happy path.
- * A wrong version prefix, a missing colour or an oversized payload must all yield null rather
- * than a half-applied palette.
+ * A parser for untrusted pasted input, so its refusals matter more than its happy path. A wrong version
+ * prefix, a missing colour or an oversized payload must all yield null rather than a half-applied palette.
  */
 
 const VALID = 'olbrand1:bg=#ffffff;fg=#000000;accent=#ff0000;secBg=#eeeeee;secFg=#333333'

--- a/apps/console/src/utils/brandingString.test.ts
+++ b/apps/console/src/utils/brandingString.test.ts
@@ -1,13 +1,9 @@
 import { parseBrandingString } from './brandingString'
 
 /**
- * #2092 — trust center branding can be imported from a pasted "branding string".
- * parseBrandingString is a parser for untrusted user input, so its refusals
- * matter more than its happy path: a wrong version prefix, a missing colour, or
- * an oversized payload must all yield null rather than a half-applied palette.
- *
- * Colours are normalised through normalizeHexColor (tested separately), so
- * shorthand and casing are accepted here too.
+ * #2092 — a parser for untrusted pasted input, so its refusals matter more than its happy path.
+ * A wrong version prefix, a missing colour or an oversized payload must all yield null rather
+ * than a half-applied palette.
  */
 
 const VALID = 'olbrand1:bg=#ffffff;fg=#000000;accent=#ff0000;secBg=#eeeeee;secFg=#333333'

--- a/apps/console/src/utils/date.test.ts
+++ b/apps/console/src/utils/date.test.ts
@@ -148,8 +148,8 @@ describe('formatDate', () => {
   })
 })
 
-// ISS-2409 — the program landing page marks overdue audit periods with isPastDate. Empty input
-// must read as "not past" rather than falling through to an Invalid Date comparison.
+// The program landing page marks overdue audit periods with isPastDate. Empty input must read as "not past"
+// rather than falling through to an Invalid Date comparison.
 describe('isPastDate', () => {
   it('returns false for undefined, null and empty input', () => {
     expect(isPastDate(undefined)).toBe(false)
@@ -172,9 +172,8 @@ describe('isPastDate', () => {
 })
 
 /**
- * ISS-2657 — campaign launch scheduling gained a timezone selector, so scheduled times must be
- * shown with their zone. A bare "March 3, 2026 9:00 AM" is ambiguous once a campaign can be
- * scheduled from another zone.
+ * Campaign launch scheduling gained a timezone selector, so scheduled times must be shown with their zone. A
+ * bare "March 3, 2026 9:00 AM" is ambiguous once a campaign can be scheduled from another zone.
  */
 describe('formatDateTimeWithZone', () => {
   it('falls back for empty input', () => {

--- a/apps/console/src/utils/date.test.ts
+++ b/apps/console/src/utils/date.test.ts
@@ -148,9 +148,8 @@ describe('formatDate', () => {
   })
 })
 
-// ISS-2409 — the program landing page marks overdue audit periods with
-// isPastDate. Empty input must read as "not past" rather than falling through to
-// an Invalid Date comparison (which would be false anyway, but only by accident).
+// ISS-2409 — the program landing page marks overdue audit periods with isPastDate. Empty input
+// must read as "not past" rather than falling through to an Invalid Date comparison.
 describe('isPastDate', () => {
   it('returns false for undefined, null and empty input', () => {
     expect(isPastDate(undefined)).toBe(false)
@@ -173,9 +172,9 @@ describe('isPastDate', () => {
 })
 
 /**
- * ISS-2657 — campaign launch scheduling gained a timezone selector, so scheduled
- * times must be shown WITH their zone. A bare "March 3, 2026 9:00 AM" is
- * ambiguous once a campaign can be scheduled from another zone.
+ * ISS-2657 — campaign launch scheduling gained a timezone selector, so scheduled times must be
+ * shown with their zone. A bare "March 3, 2026 9:00 AM" is ambiguous once a campaign can be
+ * scheduled from another zone.
  */
 describe('formatDateTimeWithZone', () => {
   it('falls back for empty input', () => {

--- a/apps/console/src/utils/date.test.ts
+++ b/apps/console/src/utils/date.test.ts
@@ -1,4 +1,4 @@
-import { formatTimeSince, formatDateSince, formatDateTime, formatDate } from './date'
+import { formatTimeSince, formatDateSince, formatDateTime, formatDate, isPastDate, formatDateTimeWithZone, formatTimeZoneLabel, getBrowserTimeZone } from './date'
 
 describe('formatTimeSince', () => {
   beforeEach(() => {
@@ -145,5 +145,81 @@ describe('formatDate', () => {
   it('should handle undefined date input', () => {
     const result = formatDate(undefined)
     expect(result).toBe('-')
+  })
+})
+
+// ISS-2409 — the program landing page marks overdue audit periods with
+// isPastDate. Empty input must read as "not past" rather than falling through to
+// an Invalid Date comparison (which would be false anyway, but only by accident).
+describe('isPastDate', () => {
+  it('returns false for undefined, null and empty input', () => {
+    expect(isPastDate(undefined)).toBe(false)
+    expect(isPastDate(null)).toBe(false)
+    expect(isPastDate('')).toBe(false)
+  })
+
+  it('returns true for a date in the past', () => {
+    expect(isPastDate('2000-01-01T00:00:00.000Z')).toBe(true)
+  })
+
+  it('returns false for a date in the future', () => {
+    const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+    expect(isPastDate(future)).toBe(false)
+  })
+
+  it('handles a date-only string', () => {
+    expect(isPastDate('1999-12-31')).toBe(true)
+  })
+})
+
+/**
+ * ISS-2657 — campaign launch scheduling gained a timezone selector, so scheduled
+ * times must be shown WITH their zone. A bare "March 3, 2026 9:00 AM" is
+ * ambiguous once a campaign can be scheduled from another zone.
+ */
+describe('formatDateTimeWithZone', () => {
+  it('falls back for empty input', () => {
+    expect(formatDateTimeWithZone(undefined)).toBe('-')
+    expect(formatDateTimeWithZone(null)).toBe('-')
+    expect(formatDateTimeWithZone('')).toBe('-')
+  })
+
+  it('honours a custom fallback', () => {
+    expect(formatDateTimeWithZone('', 'Not scheduled')).toBe('Not scheduled')
+  })
+
+  it('renders a date, a time and a parenthesised zone abbreviation', () => {
+    const formatted = formatDateTimeWithZone('2026-03-03T09:00:00.000Z')
+
+    expect(formatted).toMatch(/^[A-Z][a-z]+ \d{1,2}, \d{4} \d{1,2}:\d{2} (AM|PM)/)
+    expect(formatted).toMatch(/\([^)]+\)$/)
+  })
+
+  it('always includes a zone, unlike the plain formatter', () => {
+    const iso = '2026-03-03T09:00:00.000Z'
+
+    expect(formatDateTimeWithZone(iso)).not.toBe(formatDateTime(iso))
+  })
+})
+
+describe('formatTimeZoneLabel', () => {
+  const when = new Date('2026-03-03T09:00:00.000Z')
+
+  it('prefixes a GMT offset and humanises underscores', () => {
+    expect(formatTimeZoneLabel('America/New_York', when)).toMatch(/^\(GMT[+-]\d{2}:\d{2}\) America\/New York$/)
+  })
+
+  it('renders UTC with a zero offset', () => {
+    expect(formatTimeZoneLabel('UTC', when)).toBe('(GMT+00:00) UTC')
+  })
+
+  it('falls back to the bare zone name when the offset cannot be resolved', () => {
+    expect(formatTimeZoneLabel('Not/AZone', when)).toBe('Not/AZone')
+  })
+})
+
+describe('getBrowserTimeZone', () => {
+  it('returns a non-empty IANA zone name', () => {
+    expect(getBrowserTimeZone()).toMatch(/\S/)
   })
 })

--- a/apps/console/src/utils/graphQlErrorMatcher.test.ts
+++ b/apps/console/src/utils/graphQlErrorMatcher.test.ts
@@ -1,0 +1,88 @@
+import { ClientError } from 'graphql-request'
+import { GraphQlResponseError } from '@/constants/graphQlResponseError'
+import { isNonRetryableGraphQlError } from './graphQlErrorMatcher'
+
+/**
+ * ISS-2733 — react-query was retrying 400s and GRAPHQL_VALIDATION_FAILED, so a
+ * malformed query hammered the backend several times before surfacing an error
+ * the user could do nothing about. isNonRetryableGraphQlError is the guard.
+ *
+ * Two rules do the work, and both fail in the dangerous direction if broken —
+ * returning false means "retry", so a mistake here re-introduces the hammering:
+ *
+ *  - HTTP 4xx is permanent EXCEPT 408 / 425 / 429, which are genuinely transient
+ *  - a GraphQL error payload is permanent only when EVERY error in it is a known
+ *    permanent code; a mixed payload may still contain something worth retrying
+ */
+
+const clientError = (status: number, errors?: unknown[]): ClientError => new ClientError({ status, errors, data: undefined, headers: new Headers() } as never, { query: 'query {}' } as never)
+
+const gqlErrors = (...codes: (string | undefined)[]) => codes.map((code) => ({ message: 'boom', extensions: code ? { code } : {}, path: [] }))
+
+describe('HTTP status handling', () => {
+  test.each([400, 401, 403, 404, 409, 422])('treats %s as non-retryable', (status) => {
+    expect(isNonRetryableGraphQlError(clientError(status))).toBe(true)
+  })
+
+  test.each([408, 425, 429])('still retries %s, which is transient', (status) => {
+    expect(isNonRetryableGraphQlError(clientError(status))).toBe(false)
+  })
+
+  test.each([500, 502, 503])('still retries server error %s', (status) => {
+    expect(isNonRetryableGraphQlError(clientError(status))).toBe(false)
+  })
+})
+
+describe('GraphQL error codes', () => {
+  test('is non-retryable when every error carries a permanent code', () => {
+    const error = clientError(200, gqlErrors(GraphQlResponseError.GraphQlValidationFailedCode))
+
+    expect(isNonRetryableGraphQlError(error)).toBe(true)
+  })
+
+  test.each([
+    GraphQlResponseError.NotFoundErrorCode,
+    GraphQlResponseError.ValidationErrorCode,
+    GraphQlResponseError.ConflictErrorCode,
+    GraphQlResponseError.UnauthorizedErrorCode,
+    GraphQlResponseError.AlreadyExistsErrorCode,
+    GraphQlResponseError.BadRequestErrorCode,
+    GraphQlResponseError.NoAccessToModuleErrorCode,
+    GraphQlResponseError.GraphQlParseFailedCode,
+  ])('treats %s as permanent', (code) => {
+    expect(isNonRetryableGraphQlError(clientError(200, gqlErrors(code)))).toBe(true)
+  })
+
+  test('retries when ANY error in the payload is not a known permanent code', () => {
+    // A mixed payload may still contain something transient.
+    const error = clientError(200, gqlErrors(GraphQlResponseError.NotFoundErrorCode, 'INTERNAL_SERVER_ERROR'))
+
+    expect(isNonRetryableGraphQlError(error)).toBe(false)
+  })
+
+  test('retries when an error carries no code at all', () => {
+    expect(isNonRetryableGraphQlError(clientError(200, gqlErrors(undefined)))).toBe(false)
+  })
+
+  test('retries an empty error payload', () => {
+    expect(isNonRetryableGraphQlError(clientError(200, []))).toBe(false)
+  })
+
+  test('reads a bare array of GraphQL errors, not just a ClientError', () => {
+    expect(isNonRetryableGraphQlError(gqlErrors(GraphQlResponseError.ValidationErrorCode))).toBe(true)
+  })
+})
+
+describe('unrecognised inputs stay retryable', () => {
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a plain Error', new Error('network down')],
+    ['a string', 'boom'],
+    ['an empty object', {}],
+  ])('retries %s', (_label, error) => {
+    // Defaulting to "retry" is the safe direction for an error shape we do not
+    // recognise — a transient network failure must not be treated as permanent.
+    expect(isNonRetryableGraphQlError(error)).toBe(false)
+  })
+})

--- a/apps/console/src/utils/graphQlErrorMatcher.test.ts
+++ b/apps/console/src/utils/graphQlErrorMatcher.test.ts
@@ -3,16 +3,9 @@ import { GraphQlResponseError } from '@/constants/graphQlResponseError'
 import { isNonRetryableGraphQlError } from './graphQlErrorMatcher'
 
 /**
- * ISS-2733 — react-query was retrying 400s and GRAPHQL_VALIDATION_FAILED, so a
- * malformed query hammered the backend several times before surfacing an error
- * the user could do nothing about. isNonRetryableGraphQlError is the guard.
- *
- * Two rules do the work, and both fail in the dangerous direction if broken —
- * returning false means "retry", so a mistake here re-introduces the hammering:
- *
- *  - HTTP 4xx is permanent EXCEPT 408 / 425 / 429, which are genuinely transient
- *  - a GraphQL error payload is permanent only when EVERY error in it is a known
- *    permanent code; a mixed payload may still contain something worth retrying
+ * ISS-2733 — react-query was retrying 400s and GRAPHQL_VALIDATION_FAILED, hammering the backend
+ * before surfacing an error the user could do nothing about. Returning false means "retry", so
+ * both rules fail in the dangerous direction.
  */
 
 const clientError = (status: number, errors?: unknown[]): ClientError => new ClientError({ status, errors, data: undefined, headers: new Headers() } as never, { query: 'query {}' } as never)

--- a/apps/console/src/utils/graphQlErrorMatcher.test.ts
+++ b/apps/console/src/utils/graphQlErrorMatcher.test.ts
@@ -3,9 +3,9 @@ import { GraphQlResponseError } from '@/constants/graphQlResponseError'
 import { isNonRetryableGraphQlError } from './graphQlErrorMatcher'
 
 /**
- * ISS-2733 — react-query was retrying 400s and GRAPHQL_VALIDATION_FAILED, hammering the backend
- * before surfacing an error the user could do nothing about. Returning false means "retry", so
- * both rules fail in the dangerous direction.
+ * react-query was retrying 400s and GRAPHQL_VALIDATION_FAILED, hammering the backend before surfacing an
+ * error the user could do nothing about. Returning false means "retry", so both rules fail in the dangerous
+ * direction.
  */
 
 const clientError = (status: number, errors?: unknown[]): ClientError => new ClientError({ status, errors, data: undefined, headers: new Headers() } as never, { query: 'query {}' } as never)
@@ -74,8 +74,8 @@ describe('unrecognised inputs stay retryable', () => {
     ['a string', 'boom'],
     ['an empty object', {}],
   ])('retries %s', (_label, error) => {
-    // Defaulting to "retry" is the safe direction for an error shape we do not
-    // recognise — a transient network failure must not be treated as permanent.
+    // Defaulting to "retry" is the safe direction for an error shape we do not recognise — a transient
+    // network failure must not be treated as permanent.
     expect(isNonRetryableGraphQlError(error)).toBe(false)
   })
 })

--- a/apps/console/src/utils/normalizeHexColor.test.ts
+++ b/apps/console/src/utils/normalizeHexColor.test.ts
@@ -1,9 +1,8 @@
 import { normalizeHexColor } from './normalizeHexColor'
 
 /**
- * ISS-2542 — accepts what a user might reasonably paste (with or without a leading #, 3- or
- * 6-digit, any case) and returns a canonical lowercase 6-digit form, or null so the caller can
- * reject the input.
+ * Accepts what a user might reasonably paste (with or without a leading #, 3- or 6-digit, any case) and
+ * returns a canonical lowercase 6-digit form, or null so the caller can reject the input.
  */
 describe('normalizeHexColor', () => {
   test('canonicalises a 6-digit value to lowercase with a single #', () => {

--- a/apps/console/src/utils/normalizeHexColor.test.ts
+++ b/apps/console/src/utils/normalizeHexColor.test.ts
@@ -1,10 +1,9 @@
 import { normalizeHexColor } from './normalizeHexColor'
 
 /**
- * ISS-2542 — trust center branding requires a real hex colour. normalizeHexColor
- * is the gate: it accepts what a user might reasonably paste (with or without a
- * leading #, 3- or 6-digit, any case, padded) and returns a single canonical
- * lowercase 6-digit form, or null so the caller can reject the input.
+ * ISS-2542 — accepts what a user might reasonably paste (with or without a leading #, 3- or
+ * 6-digit, any case) and returns a canonical lowercase 6-digit form, or null so the caller can
+ * reject the input.
  */
 describe('normalizeHexColor', () => {
   test('canonicalises a 6-digit value to lowercase with a single #', () => {

--- a/apps/console/src/utils/normalizeHexColor.test.ts
+++ b/apps/console/src/utils/normalizeHexColor.test.ts
@@ -1,0 +1,49 @@
+import { normalizeHexColor } from './normalizeHexColor'
+
+/**
+ * ISS-2542 — trust center branding requires a real hex colour. normalizeHexColor
+ * is the gate: it accepts what a user might reasonably paste (with or without a
+ * leading #, 3- or 6-digit, any case, padded) and returns a single canonical
+ * lowercase 6-digit form, or null so the caller can reject the input.
+ */
+describe('normalizeHexColor', () => {
+  test('canonicalises a 6-digit value to lowercase with a single #', () => {
+    expect(normalizeHexColor('#AABBCC')).toBe('#aabbcc')
+    expect(normalizeHexColor('aabbcc')).toBe('#aabbcc')
+  })
+
+  test('expands a 3-digit shorthand', () => {
+    expect(normalizeHexColor('#abc')).toBe('#aabbcc')
+    expect(normalizeHexColor('ABC')).toBe('#aabbcc')
+  })
+
+  test('tolerates surrounding whitespace', () => {
+    expect(normalizeHexColor('  #abc  ')).toBe('#aabbcc')
+  })
+
+  test('collapses repeated leading hashes', () => {
+    // Pasting from some pickers yields "##aabbcc".
+    expect(normalizeHexColor('##aabbcc')).toBe('#aabbcc')
+  })
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['an empty string', ''],
+    ['whitespace only', '   '],
+    ['a 4-digit value', '#abcd'],
+    ['a 5-digit value', '#abcde'],
+    ['an 8-digit value with alpha', '#aabbccdd'],
+    ['a non-hex letter', '#gggggg'],
+    ['a named colour', 'rebeccapurple'],
+    ['an rgb function', 'rgb(0,0,0)'],
+    ['an inner hash', '#aab#cc'],
+  ])('returns null for %s', (_label, input) => {
+    expect(normalizeHexColor(input)).toBeNull()
+  })
+
+  test('is idempotent', () => {
+    const once = normalizeHexColor('#ABC')
+    expect(normalizeHexColor(once)).toBe(once)
+  })
+})

--- a/apps/console/src/utils/pagination.test.ts
+++ b/apps/console/src/utils/pagination.test.ts
@@ -2,8 +2,8 @@ import { type TPagination } from '@repo/ui/pagination-types'
 import { sliceByPagination } from './pagination'
 
 /**
- * #2078 — client-side pagination for lists the API returns whole. Pages are 1-based, and the
- * Math.max guard stops a stale stored page of 0 or negative from reading backwards off the array.
+ * Client-side pagination for lists the API returns whole. Pages are 1-based, and the Math.max guard stops a
+ * stale stored page of 0 or negative from reading backwards off the array.
  */
 
 const page = (page: number, pageSize: number): TPagination => ({ page, pageSize, query: { first: pageSize } }) as TPagination
@@ -32,8 +32,8 @@ describe('sliceByPagination', () => {
   })
 
   test('clamps page 0 and negative pages to the first slice', () => {
-    // A stale stored pagination can hand back page 0; reading backwards off the
-    // array would silently return the tail.
+    // A stale stored pagination can hand back page 0; reading backwards off the array would silently return
+    // the tail.
     expect(sliceByPagination(items, page(0, 2))).toEqual(['a', 'b'])
     expect(sliceByPagination(items, page(-3, 2))).toEqual(['a', 'b'])
   })

--- a/apps/console/src/utils/pagination.test.ts
+++ b/apps/console/src/utils/pagination.test.ts
@@ -1,0 +1,54 @@
+import { type TPagination } from '@repo/ui/pagination-types'
+import { sliceByPagination } from './pagination'
+
+/**
+ * #2078 — client-side pagination for lists the API returns whole. The page
+ * number is 1-BASED, which is the easy thing to get wrong: page 1 must start at
+ * index 0, not pageSize. The Math.max guard means a page of 0 or a negative page
+ * (which a stale stored pagination can produce) clamps to the first slice rather
+ * than reading backwards off the array.
+ */
+
+const page = (page: number, pageSize: number): TPagination => ({ page, pageSize, query: { first: pageSize } }) as TPagination
+
+const items = ['a', 'b', 'c', 'd', 'e']
+
+describe('sliceByPagination', () => {
+  test('page 1 starts at the beginning', () => {
+    expect(sliceByPagination(items, page(1, 2))).toEqual(['a', 'b'])
+  })
+
+  test('page 2 continues from where page 1 ended', () => {
+    expect(sliceByPagination(items, page(2, 2))).toEqual(['c', 'd'])
+  })
+
+  test('the last page returns the remainder, not a full page', () => {
+    expect(sliceByPagination(items, page(3, 2))).toEqual(['e'])
+  })
+
+  test('a page past the end returns nothing', () => {
+    expect(sliceByPagination(items, page(9, 2))).toEqual([])
+  })
+
+  test('a page size larger than the list returns everything', () => {
+    expect(sliceByPagination(items, page(1, 50))).toEqual(items)
+  })
+
+  test('clamps page 0 and negative pages to the first slice', () => {
+    // A stale stored pagination can hand back page 0; reading backwards off the
+    // array would silently return the tail.
+    expect(sliceByPagination(items, page(0, 2))).toEqual(['a', 'b'])
+    expect(sliceByPagination(items, page(-3, 2))).toEqual(['a', 'b'])
+  })
+
+  test('returns nothing for an empty list', () => {
+    expect(sliceByPagination([], page(1, 10))).toEqual([])
+  })
+
+  test('does not mutate the input', () => {
+    const original = [...items]
+    sliceByPagination(items, page(2, 2))
+
+    expect(items).toEqual(original)
+  })
+})

--- a/apps/console/src/utils/pagination.test.ts
+++ b/apps/console/src/utils/pagination.test.ts
@@ -2,11 +2,8 @@ import { type TPagination } from '@repo/ui/pagination-types'
 import { sliceByPagination } from './pagination'
 
 /**
- * #2078 — client-side pagination for lists the API returns whole. The page
- * number is 1-BASED, which is the easy thing to get wrong: page 1 must start at
- * index 0, not pageSize. The Math.max guard means a page of 0 or a negative page
- * (which a stale stored pagination can produce) clamps to the first slice rather
- * than reading backwards off the array.
+ * #2078 — client-side pagination for lists the API returns whole. Pages are 1-based, and the
+ * Math.max guard stops a stale stored page of 0 or negative from reading backwards off the array.
  */
 
 const page = (page: number, pageSize: number): TPagination => ({ page, pageSize, query: { first: pageSize } }) as TPagination

--- a/apps/console/src/utils/strings.test.ts
+++ b/apps/console/src/utils/strings.test.ts
@@ -1,4 +1,4 @@
-import { wordTokens, objectToSnakeCase, orgAbbreviation, pluralizeTypeName } from './strings'
+import { wordTokens, objectToSnakeCase, orgAbbreviation, pluralizeTypeName, isValidDomain, getEmailDomain, toHumanLabel, pluralize, pluralizeWithCount } from './strings'
 
 describe('objectToSnakeCase', () => {
   it('should convert camelCase to snake_case', () => {
@@ -88,5 +88,147 @@ describe('wordTokens', () => {
 
   it('returns nothing for a string with no word characters', () => {
     expect(wordTokens('— / —')).toEqual([])
+  })
+})
+
+/**
+ * #1957 — isValidDomain gates both the SSO exempt-domain list and the allowed-
+ * domains editor. It must reject anything that is not a bare registrable domain:
+ * no scheme, no path, no port, no bare hostname, and a TLD of at least two
+ * letters.
+ */
+describe('isValidDomain', () => {
+  it.each(['acme.com', 'sub.acme.com', 'deep.sub.acme.co.uk', 'a-b.example.io', 'x1.example.dev'])('accepts %s', (domain) => {
+    expect(isValidDomain(domain)).toBe(true)
+  })
+
+  it.each([
+    ['an empty string', ''],
+    ['a bare hostname with no dot', 'localhost'],
+    ['a scheme', 'https://acme.com'],
+    ['a path', 'acme.com/login'],
+    ['a port', 'acme.com:8080'],
+    ['a leading dot', '.acme.com'],
+    ['a trailing dot', 'acme.com.'],
+    ['a leading hyphen in a label', '-acme.com'],
+    ['a trailing hyphen in a label', 'acme-.com'],
+    ['a single-letter TLD', 'acme.c'],
+    ['a numeric TLD', 'acme.12'],
+    ['an email address', 'user@acme.com'],
+    ['whitespace', 'acme .com'],
+    ['an underscore', 'ac_me.com'],
+  ])('rejects %s', (_label, domain) => {
+    expect(isValidDomain(domain)).toBe(false)
+  })
+})
+
+/**
+ * ISS-2459 — contact↔vendor linking suggests vendors whose domain matches the
+ * contact's email domain, so getEmailDomain has to be strict: exactly one @,
+ * a non-empty host, normalised for case and whitespace. A wrong answer here
+ * surfaces as bogus vendor suggestions rather than an error.
+ */
+describe('getEmailDomain', () => {
+  it('extracts and normalises the domain', () => {
+    expect(getEmailDomain('User@Acme.COM')).toBe('acme.com')
+    expect(getEmailDomain('  user@acme.com  ')).toBe('acme.com')
+  })
+
+  it('handles a subdomain host', () => {
+    expect(getEmailDomain('user@mail.acme.co.uk')).toBe('mail.acme.co.uk')
+  })
+
+  it('returns null for empty input', () => {
+    expect(getEmailDomain(undefined)).toBeNull()
+    expect(getEmailDomain(null)).toBeNull()
+    expect(getEmailDomain('')).toBeNull()
+  })
+
+  it('returns null when there is no single @ separator', () => {
+    expect(getEmailDomain('user')).toBeNull()
+    expect(getEmailDomain('user@acme@com')).toBeNull()
+  })
+
+  it('returns null when the host side is empty', () => {
+    expect(getEmailDomain('user@')).toBeNull()
+  })
+
+  it('returns the host even when the local part is empty', () => {
+    // Not a valid address, but the split still yields a usable domain; the
+    // caller validates the address separately.
+    expect(getEmailDomain('@acme.com')).toBe('acme.com')
+  })
+})
+
+/**
+ * toHumanLabel turns identifiers into display text, keeping a known acronym set
+ * fully uppercase. The scan UI (#2040) added DNS to that set — without it a
+ * "dns_scan" event renders as "Dns Scan".
+ *
+ * Note this is for camelCase / snake_case identifiers, NOT ALL_CAPS enums —
+ * those go through getEnumLabel instead.
+ */
+describe('toHumanLabel', () => {
+  it('returns an empty string for empty input', () => {
+    expect(toHumanLabel('')).toBe('')
+  })
+
+  it('splits snake_case and kebab-case', () => {
+    expect(toHumanLabel('domain_scan')).toBe('Domain Scan')
+    expect(toHumanLabel('domain-scan')).toBe('Domain Scan')
+  })
+
+  it('splits camelCase and PascalCase', () => {
+    expect(toHumanLabel('domainDelete')).toBe('Domain Delete')
+    expect(toHumanLabel('DomainDelete')).toBe('Domain Delete')
+  })
+
+  it('separates a leading acronym from the following word', () => {
+    expect(toHumanLabel('APIToken')).toBe('API Token')
+  })
+
+  it.each(['api', 'sso', 'oauth', 'url', 'sdk', 'nda', 'mfa', 'totp', 'dns'])('uppercases the %s acronym', (acronym) => {
+    expect(toHumanLabel(`${acronym}_scan`)).toBe(`${acronym.toUpperCase()} Scan`)
+  })
+
+  it('uppercases DNS specifically, which the scan UI added', () => {
+    expect(toHumanLabel('dns_record')).toBe('DNS Record')
+  })
+
+  it('title-cases non-acronym words and collapses extra whitespace', () => {
+    expect(toHumanLabel('  vendor   RISK  review ')).toBe('Vendor Risk Review')
+  })
+})
+
+/**
+ * #2078 — pluralize/pluralizeWithCount back the assessment UI's count labels.
+ * Only a count of exactly 1 is singular; 0 and negatives take the plural, which
+ * is what an "0 responses" label depends on.
+ */
+describe('pluralize', () => {
+  it('is singular only for exactly one', () => {
+    expect(pluralize(1, 'response')).toBe('response')
+  })
+
+  it('is plural for zero and for many', () => {
+    expect(pluralize(0, 'response')).toBe('responses')
+    expect(pluralize(2, 'response')).toBe('responses')
+  })
+
+  it('honours an explicit plural form', () => {
+    expect(pluralize(2, 'person', 'people')).toBe('people')
+    expect(pluralize(1, 'person', 'people')).toBe('person')
+  })
+})
+
+describe('pluralizeWithCount', () => {
+  it('prefixes the count', () => {
+    expect(pluralizeWithCount(0, 'response')).toBe('0 responses')
+    expect(pluralizeWithCount(1, 'response')).toBe('1 response')
+    expect(pluralizeWithCount(3, 'response')).toBe('3 responses')
+  })
+
+  it('honours an explicit plural form', () => {
+    expect(pluralizeWithCount(2, 'person', 'people')).toBe('2 people')
   })
 })

--- a/apps/console/src/utils/strings.test.ts
+++ b/apps/console/src/utils/strings.test.ts
@@ -92,9 +92,9 @@ describe('wordTokens', () => {
 })
 
 /**
- * #1957 — isValidDomain gates both the SSO exempt-domain list and the allowed-domains editor. It
- * must reject anything that is not a bare registrable domain: no scheme, no path, no port, no
- * bare hostname, and a TLD of at least two letters.
+ * isValidDomain gates both the SSO exempt-domain list and the allowed-domains editor. It must reject anything
+ * that is not a bare registrable domain: no scheme, no path, no port, no bare hostname, and a TLD of at least
+ * two letters.
  */
 describe('isValidDomain', () => {
   it.each(['acme.com', 'sub.acme.com', 'deep.sub.acme.co.uk', 'a-b.example.io', 'x1.example.dev'])('accepts %s', (domain) => {
@@ -122,9 +122,8 @@ describe('isValidDomain', () => {
 })
 
 /**
- * ISS-2459 — contact/vendor linking suggests vendors whose domain matches the contact's email
- * domain, so getEmailDomain has to be strict. A wrong answer surfaces as bogus vendor suggestions
- * rather than an error.
+ * Contact/vendor linking suggests vendors whose domain matches the contact's email domain, so getEmailDomain
+ * has to be strict. A wrong answer surfaces as bogus vendor suggestions rather than an error.
  */
 describe('getEmailDomain', () => {
   it('extracts and normalises the domain', () => {
@@ -152,16 +151,16 @@ describe('getEmailDomain', () => {
   })
 
   it('returns the host even when the local part is empty', () => {
-    // Not a valid address, but the split still yields a usable domain; the
-    // caller validates the address separately.
+    // Not a valid address, but the split still yields a usable domain; the caller validates the address
+    // separately.
     expect(getEmailDomain('@acme.com')).toBe('acme.com')
   })
 })
 
 /**
- * toHumanLabel turns identifiers into display text, keeping a known acronym set uppercase; the
- * scan UI (#2040) added DNS to that set. This is for camelCase / snake_case identifiers, not
- * ALL_CAPS enums, which go through getEnumLabel.
+ * toHumanLabel turns identifiers into display text, keeping a known acronym set uppercase; the scan UI added
+ * DNS to that set. This is for camelCase / snake_case identifiers, not ALL_CAPS enums, which go through
+ * getEnumLabel.
  */
 describe('toHumanLabel', () => {
   it('returns an empty string for empty input', () => {
@@ -196,9 +195,8 @@ describe('toHumanLabel', () => {
 })
 
 /**
- * #2078 — pluralize/pluralizeWithCount back the assessment UI's count labels. Only a count of
- * exactly 1 is singular; 0 and negatives take the plural, which is what an "0 responses" label
- * depends on.
+ * pluralize/pluralizeWithCount back the assessment UI's count labels. Only a count of exactly 1 is singular;
+ * 0 and negatives take the plural, which is what an "0 responses" label depends on.
  */
 describe('pluralize', () => {
   it('is singular only for exactly one', () => {

--- a/apps/console/src/utils/strings.test.ts
+++ b/apps/console/src/utils/strings.test.ts
@@ -92,10 +92,9 @@ describe('wordTokens', () => {
 })
 
 /**
- * #1957 — isValidDomain gates both the SSO exempt-domain list and the allowed-
- * domains editor. It must reject anything that is not a bare registrable domain:
- * no scheme, no path, no port, no bare hostname, and a TLD of at least two
- * letters.
+ * #1957 — isValidDomain gates both the SSO exempt-domain list and the allowed-domains editor. It
+ * must reject anything that is not a bare registrable domain: no scheme, no path, no port, no
+ * bare hostname, and a TLD of at least two letters.
  */
 describe('isValidDomain', () => {
   it.each(['acme.com', 'sub.acme.com', 'deep.sub.acme.co.uk', 'a-b.example.io', 'x1.example.dev'])('accepts %s', (domain) => {
@@ -123,10 +122,9 @@ describe('isValidDomain', () => {
 })
 
 /**
- * ISS-2459 — contact↔vendor linking suggests vendors whose domain matches the
- * contact's email domain, so getEmailDomain has to be strict: exactly one @,
- * a non-empty host, normalised for case and whitespace. A wrong answer here
- * surfaces as bogus vendor suggestions rather than an error.
+ * ISS-2459 — contact/vendor linking suggests vendors whose domain matches the contact's email
+ * domain, so getEmailDomain has to be strict. A wrong answer surfaces as bogus vendor suggestions
+ * rather than an error.
  */
 describe('getEmailDomain', () => {
   it('extracts and normalises the domain', () => {
@@ -161,12 +159,9 @@ describe('getEmailDomain', () => {
 })
 
 /**
- * toHumanLabel turns identifiers into display text, keeping a known acronym set
- * fully uppercase. The scan UI (#2040) added DNS to that set — without it a
- * "dns_scan" event renders as "Dns Scan".
- *
- * Note this is for camelCase / snake_case identifiers, NOT ALL_CAPS enums —
- * those go through getEnumLabel instead.
+ * toHumanLabel turns identifiers into display text, keeping a known acronym set uppercase; the
+ * scan UI (#2040) added DNS to that set. This is for camelCase / snake_case identifiers, not
+ * ALL_CAPS enums, which go through getEnumLabel.
  */
 describe('toHumanLabel', () => {
   it('returns an empty string for empty input', () => {
@@ -201,9 +196,9 @@ describe('toHumanLabel', () => {
 })
 
 /**
- * #2078 — pluralize/pluralizeWithCount back the assessment UI's count labels.
- * Only a count of exactly 1 is singular; 0 and negatives take the plural, which
- * is what an "0 responses" label depends on.
+ * #2078 — pluralize/pluralizeWithCount back the assessment UI's count labels. Only a count of
+ * exactly 1 is singular; 0 and negatives take the plural, which is what an "0 responses" label
+ * depends on.
  */
 describe('pluralize', () => {
   it('is singular only for exactly one', () => {

--- a/apps/console/src/utils/vulnerability-due-date.test.ts
+++ b/apps/console/src/utils/vulnerability-due-date.test.ts
@@ -1,0 +1,136 @@
+import { VulnerabilitySecurityLevel } from '@repo/codegen/src/schema'
+import { type SlaDefinitionsNodeNonNull } from '@/lib/graphql-hooks/sla-definition'
+import { buildPastDueVulnerabilityFilter, getVulnerabilityDueDate, MS_PER_DAY } from './vulnerability-due-date'
+
+/**
+ * ISS-2434 — the triage view needs a due date per vulnerability. The precedence
+ * rules are the fiddly part and all of them are silent when wrong:
+ *
+ *  - a per-record `remediationSLA` overrides the org SLA definition
+ *  - only POSITIVE numeric SLAs count; 0 / negative / null fall through
+ *  - the clock starts at `discoveredAt`, falling back to `createdAt`
+ *  - the severity key prefers `securityLevel` over the legacy `severity` string,
+ *    matched case-insensitively
+ *
+ * buildPastDueVulnerabilityFilter turns the same definitions into a server-side
+ * filter, and must skip definitions whose level is not a real
+ * VulnerabilitySecurityLevel.
+ */
+
+const def = (securityLevel: string, slaDays: number | null): SlaDefinitionsNodeNonNull => ({ securityLevel, slaDays }) as unknown as SlaDefinitionsNodeNonNull
+
+const daysAgo = (days: number): string => new Date(Date.now() - days * MS_PER_DAY).toISOString()
+const daysFromNow = (days: number): string => new Date(Date.now() + days * MS_PER_DAY).toISOString()
+
+describe('getVulnerabilityDueDate — SLA source precedence', () => {
+  test('prefers the record remediationSLA over the org definition', () => {
+    const info = getVulnerabilityDueDate({ securityLevel: 'CRITICAL', createdAt: daysAgo(1), remediationSLA: 3 }, [def('CRITICAL', 30)])
+
+    expect(info.slaDays).toBe(3)
+  })
+
+  test('falls back to the org definition when remediationSLA is absent', () => {
+    const info = getVulnerabilityDueDate({ securityLevel: 'CRITICAL', createdAt: daysAgo(1) }, [def('CRITICAL', 30)])
+
+    expect(info.slaDays).toBe(30)
+  })
+
+  test('ignores a zero or negative remediationSLA', () => {
+    expect(getVulnerabilityDueDate({ securityLevel: 'CRITICAL', createdAt: daysAgo(1), remediationSLA: 0 }, [def('CRITICAL', 30)]).slaDays).toBe(30)
+    expect(getVulnerabilityDueDate({ securityLevel: 'CRITICAL', createdAt: daysAgo(1), remediationSLA: -5 }, [def('CRITICAL', 30)]).slaDays).toBe(30)
+  })
+
+  test('yields no due date when neither source provides a usable SLA', () => {
+    const info = getVulnerabilityDueDate({ securityLevel: 'CRITICAL', createdAt: daysAgo(1) }, [def('CRITICAL', 0)])
+
+    expect(info).toMatchObject({ dueDate: null, slaDays: null, pastDue: false, daysOverdue: null, daysUntilDue: null })
+  })
+})
+
+describe('getVulnerabilityDueDate — severity matching', () => {
+  test('matches the org definition case-insensitively', () => {
+    expect(getVulnerabilityDueDate({ securityLevel: 'critical', createdAt: daysAgo(1) }, [def('CRITICAL', 30)]).slaDays).toBe(30)
+  })
+
+  test('falls back to the legacy severity string when securityLevel is unset', () => {
+    expect(getVulnerabilityDueDate({ severity: 'Critical', createdAt: daysAgo(1) }, [def('CRITICAL', 30)]).slaDays).toBe(30)
+  })
+
+  test('prefers securityLevel over severity when both are present', () => {
+    const info = getVulnerabilityDueDate({ securityLevel: 'HIGH', severity: 'critical', createdAt: daysAgo(1) }, [def('CRITICAL', 7), def('HIGH', 60)])
+
+    expect(info.slaDays).toBe(60)
+  })
+
+  test('yields no SLA when no definition matches the severity', () => {
+    expect(getVulnerabilityDueDate({ securityLevel: 'LOW', createdAt: daysAgo(1) }, [def('CRITICAL', 30)]).slaDays).toBeNull()
+  })
+})
+
+describe('getVulnerabilityDueDate — base date and overdue maths', () => {
+  test('counts from discoveredAt when present', () => {
+    const info = getVulnerabilityDueDate({ securityLevel: 'CRITICAL', discoveredAt: daysAgo(10), createdAt: daysAgo(100), remediationSLA: 5 }, [])
+
+    // discoveredAt (10 days ago) + 5 days = 5 days overdue, not 95.
+    expect(info.pastDue).toBe(true)
+    expect(info.daysOverdue).toBe(5)
+  })
+
+  test('falls back to createdAt when discoveredAt is absent', () => {
+    const info = getVulnerabilityDueDate({ securityLevel: 'CRITICAL', createdAt: daysAgo(10), remediationSLA: 5 }, [])
+
+    expect(info.pastDue).toBe(true)
+    expect(info.daysOverdue).toBe(5)
+  })
+
+  test('returns no due date when there is no base date at all', () => {
+    expect(getVulnerabilityDueDate({ securityLevel: 'CRITICAL', remediationSLA: 5 }, []).dueDate).toBeNull()
+  })
+
+  test('reports days until due for a record still in window', () => {
+    const info = getVulnerabilityDueDate({ securityLevel: 'CRITICAL', discoveredAt: daysFromNow(0), remediationSLA: 10 }, [])
+
+    expect(info.pastDue).toBe(false)
+    expect(info.daysOverdue).toBeNull()
+    expect(info.daysUntilDue).toBe(10)
+  })
+
+  test('never reports both overdue and until-due', () => {
+    const overdue = getVulnerabilityDueDate({ securityLevel: 'CRITICAL', createdAt: daysAgo(30), remediationSLA: 1 }, [])
+    expect(overdue.daysUntilDue).toBeNull()
+    expect(overdue.daysOverdue).not.toBeNull()
+  })
+})
+
+describe('buildPastDueVulnerabilityFilter', () => {
+  test('returns null when there are no usable definitions', () => {
+    expect(buildPastDueVulnerabilityFilter([])).toBeNull()
+    expect(buildPastDueVulnerabilityFilter([def('CRITICAL', 0)])).toBeNull()
+  })
+
+  test('skips definitions whose level is not a real VulnerabilitySecurityLevel', () => {
+    expect(buildPastDueVulnerabilityFilter([def('NOT_A_LEVEL', 7)])).toBeNull()
+  })
+
+  test('builds one or-clause per usable definition', () => {
+    const filter = buildPastDueVulnerabilityFilter([def(VulnerabilitySecurityLevel.CRITICAL, 7), def(VulnerabilitySecurityLevel.HIGH, 30)])
+
+    expect(filter?.or).toHaveLength(2)
+  })
+
+  test('only matches records with no per-record SLA override', () => {
+    // Records carrying their own remediationSLA are excluded from the
+    // definition-driven filter, since their due date is computed differently.
+    const filter = buildPastDueVulnerabilityFilter([def(VulnerabilitySecurityLevel.CRITICAL, 7)])
+
+    expect(JSON.stringify(filter)).toContain('remediationSLAIsNil')
+  })
+
+  test('anchors the cutoff to the supplied clock', () => {
+    const now = new Date('2026-07-15T00:00:00.000Z')
+    const filter = buildPastDueVulnerabilityFilter([def(VulnerabilitySecurityLevel.CRITICAL, 7)], now)
+    const expectedCutoff = new Date(now.getTime() - 7 * MS_PER_DAY).toISOString()
+
+    expect(JSON.stringify(filter)).toContain(expectedCutoff)
+  })
+})

--- a/apps/console/src/utils/vulnerability-due-date.test.ts
+++ b/apps/console/src/utils/vulnerability-due-date.test.ts
@@ -3,9 +3,8 @@ import { type SlaDefinitionsNodeNonNull } from '@/lib/graphql-hooks/sla-definiti
 import { buildPastDueVulnerabilityFilter, getVulnerabilityDueDate, MS_PER_DAY } from './vulnerability-due-date'
 
 /**
- * ISS-2434 — a per-record remediationSLA overrides the org SLA definition, only positive SLAs
- * count, and the clock starts at discoveredAt falling back to createdAt. Every one of these is
- * silent when wrong.
+ * A per-record remediationSLA overrides the org SLA definition, only positive SLAs count, and the clock
+ * starts at discoveredAt falling back to createdAt. Every one of these is silent when wrong.
  */
 
 const def = (securityLevel: string, slaDays: number | null): SlaDefinitionsNodeNonNull => ({ securityLevel, slaDays }) as unknown as SlaDefinitionsNodeNonNull
@@ -110,8 +109,8 @@ describe('buildPastDueVulnerabilityFilter', () => {
   })
 
   test('only matches records with no per-record SLA override', () => {
-    // Records carrying their own remediationSLA are excluded from the
-    // definition-driven filter, since their due date is computed differently.
+    // Records carrying their own remediationSLA are excluded from the definition-driven filter, since their
+    // due date is computed differently.
     const filter = buildPastDueVulnerabilityFilter([def(VulnerabilitySecurityLevel.CRITICAL, 7)])
 
     expect(JSON.stringify(filter)).toContain('remediationSLAIsNil')

--- a/apps/console/src/utils/vulnerability-due-date.test.ts
+++ b/apps/console/src/utils/vulnerability-due-date.test.ts
@@ -3,18 +3,9 @@ import { type SlaDefinitionsNodeNonNull } from '@/lib/graphql-hooks/sla-definiti
 import { buildPastDueVulnerabilityFilter, getVulnerabilityDueDate, MS_PER_DAY } from './vulnerability-due-date'
 
 /**
- * ISS-2434 — the triage view needs a due date per vulnerability. The precedence
- * rules are the fiddly part and all of them are silent when wrong:
- *
- *  - a per-record `remediationSLA` overrides the org SLA definition
- *  - only POSITIVE numeric SLAs count; 0 / negative / null fall through
- *  - the clock starts at `discoveredAt`, falling back to `createdAt`
- *  - the severity key prefers `securityLevel` over the legacy `severity` string,
- *    matched case-insensitively
- *
- * buildPastDueVulnerabilityFilter turns the same definitions into a server-side
- * filter, and must skip definitions whose level is not a real
- * VulnerabilitySecurityLevel.
+ * ISS-2434 — a per-record remediationSLA overrides the org SLA definition, only positive SLAs
+ * count, and the clock starts at discoveredAt falling back to createdAt. Every one of these is
+ * silent when wrong.
  */
 
 const def = (securityLevel: string, slaDays: number | null): SlaDefinitionsNodeNonNull => ({ securityLevel, slaDays }) as unknown as SlaDefinitionsNodeNonNull


### PR DESCRIPTION
Unit tests for the pure helpers behind filters, storage, dates and plan gating. No production code touched.

Takes the console suite from 313 tests to 854.

Most of these cover things we've actually broken before, so each file starts with a line saying which issue it pins and what the failure mode was. The ones worth a look:

- filter composition — `mergeWhere`, `hasStatusCondition`, `task-where`. The nested and/or traversal is the easy part to regress.
- date and SLA precedence — `sla`, `vulnerability-due-date`, `use-timeline-readiness-form-schema`. Fiddly rules, all silent when wrong.
- parsers for user input — `brandingString`, `normalizeHexColor`, `vendor-logo`. The refusals matter more than the happy path.
- `constants/standards` — the exclusion clauses need the OR'd IsNil branch, otherwise NULL frameworks silently vanish.

Ran locally since CI does neither: `bun test` 854/0, `tsc --noEmit` clean, prettier clean.

Related: #2211 has the filter logic and its own tests for the modules it changes — no overlap with these. #2206 is unrelated console fixes.
