### PR TITLE
fix: stripe status for past due

### DIFF
--- a/apps/console/src/app/api/stripe/invoices/route.ts
+++ b/apps/console/src/app/api/stripe/invoices/route.ts
@@ -1,4 +1,5 @@
 import { auth } from '@/lib/auth/auth'
+import { type Invoice } from '@/types/stripe'
 import { stripe } from '@/lib/stripe'
 import { NextResponse } from 'next/server'
 
@@ -21,14 +22,14 @@ export async function POST(req: Request) {
       limit: 10,
     })
 
-    const formatted = invoices.data.map((inv) => ({
+    const formatted: Invoice[] = invoices.data.map((inv) => ({
       id: inv.id,
       number: inv.number,
       status: inv.status,
       amount_paid: inv.amount_paid,
       amount_due: inv.amount_due,
-      hosted_invoice_url: inv.hosted_invoice_url,
-      invoice_pdf: inv.invoice_pdf,
+      hosted_invoice_url: inv.hosted_invoice_url ?? null,
+      invoice_pdf: inv.invoice_pdf ?? null,
       created: inv.created,
     }))
 

--- a/apps/console/src/app/api/stripe/invoices/route.ts
+++ b/apps/console/src/app/api/stripe/invoices/route.ts
@@ -26,6 +26,7 @@ export async function POST(req: Request) {
       number: inv.number,
       status: inv.status,
       amount_paid: inv.amount_paid,
+      amount_due: inv.amount_due,
       hosted_invoice_url: inv.hosted_invoice_url,
       invoice_pdf: inv.invoice_pdf,
       created: inv.created,

--- a/apps/console/src/app/api/stripe/subscription/route.ts
+++ b/apps/console/src/app/api/stripe/subscription/route.ts
@@ -3,9 +3,11 @@ import { stripe } from '@/lib/stripe'
 import type Stripe from 'stripe'
 import { auth } from '@/lib/auth/auth'
 
-// statuses that still represent a subscription the customer is on, in preference order
-// past_due / unpaid are included because a failed or unpaid invoice must not blank out the billing page
-const LIVE_STATUSES: Stripe.Subscription.Status[] = ['active', 'trialing', 'past_due', 'unpaid', 'incomplete']
+const LIVE_STATUSES: Stripe.Subscription.Status[] = ['active', 'trialing', 'past_due', 'unpaid', 'paused', 'incomplete']
+
+const isLive = (subscription: Stripe.Subscription) => LIVE_STATUSES.includes(subscription.status)
+
+const belongsToCustomer = (subscription: Stripe.Subscription, customerId: string) => (typeof subscription.customer === 'string' ? subscription.customer : subscription.customer.id) === customerId
 
 export async function GET(req: Request) {
   // ensure we have a valid session
@@ -23,22 +25,20 @@ export async function GET(req: Request) {
       return NextResponse.json({ error: 'Missing customer id' }, { status: 400 })
     }
 
-    // a released schedule keeps its subscription in released_subscription, so retrieve it directly when we know the id
     if (subscriptionId) {
-      const subscription = await stripe.subscriptions.retrieve(subscriptionId)
-      const belongsToCustomer = typeof subscription.customer === 'string' ? subscription.customer === customerId : subscription.customer.id === customerId
+      const releasedSubscription = await stripe.subscriptions.retrieve(subscriptionId).catch(() => null)
 
-      if (belongsToCustomer && subscription.status !== 'canceled') {
-        return NextResponse.json(subscription)
+      if (releasedSubscription && belongsToCustomer(releasedSubscription, customerId) && isLive(releasedSubscription)) {
+        return NextResponse.json(releasedSubscription)
       }
     }
 
     const subs = await stripe.subscriptions.list({
       customer: customerId,
-      status: 'all',
+      limit: 100,
     })
 
-    const live = LIVE_STATUSES.map((status) => subs.data.find((sub) => sub.status === status)).find((sub) => !!sub)
+    const live = subs.data.filter(isLive).sort((a, b) => LIVE_STATUSES.indexOf(a.status) - LIVE_STATUSES.indexOf(b.status))[0]
 
     return NextResponse.json(live ?? null)
   } catch (err: unknown) {

--- a/apps/console/src/app/api/stripe/subscription/route.ts
+++ b/apps/console/src/app/api/stripe/subscription/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from 'next/server'
 import { stripe } from '@/lib/stripe'
+import type Stripe from 'stripe'
 import { auth } from '@/lib/auth/auth'
+
+// statuses that still represent a subscription the customer is on, in preference order
+// past_due / unpaid are included because a failed or unpaid invoice must not blank out the billing page
+const LIVE_STATUSES: Stripe.Subscription.Status[] = ['active', 'trialing', 'past_due', 'unpaid', 'incomplete']
 
 export async function GET(req: Request) {
   // ensure we have a valid session
@@ -12,18 +17,30 @@ export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url)
     const customerId = searchParams.get('customer')
+    const subscriptionId = searchParams.get('subscription')
 
     if (!customerId) {
       return NextResponse.json({ error: 'Missing customer id' }, { status: 400 })
     }
 
+    // a released schedule keeps its subscription in released_subscription, so retrieve it directly when we know the id
+    if (subscriptionId) {
+      const subscription = await stripe.subscriptions.retrieve(subscriptionId)
+      const belongsToCustomer = typeof subscription.customer === 'string' ? subscription.customer === customerId : subscription.customer.id === customerId
+
+      if (belongsToCustomer && subscription.status !== 'canceled') {
+        return NextResponse.json(subscription)
+      }
+    }
+
     const subs = await stripe.subscriptions.list({
       customer: customerId,
-      status: 'active',
-      expand: ['data.items.data.price'],
+      status: 'all',
     })
 
-    return NextResponse.json(subs.data[0] ?? null)
+    const live = LIVE_STATUSES.map((status) => subs.data.find((sub) => sub.status === status)).find((sub) => !!sub)
+
+    return NextResponse.json(live ?? null)
   } catch (err: unknown) {
     console.error('❌ Stripe error:', err)
 

--- a/apps/console/src/components/pages/protected/organization-settings/billing/billing-summary.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/billing/billing-summary.tsx
@@ -15,9 +15,10 @@ type Props = {
   activePriceIds: Set<string | Price>
   nextPhaseStart: Date | null
   currentInterval: 'month' | 'year' | null
+  stripeStatus: string | null
 }
 
-const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart, currentInterval }: Props) => {
+const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart, currentInterval, stripeStatus }: Props) => {
   const { currentOrgId } = useOrganization()
   const { data } = useGetOrganizationBilling(currentOrgId)
   const { data: schedules = [] } = useSchedulesQuery(stripeCustomerId)
@@ -30,6 +31,8 @@ const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart, curr
   })
   const subscription = data?.organization.orgSubscriptions?.[0] ?? ({} as OrgSubscription)
   const { expiresAt, active, stripeSubscriptionStatus, trialExpiresAt } = subscription
+  // stripe is the source of truth, the org record only catches up once its webhook lands
+  const status = stripeStatus ?? stripeSubscriptionStatus
   const { mutateAsync: switchInterval, isPending: updating } = useSwitchIntervalMutation()
   const [confirmSwitchOpen, setConfirmSwitchOpen] = useState(false)
   const trialExpirationDate = trialExpiresAt ? parseISO(trialExpiresAt) : null
@@ -131,15 +134,29 @@ const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart, curr
   const hasDiscount = discountAmount > 0
 
   const badge = useMemo(() => {
-    if (stripeSubscriptionStatus === 'trialing') return { variant: 'gold', text: 'Trial' } as const
+    switch (status) {
+      case 'trialing':
+        return { variant: 'gold', text: 'Trial' } as const
+      case 'past_due':
+        return { variant: 'destructive', text: 'Past due' } as const
+      case 'unpaid':
+        return { variant: 'destructive', text: 'Unpaid' } as const
+      case 'incomplete':
+        return { variant: 'destructive', text: 'Incomplete' } as const
+      case 'canceled':
+      case 'incomplete_expired':
+        return { variant: 'destructive', text: 'Expired' } as const
+      case 'active':
+        return { variant: 'default', text: 'Active' } as const
+    }
+
     if (active) return { variant: 'default', text: 'Active' } as const
-    if (!active) return { variant: 'destructive', text: 'Expired' } as const
-    return { variant: 'destructive', text: 'Unknown' } as const
-  }, [stripeSubscriptionStatus, active])
+    return { variant: 'destructive', text: 'Expired' } as const
+  }, [status, active])
 
   const formattedExpiresDate = useMemo(() => {
     try {
-      if (stripeSubscriptionStatus === 'trialing') {
+      if (status === 'trialing') {
         const expirationDate = parseISO(trialExpiresAt)
         return `Expires in ${formatDistanceToNowStrict(expirationDate, { addSuffix: false })}`
       }
@@ -152,7 +169,7 @@ const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart, curr
     } catch {
       return 'N/A'
     }
-  }, [expiresAt, stripeSubscriptionStatus, trialExpiresAt, trialEnded, now])
+  }, [expiresAt, status, trialExpiresAt, trialEnded, now])
 
   const handleSwitchInterval = async () => {
     try {
@@ -195,7 +212,7 @@ const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart, curr
             {/* Expiration */}
             <Badge variant={badge.variant}>{badge.text}</Badge>
           </div>
-          {trialExpiresAt && stripeSubscriptionStatus === 'trialing' ? (
+          {trialExpiresAt && status === 'trialing' ? (
             <div className="flex items-center gap-2">
               <p className="text-sm font-medium text-text-informational">Trial status:</p>
               <p className="text-sm text-text-informational">{formattedExpiresDate}</p>

--- a/apps/console/src/components/pages/protected/organization-settings/billing/billing-summary.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/billing/billing-summary.tsx
@@ -143,6 +143,8 @@ const BillingSummary = ({ stripeCustomerId, activePriceIds, nextPhaseStart, curr
         return { variant: 'destructive', text: 'Unpaid' } as const
       case 'incomplete':
         return { variant: 'destructive', text: 'Incomplete' } as const
+      case 'paused':
+        return { variant: 'select', text: 'Paused' } as const
       case 'canceled':
       case 'incomplete_expired':
         return { variant: 'destructive', text: 'Expired' } as const

--- a/apps/console/src/components/pages/protected/organization-settings/billing/invoices.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/billing/invoices.tsx
@@ -54,7 +54,8 @@ const Invoices = ({ stripeCustomerId }: { stripeCustomerId: string | null | unde
         {!isLoading && !error && invoicesData?.invoices.length === 0 && <p className="p-4 text-sm ">No invoices found</p>}
 
         {invoicesData?.invoices.slice(0, 5).map((invoice: Invoice) => {
-          const amount = (invoice.amount_paid || invoice.amount_due || 0) / 100
+          // a paid invoice reports what was collected, anything still open reports what is owed
+          const amount = (invoice.status === 'paid' ? invoice.amount_paid : invoice.amount_due) / 100
           const formattedDate = invoice.created ? formatDate(new Date(invoice.created * 1000).toISOString()) : ''
 
           return (

--- a/apps/console/src/components/pages/protected/organization-settings/billing/invoices.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/billing/invoices.tsx
@@ -54,8 +54,8 @@ const Invoices = ({ stripeCustomerId }: { stripeCustomerId: string | null | unde
         {!isLoading && !error && invoicesData?.invoices.length === 0 && <p className="p-4 text-sm ">No invoices found</p>}
 
         {invoicesData?.invoices.slice(0, 5).map((invoice: Invoice) => {
-          // a paid invoice reports what was collected, anything still open reports what is owed
-          const amount = (invoice.status === 'paid' ? invoice.amount_paid : invoice.amount_due) / 100
+          const amountCents = invoice.status === 'paid' ? invoice.amount_paid : invoice.amount_due
+          const amount = amountCents / 100
           const formattedDate = invoice.created ? formatDate(new Date(invoice.created * 1000).toISOString()) : ''
 
           return (
@@ -72,7 +72,6 @@ const Invoices = ({ stripeCustomerId }: { stripeCustomerId: string | null | unde
 
                 {invoice.status === 'paid' && <span className="text-green-500 font-medium">Paid</span>}
                 {invoice.status === 'open' && <span className="text-purple-400 font-medium">Pending</span>}
-                {invoice.status === 'overdue' && <span className="text-destructive font-medium">Overdue</span>}
 
                 {invoice.invoice_pdf && (
                   <a href={invoice.invoice_pdf} className=" hover:text-white">

--- a/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
@@ -26,7 +26,6 @@ const PricingPlan = () => {
 
   const scheduleSubscription = schedules[0]?.subscription ?? null
 
-  // For released schedules, subscription is null - the id lives on released_subscription, otherwise fall back to the customer's live subscription
   const releasedSubscriptionId = schedules[0]?.released_subscription ?? null
   const { data: directSubscription, isLoading: subscriptionLoading } = useSubscriptionQuery(!schedulesLoading && !scheduleSubscription ? stripeCustomerId : null, releasedSubscriptionId)
 

--- a/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
+++ b/apps/console/src/components/pages/protected/organization-settings/billing/pricing-plan.tsx
@@ -26,8 +26,9 @@ const PricingPlan = () => {
 
   const scheduleSubscription = schedules[0]?.subscription ?? null
 
-  // For released schedules, subscription is null — fetch it directly by customer ID
-  const { data: directSubscription, isLoading: subscriptionLoading } = useSubscriptionQuery(!schedulesLoading && !scheduleSubscription ? stripeCustomerId : null)
+  // For released schedules, subscription is null - the id lives on released_subscription, otherwise fall back to the customer's live subscription
+  const releasedSubscriptionId = schedules[0]?.released_subscription ?? null
+  const { data: directSubscription, isLoading: subscriptionLoading } = useSubscriptionQuery(!schedulesLoading && !scheduleSubscription ? stripeCustomerId : null, releasedSubscriptionId)
 
   const subscription = scheduleSubscription ?? directSubscription ?? null
 
@@ -165,7 +166,13 @@ const PricingPlan = () => {
       <SideNavigation />
 
       <div className="max-w-[1000px] ml-14">
-        <BillingSummary activePriceIds={activePriceIds} stripeCustomerId={stripeCustomerId} nextPhaseStart={nextPhaseStart} currentInterval={currentInterval} />
+        <BillingSummary
+          activePriceIds={activePriceIds}
+          stripeCustomerId={stripeCustomerId}
+          nextPhaseStart={nextPhaseStart}
+          currentInterval={currentInterval}
+          stripeStatus={subscription?.status ?? null}
+        />
         <>
           {!!schedules[0] && (
             <div>

--- a/apps/console/src/lib/query-hooks/stripe.ts
+++ b/apps/console/src/lib/query-hooks/stripe.ts
@@ -154,12 +154,16 @@ export function useOpenlaneProductsQuery(includeBeta: boolean = false) {
   })
 }
 
-export function useSubscriptionQuery(customerId?: string | null) {
+export function useSubscriptionQuery(customerId?: string | null, subscriptionId?: string | null) {
   return useQuery<Subscription | null>({
-    queryKey: ['stripe-subscription', customerId],
+    queryKey: ['stripe-subscription', customerId, subscriptionId],
     queryFn: async () => {
       if (!customerId) return null
-      const res = await fetch(`/api/stripe/subscription?customer=${customerId}`)
+      const params = new URLSearchParams({ customer: customerId })
+      if (subscriptionId) {
+        params.set('subscription', subscriptionId)
+      }
+      const res = await fetch(`/api/stripe/subscription?${params.toString()}`)
       if (!res.ok) throw new Error('Failed to fetch subscription')
       return res.json() as Promise<Subscription | null>
     },

--- a/apps/console/src/types/stripe.ts
+++ b/apps/console/src/types/stripe.ts
@@ -367,7 +367,7 @@ export type PaymentMethodsResponse = {
 export interface Invoice {
   id: string
   number: string | null
-  status: 'draft' | 'open' | 'paid' | 'uncollectible' | 'void' | 'overdue'
+  status: Stripe.Invoice.Status | null
   amount_paid: number
   amount_due: number
   hosted_invoice_url: string | null


### PR DESCRIPTION
- recent backend changes allowed for new status: `past_due` and `unpaid` that was not caught
- released schedules causing a few issues
- status should be pulled from stripe as source of truth first instead of graphql query
- amount due on invoice was showing the wrong value when not paid yet