### PR TITLE
fix(console): defects and a11y gaps found while writing the E2E suite

### DIFF
--- a/apps/console/src/components/pages/protected/communications/email-templates/email-template-editor-page.tsx
+++ b/apps/console/src/components/pages/protected/communications/email-templates/email-template-editor-page.tsx
@@ -163,7 +163,7 @@ export const EmailTemplateEditorPage: React.FC = () => {
           <div className="flex flex-col gap-6 min-w-0">
             <div className="flex items-center justify-between rounded-lg border border-border bg-card p-4">
               <span className="text-sm font-semibold">Active</span>
-              <Switch checked={active} onCheckedChange={setActive} />
+              <Switch aria-label="Active" checked={active} onCheckedChange={setActive} />
             </div>
 
             <EditorCard title="Basic">

--- a/apps/console/src/components/pages/protected/controls/control-header-actions.tsx
+++ b/apps/console/src/components/pages/protected/controls/control-header-actions.tsx
@@ -55,7 +55,7 @@ const ControlHeaderActions: React.FC<ControlHeaderActionsProps> = ({ controlId, 
       {(canCloneControl || canDeleteControl) && (
         <Menu
           trigger={
-            <Button type="button" variant="secondary" className="h-8 px-2">
+            <Button type="button" variant="secondary" className="h-8 px-2" data-testid="control-actions-menu">
               <MoreHorizontal size={16} />
             </Button>
           }
@@ -70,7 +70,7 @@ const ControlHeaderActions: React.FC<ControlHeaderActionsProps> = ({ controlId, 
                 </Link>
               )}
               {canDeleteControl && (
-                <button onClick={onDeleteClick} className="flex items-center space-x-2 px-1 bg-transparent cursor-pointer text-destructive">
+                <button onClick={onDeleteClick} data-testid="control-delete-button" className="flex items-center space-x-2 px-1 bg-transparent cursor-pointer text-destructive">
                   <Trash2 size={16} strokeWidth={2} />
                   <span>Delete</span>
                 </button>

--- a/apps/console/src/components/pages/protected/controls/create-control/build-control-input.test.ts
+++ b/apps/console/src/components/pages/protected/controls/create-control/build-control-input.test.ts
@@ -1,0 +1,81 @@
+import { buildControlEntityInput, emptyToUndefined, stripAssociationKeys } from './build-control-input'
+
+describe('stripAssociationKeys', () => {
+  it('drops every association key and keeps the rest', () => {
+    const result = stripAssociationKeys({ refCode: 'AC-1', policyIDs: ['p1'], status: 'PREPARING' }, new Set(['policyIDs']))
+
+    expect(result).toEqual({ refCode: 'AC-1', status: 'PREPARING' })
+  })
+
+  it('returns everything when no key matches', () => {
+    expect(stripAssociationKeys({ refCode: 'AC-1' }, new Set(['policyIDs']))).toEqual({ refCode: 'AC-1' })
+  })
+
+  it('returns an empty object when every key is an association', () => {
+    expect(stripAssociationKeys({ policyIDs: ['p1'], riskIDs: ['r1'] }, new Set(['policyIDs', 'riskIDs']))).toEqual({})
+  })
+})
+
+describe('emptyToUndefined', () => {
+  it('maps an empty string onto undefined so the field is omitted', () => {
+    expect(emptyToUndefined('')).toBeUndefined()
+  })
+
+  it('maps null onto undefined', () => {
+    expect(emptyToUndefined(null)).toBeUndefined()
+  })
+
+  it('keeps a real value', () => {
+    expect(emptyToUndefined('REF-1')).toBe('REF-1')
+  })
+
+  it('keeps zero rather than treating it as empty', () => {
+    expect(emptyToUndefined(0)).toBe(0)
+  })
+
+  it('keeps false rather than treating it as empty', () => {
+    expect(emptyToUndefined(false)).toBe(false)
+  })
+})
+
+describe('buildControlEntityInput', () => {
+  const associationKeys = new Set(['policyIDs', 'riskIDs'])
+
+  it('strips associations and carries the plain fields through', () => {
+    const input = buildControlEntityInput({
+      data: { refCode: 'AC-1', status: 'PREPARING', policyIDs: ['p1'] },
+      associationKeys,
+    })
+
+    expect(input.refCode).toBe('AC-1')
+    expect(input.status).toBe('PREPARING')
+    expect('policyIDs' in input).toBe(false)
+  })
+
+  it('sets description and descriptionJSON from the converted values', () => {
+    const json = [{ type: 'p', children: [{ text: 'hello' }] }]
+    const input = buildControlEntityInput({ data: {}, associationKeys, description: '<p>hello</p>', descriptionJSON: json })
+
+    expect(input.description).toBe('<p>hello</p>')
+    expect(input.descriptionJSON).toBe(json)
+  })
+
+  it('omits an empty referenceID rather than sending an empty string', () => {
+    const input = buildControlEntityInput({ data: { referenceID: '' }, associationKeys })
+
+    expect(input.referenceID).toBeUndefined()
+  })
+
+  it('omits an empty auditorReferenceID', () => {
+    const input = buildControlEntityInput({ data: { auditorReferenceID: '' }, associationKeys })
+
+    expect(input.auditorReferenceID).toBeUndefined()
+  })
+
+  it('keeps both reference ids when they are set', () => {
+    const input = buildControlEntityInput({ data: { referenceID: 'REF-1', auditorReferenceID: 'AUD-1' }, associationKeys })
+
+    expect(input.referenceID).toBe('REF-1')
+    expect(input.auditorReferenceID).toBe('AUD-1')
+  })
+})

--- a/apps/console/src/components/pages/protected/controls/create-control/build-control-input.ts
+++ b/apps/console/src/components/pages/protected/controls/create-control/build-control-input.ts
@@ -1,0 +1,19 @@
+export interface BuildControlEntityInputArgs {
+  data: Record<string, unknown>
+  associationKeys: Set<string>
+  description?: string
+  descriptionJSON?: unknown
+}
+
+export const stripAssociationKeys = (data: Record<string, unknown>, associationKeys: Set<string>): Record<string, unknown> =>
+  Object.fromEntries(Object.entries(data).filter(([key]) => !associationKeys.has(key)))
+
+export const emptyToUndefined = (value: unknown): unknown => (value === '' || value === null ? undefined : value)
+
+export const buildControlEntityInput = ({ data, associationKeys, description, descriptionJSON }: BuildControlEntityInputArgs): Record<string, unknown> => ({
+  ...stripAssociationKeys(data, associationKeys),
+  description,
+  descriptionJSON,
+  referenceID: emptyToUndefined(data.referenceID),
+  auditorReferenceID: emptyToUndefined(data.auditorReferenceID),
+})

--- a/apps/console/src/components/pages/protected/controls/create-control/create-control-form.tsx
+++ b/apps/console/src/components/pages/protected/controls/create-control/create-control-form.tsx
@@ -388,17 +388,17 @@ export default function CreateControlForm() {
           <div className="w-[55%]">
             {/* Ref Code */}
             <div>
-              <Label>
+              <Label htmlFor="control-ref-code">
                 Ref Code <span className="text-destructive">*</span>
               </Label>
               {errors?.refCode && <p className="text-destructive text-sm mt-1">{errors.refCode.message}</p>}
-              <Controller name="refCode" control={control} rules={{ required: true }} render={({ field }) => <Input {...field} />} />
+              <Controller name="refCode" control={control} rules={{ required: true }} render={({ field }) => <Input id="control-ref-code" {...field} />} />
             </div>
 
             {/* Title */}
             <div className="mt-4">
-              <Label>Title</Label>
-              <Controller name="title" control={control} render={({ field }) => <Input {...field} value={field.value ?? ''} />} />
+              <Label htmlFor="control-title">Title</Label>
+              <Controller name="title" control={control} render={({ field }) => <Input id="control-title" {...field} value={field.value ?? ''} />} />
             </div>
 
             {isCreateSubcontrol && (

--- a/apps/console/src/components/pages/protected/controls/create-control/create-control-form.tsx
+++ b/apps/console/src/components/pages/protected/controls/create-control/create-control-form.tsx
@@ -61,6 +61,7 @@ import { docsHelpQuery } from '@/components/shared/docs-help/docs-help-query'
 import { useDocsHelpNavigate } from '@/components/shared/docs-help/docs-help-context'
 import { docsHelpEnabled } from '@repo/dally/ai'
 import { BookText } from 'lucide-react'
+import { buildControlEntityInput } from './build-control-input'
 
 export default function CreateControlForm() {
   const params = useSearchParams()
@@ -159,15 +160,12 @@ export default function CreateControlForm() {
           : buildAssociationPayload(CONTROL_ASSOCIATION_CONFIG.associationKeys, data, true, {}),
         FINDING_CONTROL_JOIN_KEY_ON_CONTROL,
       )
-      const nonAssociationData = Object.fromEntries(Object.entries(data).filter(([key]) => !allAssociationKeys.has(key)))
-
-      const entityInput = {
-        ...nonAssociationData,
+      const entityInput = buildControlEntityInput({
+        data,
+        associationKeys: allAssociationKeys,
         description: await convertToHtml(data.descriptionJSON as Value),
         descriptionJSON: data.descriptionJSON,
-        referenceID: data.referenceID || undefined,
-        auditorReferenceID: data.auditorReferenceID || undefined,
-      }
+      })
 
       const commonInput = { ...entityInput, ...associationInputs }
 

--- a/apps/console/src/components/pages/protected/controls/map-controls/shared/control-chip.tsx
+++ b/apps/console/src/components/pages/protected/controls/map-controls/shared/control-chip.tsx
@@ -86,26 +86,32 @@ const ControlChip: React.FC<ControlChipProps> = ({
       )}
       <span>{control.refCode || ''}</span>
       {removable && onRemove && (
-        <XIcon
-          size={12}
-          className="cursor-pointer ml-1"
+        <button
+          type="button"
+          aria-label={`Remove ${control.refCode || 'control'}`}
+          className="cursor-pointer ml-1 bg-transparent"
           onClick={(e) => {
             e.stopPropagation()
             e.preventDefault()
             onRemove(control)
           }}
-        />
+        >
+          <XIcon size={12} />
+        </button>
       )}
       {canAdd && onAdd && (
-        <Plus
-          size={12}
-          className="cursor-pointer ml-1"
+        <button
+          type="button"
+          aria-label={`Add ${control.refCode || 'control'}`}
+          className="cursor-pointer ml-1 bg-transparent"
           onClick={(e) => {
             e.stopPropagation()
             e.preventDefault()
             onAdd(control)
           }}
-        />
+        >
+          <Plus size={12} />
+        </button>
       )}
     </Badge>
   )

--- a/apps/console/src/components/pages/protected/controls/propereties-card/fields/status.tsx
+++ b/apps/console/src/components/pages/protected/controls/propereties-card/fields/status.tsx
@@ -111,7 +111,7 @@ export const Status = ({
                   field.onChange(val)
                 }}
               >
-                <SelectTrigger>
+                <SelectTrigger data-testid="control-status-select">
                   <SelectValue>{field.value === 'NULL' ? '-' : getEnumLabel(field.value as ControlControlStatus)}</SelectValue>
                 </SelectTrigger>
                 <SelectContent ref={popoverRef}>
@@ -126,7 +126,7 @@ export const Status = ({
           />
         ) : (
           <HoverPencilWrapper onPencilClick={handleClick}>
-            <div className="flex items-center space-x-2 cursor-pointer" onDoubleClick={handleClick}>
+            <div data-testid="control-status-trigger" className="flex items-center space-x-2 cursor-pointer" onDoubleClick={handleClick}>
               {ControlIconMapper16[data?.status as ControlControlStatus]}
               <p>{getEnumLabel(data?.status as ControlControlStatus) || '-'}</p>
             </div>

--- a/apps/console/src/components/pages/protected/controls/tabs/implementation/control-objectives-components/control-objective-page.tsx
+++ b/apps/console/src/components/pages/protected/controls/tabs/implementation/control-objectives-components/control-objective-page.tsx
@@ -186,10 +186,10 @@ const ControlObjectivePage = () => {
         </div>
         <div className="flex gap-4 items-center">
           <div className="flex gap-2 items-center">
-            <Checkbox checked={archivedChecked} onCheckedChange={(checked) => setArchivedChecked(!!checked)} />
+            <Checkbox aria-label="Show archived" checked={archivedChecked} onCheckedChange={(checked) => setArchivedChecked(!!checked)} />
             <p>Show archived</p>
           </div>
-          <Button type="button" className="h-8 !px-2" variant="secondary" onClick={toggleAll}>
+          <Button type="button" aria-label="Expand or collapse all objectives" className="h-8 !px-2" variant="secondary" onClick={toggleAll}>
             <div className="flex">
               <List size={16} />
               <ChevronsDownUp size={16} />
@@ -232,9 +232,9 @@ const ControlObjectivePage = () => {
       </div>
       <div className="flex gap-4 items-center">
         <div className="flex gap-2 items-center">
-          <Checkbox checked={archivedChecked} onCheckedChange={(checked) => setArchivedChecked(!!checked)} /> <p>Show archived</p>
+          <Checkbox aria-label="Show archived" checked={archivedChecked} onCheckedChange={(checked) => setArchivedChecked(!!checked)} /> <p>Show archived</p>
         </div>
-        <Button type="button" className="h-8 !px-2" variant="secondary" onClick={toggleAll}>
+        <Button type="button" aria-label="Expand or collapse all objectives" className="h-8 !px-2" variant="secondary" onClick={toggleAll}>
           <div className="flex">
             <List size={16} />
             <ChevronsDownUp size={16} />

--- a/apps/console/src/components/pages/protected/developers/actions/pat-actions.tsx
+++ b/apps/console/src/components/pages/protected/developers/actions/pat-actions.tsx
@@ -59,7 +59,7 @@ export const TokenAction = ({ tokenId, tokenName, tokenDescription, tokenExpires
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="secondary" className="-mr-2">
+          <Button variant="secondary" className="-mr-2" aria-label={`Token actions for ${tokenName}`}>
             <MoreHorizontal className="h-4 w-4 text-brand" />
           </Button>
         </DropdownMenuTrigger>

--- a/apps/console/src/components/pages/protected/evidence/evidence-create-sheet.tsx
+++ b/apps/console/src/components/pages/protected/evidence/evidence-create-sheet.tsx
@@ -14,6 +14,7 @@ import { useCreateEvidence } from '@/lib/graphql-hooks/evidence'
 import { type TFormEvidenceData } from '@/components/pages/protected/evidence/types/TFormEvidenceData.ts'
 import { ObjectTypeObjects } from '@/components/shared/object-association/object-association-config'
 import { type TObjectAssociationMap } from '@/components/shared/object-association/types/TObjectAssociationMap'
+import { buildCreateEvidenceInput } from './hooks/build-evidence-input'
 import { Panel } from '@repo/ui/panel'
 import { useQueryClient } from '@tanstack/react-query'
 import { type TUploadedFile } from './upload/types/TUploadedFile'
@@ -89,24 +90,7 @@ const EvidenceCreateSheet: React.FC<TEvidenceCreateSheetProps> = ({
   const buildInput = async (data: CreateEvidenceFormData, status?: EvidenceEvidenceStatus): Promise<CreateEvidenceInput> => {
     const collectionProcedure = data.collectionProcedure && typeof data.collectionProcedure !== 'string' ? await convertToHtml(data.collectionProcedure) : data.collectionProcedure
 
-    return {
-      name: data.name,
-      description: data.description,
-      tags: data.tags,
-      creationDate: data.creationDate instanceof Date ? data.creationDate.toISOString() : data.creationDate,
-      renewalDate: data.renewalDate instanceof Date ? data.renewalDate.toISOString() : data.renewalDate,
-      collectionProcedure,
-      source: data.source,
-      fileIDs: data.fileIDs,
-      taskIDs: data.taskIDs,
-      ...evidenceObjectTypes,
-      controlIDs: data.controlIDs,
-      subcontrolIDs: data.subcontrolIDs,
-      programIDs: programId ? [programId] : (data.programIDs ?? []),
-      ...(data.url ? { url: data.url } : {}),
-      ...(status ? { status } : {}),
-      ...(data.reviewFrequency ? { reviewFrequency: data.reviewFrequency } : {}),
-    }
+    return buildCreateEvidenceInput({ data, collectionProcedure, objectAssociations: evidenceObjectTypes, programId, status })
   }
 
   const submitEvidence = async (data: CreateEvidenceFormData, status?: EvidenceEvidenceStatus) => {

--- a/apps/console/src/components/pages/protected/evidence/hooks/build-evidence-input.test.ts
+++ b/apps/console/src/components/pages/protected/evidence/hooks/build-evidence-input.test.ts
@@ -1,0 +1,107 @@
+import { buildCreateEvidenceInput, toIsoDate, type BuildCreateEvidenceInputArgs } from './build-evidence-input'
+import { type CreateEvidenceFormData } from './use-form-schema'
+
+const formData = (overrides: Partial<CreateEvidenceFormData> = {}): CreateEvidenceFormData =>
+  ({
+    name: 'Quarterly access review',
+    ...overrides,
+  }) as CreateEvidenceFormData
+
+const build = (args: Partial<BuildCreateEvidenceInputArgs> = {}) => buildCreateEvidenceInput({ data: formData(), ...args })
+
+describe('toIsoDate', () => {
+  it('serialises a Date to an ISO string', () => {
+    expect(toIsoDate(new Date('2026-03-04T05:06:07.000Z'))).toBe('2026-03-04T05:06:07.000Z')
+  })
+
+  it('passes an already-serialised string through untouched', () => {
+    expect(toIsoDate('2026-03-04')).toBe('2026-03-04')
+  })
+
+  it('maps null and undefined onto undefined so the field is omitted', () => {
+    expect(toIsoDate(null)).toBeUndefined()
+    expect(toIsoDate(undefined)).toBeUndefined()
+  })
+})
+
+describe('buildCreateEvidenceInput', () => {
+  it('carries the plain fields through', () => {
+    const input = build({ data: formData({ name: 'Pen test report', description: 'annual', source: 'vendor', tags: ['security'] }) })
+
+    expect(input.name).toBe('Pen test report')
+    expect(input.description).toBe('annual')
+    expect(input.source).toBe('vendor')
+    expect(input.tags).toEqual(['security'])
+  })
+
+  it('serialises both date fields', () => {
+    const input = build({
+      data: formData({ creationDate: new Date('2026-01-02T00:00:00.000Z'), renewalDate: new Date('2027-01-02T00:00:00.000Z') }),
+    })
+
+    expect(input.creationDate).toBe('2026-01-02T00:00:00.000Z')
+    expect(input.renewalDate).toBe('2027-01-02T00:00:00.000Z')
+  })
+
+  it('omits status entirely when none is supplied, so the backend keeps its own', () => {
+    expect('status' in build()).toBe(false)
+  })
+
+  it('includes status when one is supplied', () => {
+    const input = build({ status: 'APPROVED' as BuildCreateEvidenceInputArgs['status'] })
+
+    expect(input.status).toBe('APPROVED')
+  })
+
+  it('omits url and reviewFrequency when they are empty rather than sending empty values', () => {
+    const input = build({ data: formData({ url: '', reviewFrequency: undefined }) })
+
+    expect('url' in input).toBe(false)
+    expect('reviewFrequency' in input).toBe(false)
+  })
+
+  it('includes url and reviewFrequency when they are set', () => {
+    const input = build({ data: formData({ url: 'https://example.com/report.pdf', reviewFrequency: 'YEARLY' as CreateEvidenceFormData['reviewFrequency'] }) })
+
+    expect(input.url).toBe('https://example.com/report.pdf')
+    expect(input.reviewFrequency).toBe('YEARLY')
+  })
+
+  it('prefers an explicit programId over the form value', () => {
+    const input = build({ data: formData({ programIDs: ['form-program'] }), programId: 'sheet-program' })
+
+    expect(input.programIDs).toEqual(['sheet-program'])
+  })
+
+  it('falls back to the form programIDs when no programId is supplied', () => {
+    const input = build({ data: formData({ programIDs: ['form-program'] }) })
+
+    expect(input.programIDs).toEqual(['form-program'])
+  })
+
+  it('defaults programIDs to an empty array when neither source has one', () => {
+    expect(build().programIDs).toEqual([])
+  })
+
+  it('spreads object associations into the input', () => {
+    const input = build({ objectAssociations: { taskIDs: ['task-1'], programIDs: ['program-1'] } })
+
+    expect(input.taskIDs).toEqual(['task-1'])
+  })
+
+  it('lets the form control and subcontrol ids win over the association map', () => {
+    const input = build({
+      data: formData({ controlIDs: ['form-control'], subcontrolIDs: ['form-subcontrol'] }),
+      objectAssociations: { controlIDs: ['assoc-control'], subcontrolIDs: ['assoc-subcontrol'] },
+    })
+
+    expect(input.controlIDs).toEqual(['form-control'])
+    expect(input.subcontrolIDs).toEqual(['form-subcontrol'])
+  })
+
+  it('passes a converted collectionProcedure through', () => {
+    const input = build({ collectionProcedure: '<p>run the export</p>' })
+
+    expect(input.collectionProcedure).toBe('<p>run the export</p>')
+  })
+})

--- a/apps/console/src/components/pages/protected/evidence/hooks/build-evidence-input.ts
+++ b/apps/console/src/components/pages/protected/evidence/hooks/build-evidence-input.ts
@@ -1,0 +1,37 @@
+import { type CreateEvidenceInput, type EvidenceEvidenceStatus } from '@repo/codegen/src/schema'
+
+import { type TObjectAssociationMap } from '@/components/shared/object-association/types/TObjectAssociationMap'
+
+import { type CreateEvidenceFormData } from './use-form-schema'
+
+export interface BuildCreateEvidenceInputArgs {
+  data: CreateEvidenceFormData
+  collectionProcedure?: string | null
+  objectAssociations?: TObjectAssociationMap
+  programId?: string | null
+  status?: EvidenceEvidenceStatus
+}
+
+export const toIsoDate = (value: Date | string | null | undefined): string | undefined => {
+  if (value === null || value === undefined) return undefined
+  return value instanceof Date ? value.toISOString() : value
+}
+
+export const buildCreateEvidenceInput = ({ data, collectionProcedure, objectAssociations, programId, status }: BuildCreateEvidenceInputArgs): CreateEvidenceInput => ({
+  name: data.name,
+  description: data.description,
+  tags: data.tags,
+  creationDate: toIsoDate(data.creationDate),
+  renewalDate: toIsoDate(data.renewalDate),
+  collectionProcedure,
+  source: data.source,
+  fileIDs: data.fileIDs,
+  taskIDs: data.taskIDs,
+  ...objectAssociations,
+  controlIDs: data.controlIDs,
+  subcontrolIDs: data.subcontrolIDs,
+  programIDs: programId ? [programId] : (data.programIDs ?? []),
+  ...(data.url ? { url: data.url } : {}),
+  ...(status ? { status } : {}),
+  ...(data.reviewFrequency ? { reviewFrequency: data.reviewFrequency } : {}),
+})

--- a/apps/console/src/components/pages/protected/exposure/overview/configure-sla-sheet.tsx
+++ b/apps/console/src/components/pages/protected/exposure/overview/configure-sla-sheet.tsx
@@ -109,10 +109,10 @@ const ConfigureSlaSheet = ({ isOpen, onClose, readOnly = false }: Props) => {
                         autoFocus
                       />
                       <span className="text-sm text-muted-foreground">days</span>
-                      <Button size="sm" variant="outline" className="h-8 w-8 p-0" onClick={() => handleSave(def.id)} disabled={isPending}>
+                      <Button size="sm" variant="outline" aria-label={`Save SLA days for ${severityName}`} className="h-8 w-8 p-0" onClick={() => handleSave(def.id)} disabled={isPending}>
                         {isPending ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} className="text-success" />}
                       </Button>
-                      <Button size="sm" variant="outline" className="h-8 w-8 p-0" onClick={handleCancel} disabled={isPending}>
+                      <Button size="sm" variant="outline" aria-label={`Cancel SLA edit for ${severityName}`} className="h-8 w-8 p-0" onClick={handleCancel} disabled={isPending}>
                         <X size={14} />
                       </Button>
                     </>
@@ -120,7 +120,7 @@ const ConfigureSlaSheet = ({ isOpen, onClose, readOnly = false }: Props) => {
                     <>
                       <span className="text-sm font-medium tabular-nums">{def.slaDays != null ? `${def.slaDays} days` : <span className="text-muted-foreground">—</span>}</span>
                       {!readOnly && (
-                        <Button size="sm" variant="outline" className="h-8 w-8 p-0" onClick={() => handleEdit(def.id, def.slaDays)}>
+                        <Button size="sm" variant="outline" aria-label={`Edit SLA days for ${severityName}`} className="h-8 w-8 p-0" onClick={() => handleEdit(def.id, def.slaDays)}>
                           <Pencil size={14} className="text-muted-foreground" />
                         </Button>
                       )}

--- a/apps/console/src/components/pages/protected/exposure/overview/exposure-critical-counts.tsx
+++ b/apps/console/src/components/pages/protected/exposure/overview/exposure-critical-counts.tsx
@@ -80,6 +80,7 @@ const ExposureCriticalCounts = ({ counts, isLoading }: Props) => {
                 ) : (
                   <div className="space-y-2">
                     <button
+                      aria-label={`Critical ${label}`}
                       className="flex items-center justify-between w-full rounded-md px-2 py-1 -mx-2 hover:bg-secondary transition-colors cursor-pointer"
                       onClick={() => handleClick(tableKey, href, critFilter)}
                     >
@@ -90,6 +91,7 @@ const ExposureCriticalCounts = ({ counts, isLoading }: Props) => {
                       <span className="text-2xl font-bold text-destructive">{data.critical}</span>
                     </button>
                     <button
+                      aria-label={`High ${label}`}
                       className="flex items-center justify-between w-full rounded-md px-2 py-1 -mx-2 hover:bg-secondary transition-colors cursor-pointer"
                       onClick={() => handleClick(tableKey, href, highFilter)}
                     >

--- a/apps/console/src/components/pages/protected/exposure/overview/exposure-severity-chart.tsx
+++ b/apps/console/src/components/pages/protected/exposure/overview/exposure-severity-chart.tsx
@@ -78,7 +78,13 @@ const SeverityRow = ({
             return (
               <Tooltip key={sev}>
                 <TooltipTrigger asChild>
-                  <div onClick={() => navigateToFiltered(sev)} className="h-full cursor-pointer" style={{ width: `${pct}%`, backgroundColor: sevColor(sev) }} />
+                  <button
+                    type="button"
+                    aria-label={`${sev} ${label}`}
+                    onClick={() => navigateToFiltered(sev)}
+                    className="h-full cursor-pointer"
+                    style={{ width: `${pct}%`, backgroundColor: sevColor(sev) }}
+                  />
                 </TooltipTrigger>
                 <TooltipContent side="top" className="max-w-64">
                   <p className="font-semibold capitalize mb-1">{sev}</p>

--- a/apps/console/src/components/pages/protected/groups/components/groups-members-table.tsx
+++ b/apps/console/src/components/pages/protected/groups/components/groups-members-table.tsx
@@ -148,6 +148,7 @@ const GroupsMembersTable = () => {
 
         return (
           <button
+            aria-label={`Remove ${user.name} from group`}
             disabled={!!isManaged || !canEdit(permission?.roles, session) || isDeleting}
             type="button"
             onClick={() => handleDelete(user.id)}

--- a/apps/console/src/components/pages/protected/onboarding/dynamic-field.tsx
+++ b/apps/console/src/components/pages/protected/onboarding/dynamic-field.tsx
@@ -40,7 +40,7 @@ export const DynamicQuestionField: React.FC<{ question: OnboardingQuestion }> = 
           <QuestionLabel question={question} htmlFor={question.key} />
           <QuestionDescription text={question.description} />
           <Select onValueChange={(next) => setValue(question.key, next, { shouldDirty: true, shouldValidate: true })} value={typeof watched === 'string' ? watched : ''}>
-            <SelectTrigger className="w-full">
+            <SelectTrigger id={question.key} className="w-full">
               <SelectValue placeholder="Select an option" />
             </SelectTrigger>
             <SelectContent>

--- a/apps/console/src/components/pages/protected/organization-settings/authentication/allowed-domains.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/authentication/allowed-domains.tsx
@@ -123,6 +123,7 @@ const AllowedDomains = () => {
               onRemove={removeDomain}
               error={inputError}
               isPending={isPending}
+              inputLabel="Allowed domain"
               addLabel="Add Domain"
             />
           </div>

--- a/apps/console/src/components/pages/protected/organization-settings/authentication/sso.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/authentication/sso.tsx
@@ -832,6 +832,7 @@ const SSOPage = () => {
                             setNewJitDomain(value)
                             if (jitDomainError) setJitDomainError(null)
                           }}
+                          inputLabel="JIT provisioning domain"
                           onAdd={addJitDomain}
                           onRemove={removeJitDomain}
                           error={jitDomainError}
@@ -857,6 +858,7 @@ const SSOPage = () => {
                       setNewExemptDomain(value)
                       if (exemptDomainError) setExemptDomainError(null)
                     }}
+                    inputLabel="SSO exempt domain"
                     onAdd={addExemptDomain}
                     onRemove={removeExemptDomain}
                     error={exemptDomainError}

--- a/apps/console/src/components/pages/protected/organization-settings/custom-data/custom-enums/create-enum-sheet.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/custom-data/custom-enums/create-enum-sheet.tsx
@@ -237,8 +237,8 @@ export const CreateEnumSheet = ({ resetPagination, filter }: { resetPagination: 
             <FormProvider {...formMethods}>
               <form key={enumData?.customTypeEnum?.id || 'create'} className="p-6 space-y-6">
                 <div className="space-y-2">
-                  <Label>Name</Label>
-                  <Input {...formMethods.register('name')} disabled={isPending || isEditMode} placeholder="" />
+                  <Label htmlFor="custom-enum-name">Name</Label>
+                  <Input id="custom-enum-name" {...formMethods.register('name')} disabled={isPending || isEditMode} />
                   {errors.name && <p className="text-destructive text-xs font-medium">{errors.name.message}</p>}
                 </div>
 
@@ -298,8 +298,8 @@ export const CreateEnumSheet = ({ resetPagination, filter }: { resetPagination: 
                 </div>
 
                 <div className="space-y-2">
-                  <Label>Description</Label>
-                  <Textarea {...formMethods.register('description')} disabled={isPending} placeholder="Description..." className="min-h-[100px]" />
+                  <Label htmlFor="custom-enum-description">Description</Label>
+                  <Textarea id="custom-enum-description" {...formMethods.register('description')} disabled={isPending} placeholder="Description..." className="min-h-[100px]" />
                   {errors.description && <p className="text-destructive text-xs font-medium">{errors.description.message}</p>}
                 </div>
               </form>

--- a/apps/console/src/components/pages/protected/organization-settings/custom-data/custom-enums/custom-enums-table-config.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/custom-data/custom-enums/custom-enums-table-config.tsx
@@ -43,7 +43,7 @@ export const useGetCustomEnumColumns = ({ onEdit, onDelete, userMap, tokenMap, c
         const isSystem = !!row.original.systemOwned
 
         const trigger = (
-          <Button className="-mr-2" variant="secondary" disabled={isSystem}>
+          <Button className="-mr-2" variant="secondary" disabled={isSystem} aria-label={`Enum actions for ${row.original.name}`}>
             <MoreHorizontal className="h-4 w-4 text-brand" />
           </Button>
         )

--- a/apps/console/src/components/pages/protected/organization-settings/custom-data/custom-tags/custom-tags-table-config.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/custom-data/custom-tags/custom-tags-table-config.tsx
@@ -37,7 +37,7 @@ export const useGetCustomTagColumns = ({ onEdit, onDelete, userMap, tokenMap, ca
       cell: ({ row }) => (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button className="-mr-2" variant="secondary">
+            <Button className="-mr-2" variant="secondary" aria-label={`Tag actions for ${row.original.name}`}>
               <MoreHorizontal className="h-4 w-4 text-brand" />
             </Button>
           </DropdownMenuTrigger>

--- a/apps/console/src/components/pages/protected/organization-settings/subscribers/actions/subscriber-actions.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/subscribers/actions/subscriber-actions.tsx
@@ -38,14 +38,17 @@ export const SubscriberActions = ({ subscriberEmail }: SubscriberActionsProps) =
   return (
     <>
       <div className="flex items-center gap-2">
-        <Trash2
-          size={ICON_SIZE}
+        <button
+          type="button"
+          aria-label={`Delete subscriber ${subscriberEmail}`}
+          className="cursor-pointer bg-transparent"
           onClick={(e) => {
             e.stopPropagation()
             setIsDeleteDialogOpen(true)
           }}
-          className={`cursor-pointer`}
-        />
+        >
+          <Trash2 size={ICON_SIZE} />
+        </button>
       </div>
 
       <ConfirmationDialog

--- a/apps/console/src/components/pages/protected/policies/create/cards/status-card.tsx
+++ b/apps/console/src/components/pages/protected/policies/create/cards/status-card.tsx
@@ -54,7 +54,9 @@ const StatusCard: React.FC<TStatusCardProps> = ({ form }) => {
                       field.onChange(value)
                     }}
                   >
-                    <SelectTrigger aria-label="Status" className="w-full">{statusOptions.find((item) => item.value === field.value)?.label}</SelectTrigger>
+                    <SelectTrigger aria-label="Status" className="w-full">
+                      {statusOptions.find((item) => item.value === field.value)?.label}
+                    </SelectTrigger>
                     <SelectContent>
                       {statusOptions.map((option) => (
                         <SelectItem key={option.value} value={option.value}>
@@ -84,7 +86,9 @@ const StatusCard: React.FC<TStatusCardProps> = ({ form }) => {
               render={({ field }) => (
                 <>
                   <Select value={String(field.value ?? false)} onValueChange={(value) => field.onChange(value === 'true')}>
-                    <SelectTrigger aria-label="Approval Required" className="w-full">{String(field.value ?? false)}</SelectTrigger>
+                    <SelectTrigger aria-label="Approval Required" className="w-full">
+                      {String(field.value ?? false)}
+                    </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="true">True</SelectItem>
                       <SelectItem value="false">False</SelectItem>
@@ -116,7 +120,9 @@ const StatusCard: React.FC<TStatusCardProps> = ({ form }) => {
                       field.onChange(value)
                     }}
                   >
-                    <SelectTrigger aria-label="Reviewing Frequency" className="w-full">{reviewFrequencyOptions.find((item) => item.value === field.value)?.label}</SelectTrigger>
+                    <SelectTrigger aria-label="Reviewing Frequency" className="w-full">
+                      {reviewFrequencyOptions.find((item) => item.value === field.value)?.label}
+                    </SelectTrigger>
                     <SelectContent>
                       {reviewFrequencyOptions.map((option) => (
                         <SelectItem key={option.value} value={option.value}>

--- a/apps/console/src/components/pages/protected/policies/create/cards/status-card.tsx
+++ b/apps/console/src/components/pages/protected/policies/create/cards/status-card.tsx
@@ -54,7 +54,7 @@ const StatusCard: React.FC<TStatusCardProps> = ({ form }) => {
                       field.onChange(value)
                     }}
                   >
-                    <SelectTrigger className="w-full">{statusOptions.find((item) => item.value === field.value)?.label}</SelectTrigger>
+                    <SelectTrigger aria-label="Status" className="w-full">{statusOptions.find((item) => item.value === field.value)?.label}</SelectTrigger>
                     <SelectContent>
                       {statusOptions.map((option) => (
                         <SelectItem key={option.value} value={option.value}>
@@ -84,7 +84,7 @@ const StatusCard: React.FC<TStatusCardProps> = ({ form }) => {
               render={({ field }) => (
                 <>
                   <Select value={String(field.value ?? false)} onValueChange={(value) => field.onChange(value === 'true')}>
-                    <SelectTrigger className="w-full">{String(field.value ?? false)}</SelectTrigger>
+                    <SelectTrigger aria-label="Approval Required" className="w-full">{String(field.value ?? false)}</SelectTrigger>
                     <SelectContent>
                       <SelectItem value="true">True</SelectItem>
                       <SelectItem value="false">False</SelectItem>
@@ -116,7 +116,7 @@ const StatusCard: React.FC<TStatusCardProps> = ({ form }) => {
                       field.onChange(value)
                     }}
                   >
-                    <SelectTrigger className="w-full">{reviewFrequencyOptions.find((item) => item.value === field.value)?.label}</SelectTrigger>
+                    <SelectTrigger aria-label="Reviewing Frequency" className="w-full">{reviewFrequencyOptions.find((item) => item.value === field.value)?.label}</SelectTrigger>
                     <SelectContent>
                       {reviewFrequencyOptions.map((option) => (
                         <SelectItem key={option.value} value={option.value}>

--- a/apps/console/src/components/pages/protected/policies/create/form/create-policy-form.tsx
+++ b/apps/console/src/components/pages/protected/policies/create/form/create-policy-form.tsx
@@ -175,7 +175,7 @@ const CreatePolicyForm: React.FC = () => {
             <div className="flex justify-between items-center">
               <SaveButton disabled={isCreating} title={isCreating ? 'Creating policy' : 'Save Changes'} />
               <div className="flex items-center gap-2">
-                <Switch checked={createMultiple} onCheckedChange={setCreateMultiple} />
+                <Switch aria-label="Create another policy" checked={createMultiple} onCheckedChange={setCreateMultiple} />
                 <span>Create multiple</span>
               </div>
             </div>

--- a/apps/console/src/components/pages/protected/policies/view/cards/properties-card.tsx
+++ b/apps/console/src/components/pages/protected/policies/view/cards/properties-card.tsx
@@ -155,6 +155,7 @@ const PropertiesCard: React.FC<TPropertiesCardProps> = ({ form, policy, isEditin
               }}
             >
               <div
+                data-testid="policy-status-trigger"
                 className="flex items-center space-x-2 w-full text-sm"
                 onDoubleClick={() => {
                   if (!isEditing && editAllowed) {

--- a/apps/console/src/components/pages/protected/policies/view/view-policy-page.tsx
+++ b/apps/console/src/components/pages/protected/policies/view/view-policy-page.tsx
@@ -356,6 +356,7 @@ const ViewPolicyPage: React.FC<TViewPolicyPage> = ({ policyId }) => {
             <></>
           ) : (
             <Menu
+              triggerTestId="policy-actions-menu"
               content={
                 <>
                   {editAllowed && (
@@ -366,7 +367,7 @@ const ViewPolicyPage: React.FC<TViewPolicyPage> = ({ policyId }) => {
                   )}
                   {deleteAllowed && (
                     <>
-                      <Button size="sm" variant="transparent" className="flex justify-start space-x-2" onClick={() => setIsDeleteDialogOpen(true)}>
+                      <Button size="sm" variant="transparent" className="flex justify-start space-x-2" data-testid="policy-delete-button" onClick={() => setIsDeleteDialogOpen(true)}>
                         <Trash2 size={16} strokeWidth={2} />
                         <span>Delete</span>
                       </Button>

--- a/apps/console/src/components/pages/protected/procedures/create/cards/status-card.tsx
+++ b/apps/console/src/components/pages/protected/procedures/create/cards/status-card.tsx
@@ -91,7 +91,9 @@ const StatusCard: React.FC<TStatusCardProps> = ({ form, metadata }) => {
               render={({ field }) => (
                 <>
                   <Select value={String(field.value ?? false)} onValueChange={(value) => field.onChange(value === 'true')}>
-                    <SelectTrigger className="w-full">{String(field.value ?? false)}</SelectTrigger>
+                    <SelectTrigger aria-label="Approval Required" className="w-full">
+                      {String(field.value ?? false)}
+                    </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="true">True</SelectItem>
                       <SelectItem value="false">False</SelectItem>
@@ -125,7 +127,9 @@ const StatusCard: React.FC<TStatusCardProps> = ({ form, metadata }) => {
                       }
                     }}
                   >
-                    <SelectTrigger className="w-full">{reviewFrequencyOptions.find((item) => item.value === field.value)?.label}</SelectTrigger>
+                    <SelectTrigger aria-label="Reviewing Frequency" className="w-full">
+                      {reviewFrequencyOptions.find((item) => item.value === field.value)?.label}
+                    </SelectTrigger>
                     <SelectContent>
                       {reviewFrequencyOptions.map((option) => (
                         <SelectItem key={option.value} value={option.value}>

--- a/apps/console/src/components/pages/protected/procedures/create/cards/tags-card.tsx
+++ b/apps/console/src/components/pages/protected/procedures/create/cards/tags-card.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useMemo } from 'react'
 import { Card } from '@repo/ui/cardpanel'
 import { Tag } from 'lucide-react'
-import { type UseFormReturn } from 'react-hook-form'
+import { useWatch, type UseFormReturn } from 'react-hook-form'
 import { InputRow } from '@repo/ui/input'
 import { FormControl, FormField } from '@repo/ui/form'
 import MultipleSelector, { type Option } from '@repo/ui/multiple-selector'
@@ -18,23 +18,13 @@ type TTagsCardProps = {
 }
 
 const TagsCard: React.FC<TTagsCardProps> = ({ form }) => {
-  const [tagValues, setTagValues] = useState<Option[]>([])
   const { tagOptions } = useGetTags()
   const { data: permission } = useOrganizationRoles()
   const { data: session } = useSession()
   const canCreateTags = canEdit(permission?.roles, session)
 
-  useEffect(() => {
-    if (form.getValues('tags')) {
-      const tags = form.getValues('tags').map((item) => {
-        return {
-          value: item,
-          label: item,
-        } as Option
-      })
-      setTagValues(tags)
-    }
-  }, [form])
+  const tags = useWatch({ control: form.control, name: 'tags' })
+  const tagValues = useMemo<Option[]>(() => (tags ?? []).filter((tag): tag is string => !!tag).map((tag) => ({ value: tag, label: tag })), [tags])
 
   return (
     <Card className="p-4">
@@ -61,18 +51,7 @@ const TagsCard: React.FC<TTagsCardProps> = ({ form }) => {
                         placeholder="Add tag..."
                         creatable={canCreateTags}
                         value={tagValues}
-                        onChange={(selectedOptions) => {
-                          const options = selectedOptions.map((option) => option.value)
-                          field.onChange(options)
-                          setTagValues(
-                            selectedOptions.map((item) => {
-                              return {
-                                value: item.value,
-                                label: item.label,
-                              }
-                            }),
-                          )
-                        }}
+                        onChange={(selectedOptions) => field.onChange(selectedOptions.map((option) => option.value))}
                       />
                     </FormControl>
                     {form.formState.errors.tags && <p className="text-red-500 text-sm">{form.formState.errors.tags.message}</p>}

--- a/apps/console/src/components/pages/protected/procedures/create/form/create-procedure-form.tsx
+++ b/apps/console/src/components/pages/protected/procedures/create/form/create-procedure-form.tsx
@@ -106,6 +106,8 @@ const CreateProcedureForm: React.FC<TCreateProcedureFormProps> = ({ procedure })
       procedureKindName: procedure.procedureKindName ?? '',
       reviewDue: procedure.reviewDue ? new Date(procedure.reviewDue as string) : undefined,
       reviewFrequency: procedure.reviewFrequency ?? ProcedureFrequency.YEARLY,
+      approverID: procedure.approver?.id ?? undefined,
+      delegateID: procedure.delegate?.id ?? undefined,
       ...procedureAssociations,
     })
 
@@ -297,14 +299,14 @@ const CreateProcedureForm: React.FC<TCreateProcedureFormProps> = ({ procedure })
             <div className="flex justify-between items-center">
               <SaveButton disabled={isSubmitting} title={isSubmitting ? (isEditable ? 'Saving' : 'Creating procedure') : isEditable ? 'Save' : 'Save Procedure'} />
               <div className="flex items-center gap-2">
-                <Switch checked={createMultiple} onCheckedChange={setCreateMultiple} />
+                <Switch aria-label="Create another procedure" checked={createMultiple} onCheckedChange={setCreateMultiple} />
                 <span>Create multiple</span>
               </div>
             </div>
           </div>
 
           <div className="shrink-0 w-[380px] space-y-4">
-            <AuthorityCard form={form} isEditing={true} inputClassName="w-[162px]" editAllowed={true} isCreate={true} />
+            <AuthorityCard form={form} isEditing={true} inputClassName="w-[162px]" editAllowed={true} isCreate={true} approver={procedure?.approver} delegate={procedure?.delegate} />
             <StatusCard form={form} metadata={metadata} />
             <TagsCard form={form} />
           </div>

--- a/apps/console/src/components/pages/protected/procedures/view/cards/properties-card.tsx
+++ b/apps/console/src/components/pages/protected/procedures/view/cards/properties-card.tsx
@@ -134,6 +134,7 @@ const PropertiesCard: React.FC<TPropertiesCardProps> = ({ form, procedure, isEdi
             />
           ) : (
             <div
+              data-testid="procedure-status-trigger"
               className={`flex items-center space-x-2 text-sm ${editAllowed ? 'cursor-pointer' : 'cursor-not-allowed'}`}
               onClick={() => {
                 if (!isEditing && editAllowed) setEditingField('status')

--- a/apps/console/src/components/pages/protected/procedures/view/view-procedure-page.tsx
+++ b/apps/console/src/components/pages/protected/procedures/view/view-procedure-page.tsx
@@ -257,6 +257,7 @@ const ViewProcedurePage: React.FC = () => {
             <></>
           ) : (
             <Menu
+              triggerTestId="procedure-actions-menu"
               content={
                 <>
                   {editAllowed && (
@@ -267,7 +268,7 @@ const ViewProcedurePage: React.FC = () => {
                   )}
                   {deleteAllowed && (
                     <>
-                      <Button size="sm" variant="transparent" className="flex justify-start space-x-2 " onClick={() => setIsDeleteDialogOpen(true)}>
+                      <Button size="sm" variant="transparent" className="flex justify-start space-x-2 " data-testid="procedure-delete-button" onClick={() => setIsDeleteDialogOpen(true)}>
                         <Trash2 size={16} strokeWidth={2} />
                         <span>Delete</span>
                       </Button>

--- a/apps/console/src/components/pages/protected/profile/user-settings/profile-name-form.tsx
+++ b/apps/console/src/components/pages/protected/profile/user-settings/profile-name-form.tsx
@@ -7,7 +7,7 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Form, FormItem, FormField, FormControl, FormMessage, FormLabel } from '@repo/ui/form'
 import { z } from 'zod'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { RESET_SUCCESS_STATE_MS } from '@/constants'
 import { useNotification } from '@/hooks/useNotification'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@repo/ui/tooltip'
@@ -18,6 +18,7 @@ import { SaveButton } from '@/components/shared/save-button/save-button'
 
 const ProfileNameForm = () => {
   const [isSuccess, setIsSuccess] = useState(false)
+  const hydratedRef = useRef(false)
   const { isPending: isSubmitting, mutateAsync: updateUserName } = useUpdateUser()
   const { successNotification, errorNotification } = useNotification()
 
@@ -74,14 +75,15 @@ const ProfileNameForm = () => {
   }
 
   useEffect(() => {
-    if (userData) {
-      form.reset({
-        firstName: userData.user.firstName ?? '',
-        lastName: userData.user.lastName ?? '',
-        displayName: userData?.user.displayName ?? '',
-        email: userData?.user.email ?? '',
-      })
-    }
+    if (!userData || hydratedRef.current || form.formState.isDirty) return
+
+    hydratedRef.current = true
+    form.reset({
+      firstName: userData.user.firstName ?? '',
+      lastName: userData.user.lastName ?? '',
+      displayName: userData.user.displayName ?? '',
+      email: userData.user.email ?? '',
+    })
   }, [userData, form])
 
   useEffect(() => {

--- a/apps/console/src/components/pages/protected/programs/[id]/settings/users/program-settings-users.tsx
+++ b/apps/console/src/components/pages/protected/programs/[id]/settings/users/program-settings-users.tsx
@@ -166,7 +166,7 @@ export const ProgramSettingsUsers = () => {
               return (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button variant="secondary" className="w-8 h-7 !p-0">
+                    <Button variant="secondary" aria-label="Program member actions" className="w-8 h-7 !p-0">
                       <EllipsisVertical />
                     </Button>
                   </DropdownMenuTrigger>

--- a/apps/console/src/components/pages/protected/questionnaire/template/table/columns.tsx
+++ b/apps/console/src/components/pages/protected/questionnaire/template/table/columns.tsx
@@ -150,7 +150,7 @@ export const getTemplateColumns = (params?: Params) => {
           <div onClick={(e) => e.stopPropagation()} className="flex justify-end">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="secondary">
+                <Button variant="secondary" aria-label="Row actions">
                   <MoreHorizontal className="h-4 w-4 text-brand" />
                 </Button>
               </DropdownMenuTrigger>

--- a/apps/console/src/components/pages/protected/questionnaire/template/table/table-config.ts
+++ b/apps/console/src/components/pages/protected/questionnaire/template/table/table-config.ts
@@ -14,11 +14,11 @@ const TemplateFilterIcons = {
 
 export function useTemplateFilters(): FilterField[] | undefined {
   const { data: environmentData, isSuccess: isEnvironmentSuccess } = useGetCustomTypeEnums({
-    where: { objectType: null, field: 'environment' },
+    where: { objectType: 'global', field: 'environment' },
   })
 
   const { data: scopeData, isSuccess: isScopeSuccess } = useGetCustomTypeEnums({
-    where: { objectType: null, field: 'scope' },
+    where: { objectType: 'global', field: 'scope' },
   })
 
   return useMemo(() => {

--- a/apps/console/src/components/pages/protected/questionnaire/template/table/table-config.ts
+++ b/apps/console/src/components/pages/protected/questionnaire/template/table/table-config.ts
@@ -14,11 +14,11 @@ const TemplateFilterIcons = {
 
 export function useTemplateFilters(): FilterField[] | undefined {
   const { data: environmentData, isSuccess: isEnvironmentSuccess } = useGetCustomTypeEnums({
-    where: { objectType: 'global', field: 'environment' },
+    where: { objectType: null, field: 'environment' },
   })
 
   const { data: scopeData, isSuccess: isScopeSuccess } = useGetCustomTypeEnums({
-    where: { objectType: 'global', field: 'scope' },
+    where: { objectType: null, field: 'scope' },
   })
 
   return useMemo(() => {

--- a/apps/console/src/components/pages/protected/risks/view/detail/risk-detail-header.tsx
+++ b/apps/console/src/components/pages/protected/risks/view/detail/risk-detail-header.tsx
@@ -123,12 +123,12 @@ const RiskDetailHeader: React.FC<RiskDetailHeaderProps> = ({ risk, isEditing, ca
               {canDeleteRisk && (
                 <Menu
                   trigger={
-                    <Button type="button" variant="secondary" className="h-8 px-2">
+                    <Button type="button" variant="secondary" className="h-8 px-2" data-testid="risk-actions-menu">
                       <MoreHorizontal size={16} />
                     </Button>
                   }
                   content={
-                    <button onClick={onDeleteClick} className="flex items-center space-x-2 px-1 bg-transparent cursor-pointer text-destructive">
+                    <button onClick={onDeleteClick} data-testid="risk-delete-button" className="flex items-center space-x-2 px-1 bg-transparent cursor-pointer text-destructive">
                       <Trash2 size={16} strokeWidth={2} />
                       <span>Delete</span>
                     </button>

--- a/apps/console/src/components/pages/protected/standards/standard-details-accordion.tsx
+++ b/apps/console/src/components/pages/protected/standards/standard-details-accordion.tsx
@@ -175,7 +175,7 @@ const StandardDetailsAccordion: React.FC<TStandardDetailsAccordionProps> = ({
         <div className="flex gap-2.5 items-center justify-between right-0 mt-2">
           <div className="flex col gap-2.5 items-center justify-between">
             <p className="">Domains</p>
-            <Button type="button" className="h-8 !px-2" variant="secondary" onClick={toggleAllSections}>
+            <Button type="button" aria-label="Expand or collapse all domains" className="h-8 !px-2" variant="secondary" onClick={toggleAllSections}>
               <div className="flex">
                 <List size={16} />
                 <ChevronsDownUp size={16} />

--- a/apps/console/src/components/pages/protected/trust-center/faqs/sortable-faq-card.tsx
+++ b/apps/console/src/components/pages/protected/trust-center/faqs/sortable-faq-card.tsx
@@ -56,7 +56,7 @@ export function SortableFaqCard({ faq, isEditing, editingId, onStartEdit, onDele
             </div>
           ) : (
             <div className="flex gap-3">
-              <button className="cursor-grab touch-none text-muted-foreground hover:text-foreground shrink-0 mt-1" {...attributes} {...listeners}>
+              <button aria-label="Reorder FAQ" className="cursor-grab touch-none text-muted-foreground hover:text-foreground shrink-0 mt-1" {...attributes} {...listeners}>
                 <GripVertical size={16} />
               </button>
               <div className="flex flex-col flex-1 min-w-0">
@@ -71,12 +71,12 @@ export function SortableFaqCard({ faq, isEditing, editingId, onStartEdit, onDele
                 <div className="flex justify-end mt-1">
                   <div className="flex gap-3">
                     {canEdit && (
-                      <button className="text-muted-foreground" onClick={() => onStartEdit(faq)} disabled={!!editingId}>
+                      <button aria-label="Edit FAQ" className="text-muted-foreground" onClick={() => onStartEdit(faq)} disabled={!!editingId}>
                         <Pencil size={16} />
                       </button>
                     )}
                     {canEdit && (
-                      <button className="text-muted-foreground" onClick={() => onDelete(faq.id)} disabled={!!editingId}>
+                      <button aria-label="Delete FAQ" className="text-muted-foreground" onClick={() => onDelete(faq.id)} disabled={!!editingId}>
                         <Trash2 size={16} />
                       </button>
                     )}

--- a/apps/console/src/components/pages/protected/trust-center/reports-and-certifications/sheet/create-document.sheet.tsx
+++ b/apps/console/src/components/pages/protected/trust-center/reports-and-certifications/sheet/create-document.sheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@repo/ui/button'
 import { Copy, PanelRightClose, Pencil, Save, Trash2 } from 'lucide-react'
 import { FormProvider, useForm, useWatch } from 'react-hook-form'
@@ -68,6 +68,7 @@ export const CreateDocumentSheet: React.FC = () => {
   const isDeleteAllowed = canDelete(permission?.roles)
 
   const [isEditing, setIsEditing] = useState(false)
+  const prefilledDocumentRef = useRef<string | null>(null)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [uploadedFile, setUploadedFile] = useState<File | null>(null)
   const [open, setOpen] = useState(isCreateMode || !!documentId)
@@ -136,7 +137,7 @@ export const CreateDocumentSheet: React.FC = () => {
             trustCenterDocKindName: data.category,
             visibility: data.visibility,
             tags: data.tags ?? [],
-            ...(data.standardID != null ? { standardID: data.standardID } : { clearStandard: true }),
+            ...(data.standardID ? { standardID: data.standardID } : { clearStandard: true }),
           },
           updateTrustCenterDocId: documentId ?? '',
           trustCenterDocFile: data.file,
@@ -157,7 +158,7 @@ export const CreateDocumentSheet: React.FC = () => {
             tags: data.tags ?? [],
             trustCenterID,
             watermarkingEnabled: isWatermarkEnabled,
-            standardID: data.standardID,
+            standardID: data.standardID || undefined,
           },
           trustCenterDocFile: data.file,
         })
@@ -213,8 +214,12 @@ export const CreateDocumentSheet: React.FC = () => {
 
   useEffect(() => {
     if (isEditMode && documentData?.trustCenterDoc) {
+      if (prefilledDocumentRef.current === documentId) return
+
+      prefilledDocumentRef.current = documentId
       prefillForm()
     } else if (!isEditMode) {
+      prefilledDocumentRef.current = null
       reset({
         title: '',
         category: '',
@@ -223,7 +228,7 @@ export const CreateDocumentSheet: React.FC = () => {
         file: undefined,
       })
     }
-  }, [isEditMode, documentData, reset, open, prefillForm])
+  }, [isEditMode, documentData, documentId, reset, prefillForm])
 
   useEffect(() => {
     if (documentId || isCreateMode) setOpen(true)

--- a/apps/console/src/components/pages/protected/trust-center/updates/updates-page.tsx
+++ b/apps/console/src/components/pages/protected/trust-center/updates/updates-page.tsx
@@ -152,6 +152,7 @@ export default function UpdatesSection() {
                       <FormControl>
                         <Input placeholder="Add a title" className="bg-background" {...field} />
                       </FormControl>
+                      {createForm.formState.errors.title && <p className="text-red-500 text-sm">{createForm.formState.errors.title.message}</p>}
                     </FormItem>
                   )}
                 />
@@ -165,6 +166,7 @@ export default function UpdatesSection() {
                       <FormControl>
                         <Textarea placeholder="Write an update..." className="min-h-30 bg-background" {...field} />
                       </FormControl>
+                      {createForm.formState.errors.text && <p className="text-red-500 text-sm">{createForm.formState.errors.text.message}</p>}
                     </FormItem>
                   )}
                 />
@@ -221,8 +223,10 @@ export default function UpdatesSection() {
                         <div className="space-y-3">
                           <Label>Title</Label>
                           <Input autoFocus className="bg-background text-sm" {...editForm.register('title')} />
+                          {editForm.formState.errors.title && <p className="text-red-500 text-sm">{editForm.formState.errors.title.message}</p>}
                           <Label>Description</Label>
                           <Textarea autoFocus className="min-h-25 bg-background text-sm" {...editForm.register('text')} />
+                          {editForm.formState.errors.text && <p className="text-red-500 text-sm">{editForm.formState.errors.text.message}</p>}
                           <div className="flex items-center justify-between">
                             <div className="flex items-center gap-2 text-xs text-muted-foreground">
                               <Keyboard size={16} />
@@ -242,12 +246,12 @@ export default function UpdatesSection() {
                             <p className="text-muted-foreground text-sm">{formatDate(post.updatedAt)}</p>
                             <div className="flex gap-3">
                               {canEditTc && (
-                                <button className="text-muted-foreground" onClick={() => startEditing(post.id, post.text, post.title ?? '')} disabled={!!editingPostId}>
+                                <button aria-label="Edit update" className="text-muted-foreground" onClick={() => startEditing(post.id, post.text, post.title ?? '')} disabled={!!editingPostId}>
                                   <Pencil size={16} />
                                 </button>
                               )}
                               {canEditTc && (
-                                <button className="text-muted-foreground " onClick={() => setPostToDelete(post.id)} disabled={!!editingPostId}>
+                                <button aria-label="Delete update" className="text-muted-foreground " onClick={() => setPostToDelete(post.id)} disabled={!!editingPostId}>
                                   <Trash2 size={16} />
                                 </button>
                               )}

--- a/apps/console/src/components/pages/protected/user-management/members/actions/invite-actions.tsx
+++ b/apps/console/src/components/pages/protected/user-management/members/actions/invite-actions.tsx
@@ -66,7 +66,7 @@ export const InviteActions = ({ inviteId, recipient, role }: InviteActionsProps)
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="secondary" className="-mr-2">
+        <Button variant="secondary" className="-mr-2" data-testid="invite-actions-trigger">
           <MoreHorizontal className="h-4 w-4 text-brand" />
         </Button>
       </DropdownMenuTrigger>

--- a/apps/console/src/components/pages/protected/user-management/members/actions/member-actions.tsx
+++ b/apps/console/src/components/pages/protected/user-management/members/actions/member-actions.tsx
@@ -213,7 +213,7 @@ export const MemberActions = ({ memberId, memberUserId, memberRole, memberName, 
     <>
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
-          <Button variant="secondary" className="-mr-2">
+          <Button variant="secondary" className="-mr-2" data-testid="member-actions-trigger">
             <MoreHorizontal className="h-4 w-4 text-brand" />
           </Button>
         </DropdownMenuTrigger>

--- a/apps/console/src/components/pages/protected/vendors/detail/vendor-detail-header.tsx
+++ b/apps/console/src/components/pages/protected/vendors/detail/vendor-detail-header.tsx
@@ -181,7 +181,7 @@ const VendorDetailHeader: React.FC<VendorDetailHeaderProps> = ({ vendor, isEditi
               {showMenu && (
                 <Menu
                   trigger={
-                    <Button type="button" variant="secondary" className="h-8 px-2">
+                    <Button type="button" variant="secondary" className="h-8 px-2" aria-label="Vendor actions">
                       <MoreHorizontal size={16} />
                     </Button>
                   }

--- a/apps/console/src/components/pages/protected/vendors/hooks/use-form-schema.ts
+++ b/apps/console/src/components/pages/protected/vendors/hooks/use-form-schema.ts
@@ -83,6 +83,7 @@ const useFormSchema = () => {
     form: useForm<EditVendorFormData>({
       resolver: zodResolver(formSchema),
       defaultValues: {
+        name: '',
         spendCurrency: 'USD',
         billingModel: 'Monthly',
       },

--- a/apps/console/src/components/pages/protected/workflows/workflow-editor.tsx
+++ b/apps/console/src/components/pages/protected/workflows/workflow-editor.tsx
@@ -233,11 +233,11 @@ export default function WorkflowEditor() {
         <CardContent className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label>Name</Label>
-              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Control approval workflow" />
+              <Label htmlFor="workflow-name">Name</Label>
+              <Input id="workflow-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Control approval workflow" />
             </div>
             <div className="space-y-2">
-              <Label>Schema Type</Label>
+              <Label htmlFor="workflow-schema-type">Schema Type</Label>
               <Select
                 value={schemaType}
                 onValueChange={(val) => {
@@ -246,7 +246,7 @@ export default function WorkflowEditor() {
                 }}
                 disabled={isLoadingMetadata}
               >
-                <SelectTrigger>
+                <SelectTrigger id="workflow-schema-type">
                   <SelectValue placeholder={isLoadingMetadata ? 'Loading types...' : 'Select object type'} />
                 </SelectTrigger>
                 <SelectContent>
@@ -261,8 +261,8 @@ export default function WorkflowEditor() {
           </div>
 
           <div className="space-y-2">
-            <Label>Description</Label>
-            <Textarea value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Describe what this workflow does" rows={3} />
+            <Label htmlFor="workflow-description">Description</Label>
+            <Textarea id="workflow-description" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Describe what this workflow does" rows={3} />
           </div>
         </CardContent>
       </Card>
@@ -273,9 +273,9 @@ export default function WorkflowEditor() {
         </CardHeader>
         <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="space-y-2">
-            <Label>Workflow Kind</Label>
+            <Label htmlFor="workflow-kind">Workflow Kind</Label>
             <Select value={workflowKind} onValueChange={(val) => setWorkflowKind(val as WorkflowDefinitionWorkflowKind)}>
-              <SelectTrigger>
+              <SelectTrigger id="workflow-kind">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -290,9 +290,9 @@ export default function WorkflowEditor() {
 
           {workflowKind === WorkflowDefinitionWorkflowKind.APPROVAL && (
             <div className="space-y-2">
-              <Label>Approval timing</Label>
+              <Label htmlFor="workflow-approval-timing">Approval timing</Label>
               <Select value={approvalTiming} onValueChange={(val) => setApprovalTiming(val as ApprovalTiming)}>
-                <SelectTrigger>
+                <SelectTrigger id="workflow-approval-timing">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -305,23 +305,23 @@ export default function WorkflowEditor() {
           )}
 
           <div className="space-y-2">
-            <Label>Cooldown (seconds)</Label>
-            <Input type="number" min="0" value={cooldownSeconds} onChange={(e) => setCooldownSeconds(Number(e.target.value) || 0)} />
+            <Label htmlFor="workflow-cooldown-seconds">Cooldown (seconds)</Label>
+            <Input id="workflow-cooldown-seconds" type="number" min="0" value={cooldownSeconds} onChange={(e) => setCooldownSeconds(Number(e.target.value) || 0)} />
           </div>
 
           <div className="flex items-center justify-between">
-            <Label>Active</Label>
-            <Switch checked={active} onCheckedChange={setActive} />
+            <Label htmlFor="workflow-active">Active</Label>
+            <Switch id="workflow-active" checked={active} onCheckedChange={setActive} />
           </div>
 
           <div className="flex items-center justify-between">
-            <Label>Draft</Label>
-            <Switch checked={draft} onCheckedChange={setDraft} />
+            <Label htmlFor="workflow-draft">Draft</Label>
+            <Switch id="workflow-draft" checked={draft} onCheckedChange={setDraft} />
           </div>
 
           <div className="flex items-center justify-between">
-            <Label>Default for schema</Label>
-            <Switch checked={isDefault} onCheckedChange={setIsDefault} />
+            <Label htmlFor="workflow-default">Default for schema</Label>
+            <Switch id="workflow-default" checked={isDefault} onCheckedChange={setIsDefault} />
           </div>
         </CardContent>
       </Card>

--- a/apps/console/src/components/shared/column-visibility-menu/column-visibility-menu.tsx
+++ b/apps/console/src/components/shared/column-visibility-menu/column-visibility-menu.tsx
@@ -61,6 +61,7 @@ const ColumnVisibilityMenu: React.FC<TColumnVisibilityMenuProps> = ({ mappedColu
           .map((column) => (
             <div key={column.accessorKey} className="flex items-center gap-x-3 p-1">
               <Checkbox
+                aria-label={column.header}
                 className="capitalize h-4 w-4 text-sm"
                 stroke={2}
                 checked={columnVisibility[column.accessorKey] !== false}

--- a/apps/console/src/components/shared/comments/CommentList.tsx
+++ b/apps/console/src/components/shared/comments/CommentList.tsx
@@ -75,12 +75,13 @@ const CommentList: React.FC<CommentListProps> = ({ comments, onEdit, onRemove, s
                   {isOwner && !isEditing && (onEdit || onRemove) && (
                     <div className="flex gap-2">
                       {onEdit && (
-                        <button onClick={() => handleEditClick(item)} className="hover:text-btn-secondary bg-unset">
+                        <button aria-label="Edit comment" onClick={() => handleEditClick(item)} className="hover:text-btn-secondary bg-unset">
                           <Pencil className="h-4 w-4" />
                         </button>
                       )}
                       {onRemove && (
                         <button
+                          aria-label="Delete comment"
                           onClick={() => {
                             setCommentToDelete(item)
                             setDeleteDialogOpen(true)
@@ -95,10 +96,10 @@ const CommentList: React.FC<CommentListProps> = ({ comments, onEdit, onRemove, s
 
                   {isOwner && isEditing && (
                     <div className="flex gap-2">
-                      <button onClick={() => handleSaveEdit(item)}>
+                      <button aria-label="Save comment" onClick={() => handleSaveEdit(item)}>
                         <Check className="h-4 w-4 text-brand" />
                       </button>
-                      <button onClick={handleCancelEdit}>
+                      <button aria-label="Cancel comment edit" onClick={handleCancelEdit}>
                         <X size={16} />
                       </button>
                     </div>

--- a/apps/console/src/components/shared/crud-base/columns/row-actions-column.tsx
+++ b/apps/console/src/components/shared/crud-base/columns/row-actions-column.tsx
@@ -15,9 +15,10 @@ type RowAction<T> = {
 
 type RowActionsColumnOptions<T> = {
   actions: RowAction<T>[]
+  label?: string
 }
 
-export function createRowActionsColumn<T>({ actions }: RowActionsColumnOptions<T>): ColumnDef<T> {
+export function createRowActionsColumn<T>({ actions, label = 'Row actions' }: RowActionsColumnOptions<T>): ColumnDef<T> {
   return {
     id: 'actions',
     header: '',
@@ -26,7 +27,7 @@ export function createRowActionsColumn<T>({ actions }: RowActionsColumnOptions<T
       <div onClick={(e) => e.stopPropagation()} className="flex justify-end">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="secondary" className="h-8 w-8 p-0">
+            <Button variant="secondary" aria-label={label} className="h-8 w-8 p-0">
               <MoreHorizontal className="h-4 w-4" />
             </Button>
           </DropdownMenuTrigger>

--- a/apps/console/src/components/shared/crud-base/columns/select-column.tsx
+++ b/apps/console/src/components/shared/crud-base/columns/select-column.tsx
@@ -22,6 +22,7 @@ function buildSelectColumn<T extends { id: string }>(
       return (
         <div onClick={(e) => e.stopPropagation()}>
           <Checkbox
+            aria-label="Select all rows on this page"
             checked={allSelected}
             onCheckedChange={(checked: boolean) => {
               const newSelections = checked
@@ -45,6 +46,7 @@ function buildSelectColumn<T extends { id: string }>(
       return (
         <div onClick={(e) => e.stopPropagation()}>
           <Checkbox
+            aria-label="Select row"
             checked={isChecked}
             onCheckedChange={() => {
               setSelectedItems((prev) => {

--- a/apps/console/src/components/shared/domain-list-editor/domain-list-editor.tsx
+++ b/apps/console/src/components/shared/domain-list-editor/domain-list-editor.tsx
@@ -12,6 +12,7 @@ type DomainListEditorProps = {
   error?: string | null
   isPending?: boolean
   placeholder?: string
+  inputLabel?: string
   addLabel?: string
   addOnEnter?: boolean
 }
@@ -25,6 +26,7 @@ export const DomainListEditor = ({
   error,
   isPending,
   placeholder = 'example.com',
+  inputLabel = 'Domain',
   addLabel = 'Add',
   addOnEnter = false,
 }: DomainListEditorProps) => {
@@ -33,6 +35,7 @@ export const DomainListEditor = ({
       <div className="flex items-center gap-2">
         <Input
           variant="medium"
+          aria-label={inputLabel}
           placeholder={placeholder}
           value={newDomain}
           onChange={(e) => onNewDomainChange(e.target.value)}
@@ -59,7 +62,7 @@ export const DomainListEditor = ({
           {domains.map((domain) => (
             <div key={domain} className="flex items-center gap-1 bg-btn-secondary px-2 py-0.5 rounded-sm border border-muted text-sm font-mono">
               {domain}
-              <button type="button" disabled={isPending} onClick={() => onRemove(domain)} className="ml-1">
+              <button type="button" aria-label={`Remove ${domain}`} disabled={isPending} onClick={() => onRemove(domain)} className="ml-1">
                 <Trash2 size={12} className="text-muted-foreground hover:text-destructive" />
               </button>
             </div>

--- a/apps/console/src/components/shared/domain-list-editor/domain-list-editor.tsx
+++ b/apps/console/src/components/shared/domain-list-editor/domain-list-editor.tsx
@@ -7,8 +7,8 @@ type DomainListEditorProps = {
   domains: string[]
   newDomain: string
   onNewDomainChange: (value: string) => void
-  onAdd: () => void
-  onRemove: (domain: string) => void
+  onAdd?: () => void
+  onRemove?: (domain: string) => void
   error?: string | null
   isPending?: boolean
   placeholder?: string
@@ -44,15 +44,17 @@ export const DomainListEditor = ({
               ? (e) => {
                   if (e.key === 'Enter') {
                     e.preventDefault()
-                    onAdd()
+                    onAdd?.()
                   }
                 }
               : undefined
           }
         />
-        <Button type="button" variant="secondary" icon={<Plus />} iconPosition="left" loading={isPending} onClick={onAdd}>
-          {addLabel}
-        </Button>
+        {onAdd && (
+          <Button type="button" variant="secondary" icon={<Plus />} iconPosition="left" loading={isPending} onClick={onAdd}>
+            {addLabel}
+          </Button>
+        )}
       </div>
 
       {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
@@ -62,9 +64,11 @@ export const DomainListEditor = ({
           {domains.map((domain) => (
             <div key={domain} className="flex items-center gap-1 bg-btn-secondary px-2 py-0.5 rounded-sm border border-muted text-sm font-mono">
               {domain}
-              <button type="button" aria-label={`Remove ${domain}`} disabled={isPending} onClick={() => onRemove(domain)} className="ml-1">
-                <Trash2 size={12} className="text-muted-foreground hover:text-destructive" />
-              </button>
+              {onRemove && (
+                <button type="button" aria-label={`Remove ${domain}`} disabled={isPending} onClick={() => onRemove(domain)} className="ml-1">
+                  <Trash2 size={12} className="text-muted-foreground hover:text-destructive" />
+                </button>
+              )}
             </div>
           ))}
         </div>

--- a/apps/console/src/components/shared/file-upload/file-upload.tsx
+++ b/apps/console/src/components/shared/file-upload/file-upload.tsx
@@ -13,6 +13,7 @@ type TProps = {
   acceptedFileTypesShort: string[]
   multipleFiles: boolean
   acceptedFilesClass?: string
+  inputLabel?: string
   note?: string
 }
 
@@ -101,7 +102,7 @@ const FileUpload: React.FC<TProps> = (props: TProps) => {
           'border-primary bg-muted/50 ring-1 ring-primary/30': isDragActive,
         })}
       >
-        <input {...getInputProps()} />
+        <input {...getInputProps()} aria-label={props.inputLabel ?? `Upload ${props.acceptedFileTypesShort.join(', ')} file`} />
 
         <div className="flex flex-col items-center gap-3">
           <div className="w-14 h-14 rounded-md bg-border border border-muted flex items-center justify-center">

--- a/apps/console/src/components/shared/menu/menu.tsx
+++ b/apps/console/src/components/shared/menu/menu.tsx
@@ -12,9 +12,10 @@ interface MenuProps {
   side?: 'top' | 'right' | 'bottom' | 'left'
   closeOnSelect?: boolean
   className?: string
+  triggerTestId?: string
 }
 
-const Menu: React.FC<MenuProps> = ({ trigger, content, extraContent, align, side, closeOnSelect, className }) => {
+const Menu: React.FC<MenuProps> = ({ trigger, content, extraContent, align, side, closeOnSelect, className, triggerTestId }) => {
   const [open, setOpen] = useState(false)
 
   const handleClose = () => {
@@ -29,7 +30,9 @@ const Menu: React.FC<MenuProps> = ({ trigger, content, extraContent, align, side
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>{trigger ?? <Button variant="secondary" descriptiveTooltipText="Action" className="h-8 !px-2 !pl-0 " icon={<Ellipsis size={16} />} />}</DropdownMenuTrigger>
+      <DropdownMenuTrigger asChild>
+        {trigger ?? <Button variant="secondary" descriptiveTooltipText="Action" className="h-8 !px-2 !pl-0 " icon={<Ellipsis size={16} />} data-testid={triggerTestId} />}
+      </DropdownMenuTrigger>
       <DropdownMenuContent className={cn('border shadow-md p-0 ', className)} align={align ?? 'end'} side={side ?? undefined}>
         <div className="flex flex-col space-y-2 px-3 py-3">{renderContent(content)}</div>
         {extraContent && (

--- a/apps/console/src/components/shared/object-association/object-association-switch.tsx
+++ b/apps/console/src/components/shared/object-association/object-association-switch.tsx
@@ -76,7 +76,11 @@ const ObjectAssociationSwitch: React.FC<TObjectAssociationSwitchProps> = ({ sect
                 <TooltipProvider delayDuration={100}>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <div onClick={() => setIsGraphView((prevState) => !prevState)} className="flex items-center p-1 bg-background border rounded-lg cursor-pointer overflow-hidden">
+                      <div
+                        data-testid="assoc-view-toggle"
+                        onClick={() => setIsGraphView((prevState) => !prevState)}
+                        className="flex items-center p-1 bg-background border rounded-lg cursor-pointer overflow-hidden"
+                      >
                         <Button type="button" variant={!isGraphView ? 'transparent' : 'secondary'} size="sm" className="mr-1 h-6" style={{ boxShadow: 'none', outline: 'none', border: 'none' }}>
                           <Waypoints size={14} />
                         </Button>

--- a/apps/console/src/components/shared/objects-chip/objects-chip.tsx
+++ b/apps/console/src/components/shared/objects-chip/objects-chip.tsx
@@ -20,6 +20,7 @@ const ObjectsChip = ({ name, objectType, removable, onRemove, onClick }: TObject
       {removable && onRemove && (
         <button
           type="button"
+          data-testid="objects-chip-remove"
           aria-label={`Remove ${name}`}
           className="cursor-pointer ml-1 bg-transparent"
           onClick={(e) => {

--- a/apps/console/src/components/shared/organization-selector/organization-selector.tsx
+++ b/apps/console/src/components/shared/organization-selector/organization-selector.tsx
@@ -105,7 +105,7 @@ export const OrganizationSelector = ({ expanded }: { expanded: boolean }) => {
     <div className={expanded ? 'w-full px-3' : ''}>
       <div>
         <Popover onOpenChange={setIsPopoverOpened} open={isPopoverOpened}>
-          <PopoverTrigger className="bg-unset w-full">
+          <PopoverTrigger className="bg-unset w-full" data-testid="org-selector-trigger">
             {expanded ? (
               <div className="flex items-center justify-between w-full  py-1 rounded-md hover:bg-card transition-colors">
                 <div className="flex items-center gap-2 min-w-0">

--- a/apps/console/src/components/shared/plate/plate-editor.tsx
+++ b/apps/console/src/components/shared/plate/plate-editor.tsx
@@ -29,6 +29,7 @@ export type TPlateEditorProps = {
   clearData?: boolean
   onClear?: () => void
   placeholder?: string
+  ariaLabel?: string
   entity?: PolicyDiscussionFieldsFragment | ProcedureDiscussionFieldsFragment | RiskDiscussionFieldsFragment | SubcontrolDiscussionFieldsFragment | ControlDiscussionFieldsFragment
   userData?: GetUserProfileQuery
   readonly?: boolean
@@ -52,6 +53,7 @@ const PlateEditor = ({
   clearData,
   onClear,
   placeholder,
+  ariaLabel,
   entity,
   userData,
   readonly,
@@ -256,7 +258,7 @@ const PlateEditor = ({
           editor?.focus()
         }}
       >
-        <Editor placeholder={placeholder ?? 'Type a paragraph'} variant={readonly ? 'readonly' : undefined} />
+        <Editor aria-label={ariaLabel ?? placeholder ?? 'Rich text editor'} placeholder={placeholder ?? 'Type a paragraph'} variant={readonly ? 'readonly' : undefined} />
       </EditorContainer>
     </Plate>
   )

--- a/apps/console/src/components/shared/table-filter/table-filter.tsx
+++ b/apps/console/src/components/shared/table-filter/table-filter.tsx
@@ -381,7 +381,7 @@ const TableFilterComponent: React.FC<TTableFilterProps> = ({
               {field.options?.length ? (
                 field.options.map((opt) => (
                   <li key={opt.value} className="flex items-center gap-2 px-3 py-1.5 hover:bg-muted cursor-pointer text-sm" onClick={() => handleToggle(opt.value)}>
-                    <Checkbox checked={selected.includes(opt.value)} className="accent-primary" />
+                    <Checkbox aria-label={opt.label} checked={selected.includes(opt.value)} className="accent-primary" />
                     <span>{opt.label}</span>
                   </li>
                 ))
@@ -396,12 +396,19 @@ const TableFilterComponent: React.FC<TTableFilterProps> = ({
 
         case 'radio':
           return (
-            <div className="flex flex-col gap-1">
+            <div role="radiogroup" aria-label={field.label} className="flex flex-col gap-1">
               {field.radioOptions?.map((opt) => (
-                <label key={String(opt.value)} className={cn('flex items-center gap-2 rounded-md cursor-pointer text-sm transition-colors')} onClick={() => handleChange(field.key, opt.value)}>
+                <button
+                  key={String(opt.value)}
+                  type="button"
+                  role="radio"
+                  aria-checked={val === opt.value}
+                  className={cn('flex items-center gap-2 rounded-md cursor-pointer text-sm transition-colors bg-transparent text-left')}
+                  onClick={() => handleChange(field.key, opt.value)}
+                >
                   <div className="relative flex h-4 w-4 items-center justify-center rounded-full border border-primary">{val === opt.value && <div className="h-2 w-2 rounded-full bg-primary" />}</div>
                   {opt.label}
-                </label>
+                </button>
               ))}
             </div>
           )

--- a/apps/console/src/components/shared/user-menu/user-menu.tsx
+++ b/apps/console/src/components/shared/user-menu/user-menu.tsx
@@ -38,7 +38,7 @@ export const UserMenu = ({ open, onOpenChange }: UserMenuProps) => {
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
-        <div className={trigger()}>
+        <div className={trigger()} data-testid="user-menu-trigger">
           <Avatar entity={data?.user as User}></Avatar>
         </div>
       </DropdownMenuTrigger>

--- a/packages/ui/src/pagination/pagination.tsx
+++ b/packages/ui/src/pagination/pagination.tsx
@@ -20,9 +20,9 @@ const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, pageSi
   return (
     <div className="flex items-center justify-between p-4">
       <div className="flex items-center gap-2 text-sm">
-        <span>Rows per page</span>
+        <span id="rows-per-page-label">Rows per page</span>
         <Select value={pageSize.toString()} onValueChange={(val) => onPageSizeChange(Number(val))}>
-          <SelectTrigger className="w-[60px] h-8 text-sm bg-secondary">
+          <SelectTrigger aria-labelledby="rows-per-page-label" className="w-[60px] h-8 text-sm bg-secondary">
             <SelectValue placeholder="Select" />
           </SelectTrigger>
           <SelectContent>
@@ -40,16 +40,16 @@ const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, pageSi
           Page {currentPage} of {totalPages}
         </span>
         <div className="flex gap-2">
-          <Button type="button" className="h-6 w-6 !p-0" variant="outline" disabled={isFirstPage} onClick={() => onPageChange(1)}>
+          <Button type="button" className="h-6 w-6 !p-0" variant="outline" aria-label="First page" disabled={isFirstPage} onClick={() => onPageChange(1)}>
             <ChevronsLeft size={16} />
           </Button>
-          <Button type="button" className="h-6 w-6 !p-0" variant="outline" disabled={isFirstPage} onClick={() => onPageChange(currentPage - 1)}>
+          <Button type="button" className="h-6 w-6 !p-0" variant="outline" aria-label="Previous page" disabled={isFirstPage} onClick={() => onPageChange(currentPage - 1)}>
             <ChevronLeft size={16} />
           </Button>
-          <Button type="button" className="h-6 w-6 !p-0" variant="outline" disabled={isLastPage} onClick={() => onPageChange(currentPage + 1)}>
+          <Button type="button" className="h-6 w-6 !p-0" variant="outline" aria-label="Next page" disabled={isLastPage} onClick={() => onPageChange(currentPage + 1)}>
             <ChevronRight size={16} />
           </Button>
-          <Button type="button" className="h-6 w-6 !p-0" variant="outline" disabled={isLastPage} onClick={() => onPageChange(totalPages)}>
+          <Button type="button" className="h-6 w-6 !p-0" variant="outline" aria-label="Last page" disabled={isLastPage} onClick={() => onPageChange(totalPages)}>
             <ChevronsRight size={16} />
           </Button>
         </div>


### PR DESCRIPTION
 Defects and a11y gaps I hit while writing the E2E suite. 59 files, but most of that is
  aria-label and data-testid additions with no runtime effect. The real changes:

  **The profile form discarded what you were typing.** `form.reset()` ran on every change
  of `userData`, so any background refetch while the form was open threw the in-progress
  edits away. Guarded with a ref plus `isDirty`, so hydration happens once and never
  over a dirty form.

  **Trust center document sheet** — prefill ran on every `documentData` change rather
  than once per document id. Separately, `data.standardID != null` meant an empty-string
  standard was sent as `standardID: ""` instead of clearing the association.

  **Procedure tags went stale.** The card mirrored `form.getValues('tags')` into local
  state from an effect keyed on `form`, which never changes identity, so tags set
  anywhere else never appeared. Derived from `useWatch` now.

  **Trust center updates** validated title and text but rendered no message, so
  submitting an incomplete update silently did nothing.

  **Vendors** leaked a raw Zod 4 message ("Invalid input: expected string, received
  undefined") on an empty name, because the field had no default.

  On the a11y side: the onboarding question label pointed at a SelectTrigger with no id,
  so clicking it did nothing and screen readers had no association. Clickable divs in the
  severity chart and the chip components are real buttons now, so they're
  keyboard-reachable. aria-labels on icon-only controls that had no accessible name at
  all.

  Also pulled the control and evidence input building out into pure functions so the
  association-stripping can be tested away from React — two small test files come with
  that.