### PR TITLE
Fix quick component flashes

### DIFF
--- a/apps/console/src/components/pages/protected/programs/dashboard/programs-dashboard-page.tsx
+++ b/apps/console/src/components/pages/protected/programs/dashboard/programs-dashboard-page.tsx
@@ -41,7 +41,7 @@ const ProgramsDashboardPage = () => {
   const { data: session } = useSession()
   const [expanded, setExpanded] = useState<string[]>([])
   const [filterStatus, setFilterStatus] = useState<'ACTIVE' | 'ARCHIVED'>('ACTIVE')
-  const { data: orgPermission } = useOrganizationRoles()
+  const { data: orgPermission, isPending: isPermissionPending } = useOrganizationRoles()
   const { setCrumbs } = use(BreadcrumbContext)
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -116,6 +116,10 @@ const ProgramsDashboardPage = () => {
   }
 
   if (!data?.programs.edges?.length && isSuccess && !search && filterStatus === 'ACTIVE') {
+    if (!session?.user?.isImpersonation && isPermissionPending) {
+      return <ProgramsDashboardSkeleton />
+    }
+
     return (
       <>
         {hasPermission(orgPermission?.roles, AccessEnum.CanCreateProgram, session) ? (


### PR DESCRIPTION
<img width="2722" height="1008" alt="CleanShot 2026-09-10 at 00 40 17@2x" src="https://github.com/user-attachments/assets/b18e4bc4-2870-4412-b645-a5a94a6e0063" />

I occasionally get this flashes when viewing `/programs` then it moves back to the actual rendered data